### PR TITLE
Fix "command not found" on Bundler

### DIFF
--- a/awspec.gemspec
+++ b/awspec.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir        = 'bin'
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Thank you for your work! 

### Reproduce 

Create a Gemfile:

```sh
$ cat Gemfile
source 'https://rubygems.org'

gem 'awspec'
```

Install:

```sh
$ bundle install --path vendor/bundle
```

Run the `awspec` command:

```sh
$ bundle exec awspec
bundler: command not found: awspec
Install missing gem executables with `bundle install`
```

:cry:  So, I've updated `gemspec` file.