### PR TITLE
fix wrong order of permissions count in generated security_group_spec

### DIFF
--- a/lib/awspec/generator/spec/security_group.rb
+++ b/lib/awspec/generator/spec/security_group.rb
@@ -62,8 +62,8 @@ describe security_group('<%= sg.group_name %>') do
 <% linespecs.each do |line| %>
   <%= line %>
 <% end %>
-  its(:outbound_permissions_count) { should eq <%= sg.ip_permissions.count %> }
-  its(:inbound_permissions_count) { should eq <%= sg.ip_permissions_egress.count %> }
+  its(:inbound_permissions_count) { should eq <%= sg.ip_permissions.count %> }
+  its(:outbound_permissions_count) { should eq <%= sg.ip_permissions_egress.count %> }
 <%- if @vpc_tag_name -%>
   it { should belong_to_vpc('<%= @vpc_tag_name %>') }
 <%- else -%>

--- a/spec/generator/security_group_spec.rb
+++ b/spec/generator/security_group_spec.rb
@@ -14,8 +14,8 @@ describe security_group('my-security-group-name') do
   its(:inbound) { should be_opened(80).protocol('tcp').for('456.789.123.456/32') }
   its(:inbound) { should be_opened(22).protocol('tcp').for('group-name-sg') }
   its(:outbound) { should be_opened }
-  its(:outbound_permissions_count) { should eq 2 }
-  its(:inbound_permissions_count) { should eq 1 }
+  its(:inbound_permissions_count) { should eq 2 }
+  its(:outbound_permissions_count) { should eq 1 }
   it { should belong_to_vpc('my-vpc') }
 end
 EOF


### PR DESCRIPTION
generated security_group spec's permissions count is wrong. 
I think it should be in reverse order