### PR TITLE
Fix Awspec::Type::IamPolicy#attachable?

### DIFF
--- a/lib/awspec/type/iam_policy.rb
+++ b/lib/awspec/type/iam_policy.rb
@@ -7,7 +7,7 @@ module Awspec::Type
     end
 
     def attachable?
-      policy.is_attachable
+      @resource.is_attachable
     end
 
     def attached_to_user?(user_id = nil)

--- a/spec/type/iam_policy_spec.rb
+++ b/spec/type/iam_policy_spec.rb
@@ -4,4 +4,8 @@ Awspec::Stub.load 'iam_policy'
 describe iam_policy('my-iam-policy') do
   it { should exist }
   it { should be_attachable }
+  its(:arn){ should eq 'arn:aws:iam::aws:policy/my-iam-policy' }
+  its(:attachment_count){ should eq 1 }
+  its(:policy_id){ should eq 'PABCDEFGHI123455689' }
+  its(:policy_name){ should eq 'my-iam-policy' }
 end

--- a/spec/type/iam_policy_spec.rb
+++ b/spec/type/iam_policy_spec.rb
@@ -3,4 +3,5 @@ Awspec::Stub.load 'iam_policy'
 
 describe iam_policy('my-iam-policy') do
   it { should exist }
+  it { should be_attachable }
 end

--- a/spec/type/iam_policy_spec.rb
+++ b/spec/type/iam_policy_spec.rb
@@ -4,8 +4,8 @@ Awspec::Stub.load 'iam_policy'
 describe iam_policy('my-iam-policy') do
   it { should exist }
   it { should be_attachable }
-  its(:arn){ should eq 'arn:aws:iam::aws:policy/my-iam-policy' }
-  its(:attachment_count){ should eq 1 }
-  its(:policy_id){ should eq 'PABCDEFGHI123455689' }
-  its(:policy_name){ should eq 'my-iam-policy' }
+  its(:arn) { should eq 'arn:aws:iam::aws:policy/my-iam-policy' }
+  its(:attachment_count) { should eq 1 }
+  its(:policy_id) { should eq 'PABCDEFGHI123455689' }
+  its(:policy_name) { should eq 'my-iam-policy' }
 end


### PR DESCRIPTION
```ruby
describe iam_policy('my-iam-policy') do
 it { should be_attachable } 
end
```

と書くと必ず落ちるようになっていました。https://github.com/k1LoW/awspec/pull/39 で `policy` が参照できなくなったのが原因です。

テストも足しました c949d4c :bow: 
