### PR TITLE
Fix path for secrets.yml in spec_helper.rb

### DIFF
--- a/lib/awspec/setup.rb
+++ b/lib/awspec/setup.rb
@@ -12,8 +12,8 @@ module Awspec
     def self.generate_spec_helper
       content = <<-'EOF'
 require 'awspec'
-if File.exist?('secrets.yml')
-  creds = YAML.load_file('secrets.yml')
+if File.exist?('spec/secrets.yml')
+  creds = YAML.load_file('spec/secrets.yml')
   Aws.config.update({
                       region: creds['region'],
                       credentials: Aws::Credentials.new(


### PR DESCRIPTION
Current configuration will occurs error like 
`missing region; use :region option or export region name to ENV['AWS_REGION'] (Aws::Errors::MissingRegionError)` 
Because secrets.yml can not be loaded with current configuration of spec_helper that generated by `init` command