### PR TITLE
Add rds_db_parameters type

### DIFF
--- a/lib/awspec/helper/type.rb
+++ b/lib/awspec/helper/type.rb
@@ -2,7 +2,7 @@ module Awspec
   module Helper
     module Type
       types = %w(
-        base ec2 rds security_group vpc
+        base ec2 rds security_group vpc rds_db_parameters
       )
 
       types.each { |type| require "awspec/type/#{type}" }

--- a/lib/awspec/type/rds_db_parameters.rb
+++ b/lib/awspec/type/rds_db_parameters.rb
@@ -1,0 +1,33 @@
+module Awspec::Type
+  class RdsDbParameters < Base
+
+    def initialize(name)
+      @client = Aws::RDS::Client.new
+      @parameters = {}
+
+      marker = nil
+      while @parameters.empty? || !marker.nil? do
+        res = @client.describe_db_parameters(
+          db_parameter_group_name: name,
+          marker: marker)
+        marker = res.marker
+        if res.parameters.empty? then
+          break
+        end
+        res.parameters.each do |param|
+          @parameters[param.parameter_name] = param.parameter_value
+        end
+      end
+    end
+
+    def method_missing(name)
+      param_name = name.to_s
+      if @parameters.has_key?(param_name) then
+        @parameters[param_name].to_s
+      else
+        super
+      end
+    end
+
+  end
+end

--- a/lib/awspec/type/rds_db_parameters.rb
+++ b/lib/awspec/type/rds_db_parameters.rb
@@ -1,19 +1,16 @@
 module Awspec::Type
   class RdsDbParameters < Base
-
     def initialize(name)
       @client = Aws::RDS::Client.new
       @parameters = {}
 
       marker = nil
-      while @parameters.empty? || !marker.nil? do
+      while @parameters.empty? || !marker.nil?
         res = @client.describe_db_parameters(
           db_parameter_group_name: name,
           marker: marker)
         marker = res.marker
-        if res.parameters.empty? then
-          break
-        end
+        break if res.parameters.empty?
         res.parameters.each do |param|
           @parameters[param.parameter_name] = param.parameter_value
         end
@@ -22,12 +19,11 @@ module Awspec::Type
 
     def method_missing(name)
       param_name = name.to_s
-      if @parameters.has_key?(param_name) then
+      if @parameters.key?(param_name)
         @parameters[param_name].to_s
       else
         super
       end
     end
-
   end
 end

--- a/spec/type/rds_db_parameters_spec.rb
+++ b/spec/type/rds_db_parameters_spec.rb
@@ -17,8 +17,6 @@ Aws.config[:rds] = {
   }
 }
 
-Aws.config[:stub_responses] = false
-
 describe rds_db_parameters('test') do
   its(:basedir) { should eq '/rdsdbbin/mysql' }
   its(:innodb_buffer_pool_size) { '{DBInstanceClassMemory*3/4}' }

--- a/spec/type/rds_db_parameters_spec.rb
+++ b/spec/type/rds_db_parameters_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+Aws.config[:rds] = {
+  stub_responses: {
+    describe_db_parameters: {
+      parameters: [
+        {
+          parameter_name: 'basedir',
+          parameter_value: '/rdsdbbin/mysql',
+        },
+        {
+          parameter_name: 'innodb_buffer_pool_size',
+          parameter_value: '{DBInstanceClassMemory*3/4}',
+        }
+      ]
+    }
+  }
+}
+
+Aws.config[:stub_responses] = false
+
+describe rds_db_parameters('test') do
+  its(:basedir) { should eq '/rdsdbbin/mysql' }
+  its(:innodb_buffer_pool_size) { '{DBInstanceClassMemory*3/4}' }
+end

--- a/spec/type/rds_db_parameters_spec.rb
+++ b/spec/type/rds_db_parameters_spec.rb
@@ -6,11 +6,11 @@ Aws.config[:rds] = {
       parameters: [
         {
           parameter_name: 'basedir',
-          parameter_value: '/rdsdbbin/mysql',
+          parameter_value: '/rdsdbbin/mysql'
         },
         {
           parameter_name: 'innodb_buffer_pool_size',
-          parameter_value: '{DBInstanceClassMemory*3/4}',
+          parameter_value: '{DBInstanceClassMemory*3/4}'
         }
       ]
     }


### PR DESCRIPTION
Add type to write tests for RDS DB parameters in the Parameter Groups.

Example:

```ruby
describe rds_db_parameters('test') do
  its(:basedir) { should eq '/rdsdbbin/mysql' }
  its(:innodb_buffer_pool_size) { '{DBInstanceClassMemory*3/4}' }
end
```