### PR TITLE
Set `bundler` to tachikoma.io strategy

### DIFF
--- a/.tachikoma.yml
+++ b/.tachikoma.yml
@@ -1,0 +1,1 @@
+strategy: 'bundler'


### PR DESCRIPTION
>  設定なしの初期値として、Tachikoma.ioは `none` のストラテジー を使います。 
>  カスタム設定は完全にオプションです。これを設定したい場合、設定は .tachikoma.yml に書いて、git commit、そしてリポジトリにpushしてください。 
> - [Configuration - Tachikoma.io](http://tachikoma.io/configuration.html)