### PR TITLE
Add disable_api_termination into ec2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ describe ec2('my-ec2-tag-name') do
   it { should belong_to_vpc('my-vpc') }
   it { should belong_to_subnet('subnet-1234a567') }
   it { should have_eip('123.0.456.789') }
-  it { should be_disabled_termination }
+  it { should be_disabled_api_termination }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ describe ec2('my-ec2-tag-name') do
   it { should belong_to_vpc('my-vpc') }
   it { should belong_to_subnet('subnet-1234a567') }
   it { should have_eip('123.0.456.789') }
+  it { should be_disabled_termination }
 end
 ```
 

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -31,7 +31,7 @@ end
 ```
 
 
-### be_disabled_termination
+### be_disabled_api_termination
 
 ### be_pending
 

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -31,6 +31,8 @@ end
 ```
 
 
+### be_disabled_termination
+
 ### be_pending
 
 ### be_running
@@ -58,8 +60,6 @@ end
 ### belong_to_subnet
 
 ### belong_to_vpc
-
-### be_disabled_termination
 
 #### its(:instance_id), its(:image_id), its(:private_dns_name), its(:public_dns_name), its(:state_transition_reason), its(:key_name), its(:ami_launch_index), its(:instance_type), its(:launch_time), its(:placement), its(:kernel_id), its(:ramdisk_id), its(:platform), its(:monitoring), its(:subnet_id), its(:vpc_id), its(:private_ip_address), its(:public_ip_address), its(:state_reason), its(:architecture), its(:root_device_type), its(:root_device_name), its(:virtualization_type), its(:instance_lifecycle), its(:spot_instance_request_id), its(:client_token), its(:source_dest_check), its(:hypervisor), its(:iam_instance_profile), its(:ebs_optimized), its(:sriov_net_support)
 ## <a name="rds">rds</a>

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -59,6 +59,8 @@ end
 
 ### belong_to_vpc
 
+### be_disabled_termination
+
 #### its(:instance_id), its(:image_id), its(:private_dns_name), its(:public_dns_name), its(:state_transition_reason), its(:key_name), its(:ami_launch_index), its(:instance_type), its(:launch_time), its(:placement), its(:kernel_id), its(:ramdisk_id), its(:platform), its(:monitoring), its(:subnet_id), its(:vpc_id), its(:private_ip_address), its(:public_ip_address), its(:state_reason), its(:architecture), its(:root_device_type), its(:root_device_name), its(:virtualization_type), its(:instance_lifecycle), its(:spot_instance_request_id), its(:client_token), its(:source_dest_check), its(:hypervisor), its(:iam_instance_profile), its(:ebs_optimized), its(:sriov_net_support)
 ## <a name="rds">rds</a>
 

--- a/lib/awspec/helper/finder/ec2.rb
+++ b/lib/awspec/helper/finder/ec2.rb
@@ -36,6 +36,12 @@ module Awspec::Helper
                                                              res[:reservations].first[:instances].count == 1
       end
 
+      def find_ec2_attribute(id, attribute)
+        res = @ec2_client.describe_instance_attribute({
+          instance_id: id, attribute: attribute
+        })
+      end
+
       def find_subnet(subnet_id)
         res = @ec2_client.describe_subnets({
                                              filters: [{ name: 'subnet-id', values: [subnet_id] }]

--- a/lib/awspec/helper/finder/ec2.rb
+++ b/lib/awspec/helper/finder/ec2.rb
@@ -38,8 +38,8 @@ module Awspec::Helper
 
       def find_ec2_attribute(id, attribute)
         res = @ec2_client.describe_instance_attribute({
-          instance_id: id, attribute: attribute
-        })
+                                                        instance_id: id, attribute: attribute
+                                                      })
       end
 
       def find_subnet(subnet_id)

--- a/lib/awspec/stub/ec2.rb
+++ b/lib/awspec/stub/ec2.rb
@@ -40,6 +40,12 @@ Aws.config[:ec2] = {
         }
       ]
     },
+    describe_instance_attribute: {
+      instance_id: 'i-ec12345a',
+      disable_api_termination: {
+        value: true
+      }
+    },
     describe_vpcs: {
       vpcs: [
         {

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -20,6 +20,11 @@ module Awspec::Type
       end
     end
 
+    def disabled_termination?
+      ret = find_ec2_attribute(@id, 'disableApiTermination')
+      return ret[:disable_api_termination][:value]
+    end
+
     def has_eip?(ip_address = nil)
       option = {
         filters: [{ name: 'instance-id', values: [@id] }]

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -20,7 +20,7 @@ module Awspec::Type
       end
     end
 
-    def disabled_termination?
+    def disabled_api_termination?
       ret = find_ec2_attribute(@id, 'disableApiTermination')
       ret[:disable_api_termination][:value]
     end

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -22,7 +22,7 @@ module Awspec::Type
 
     def disabled_termination?
       ret = find_ec2_attribute(@id, 'disableApiTermination')
-      return ret[:disable_api_termination][:value]
+      ret[:disable_api_termination][:value]
     end
 
     def has_eip?(ip_address = nil)

--- a/spec/type/ec2_spec.rb
+++ b/spec/type/ec2_spec.rb
@@ -9,6 +9,7 @@ describe ec2('i-ec12345a') do
   its(:image_id) { should eq 'ami-abc12def' }
   its(:public_ip_address) { should eq '123.0.456.789' }
   its(:private_ip_address) { should eq '10.0.1.1' }
+  it { should be_disabled_termination }
   it { should have_security_group('sg-1a2b3cd4') }
   it { should have_security_group('my-security-group-name') }
   it { should have_security_group('my-security-group-tag-name') }

--- a/spec/type/ec2_spec.rb
+++ b/spec/type/ec2_spec.rb
@@ -9,7 +9,7 @@ describe ec2('i-ec12345a') do
   its(:image_id) { should eq 'ami-abc12def' }
   its(:public_ip_address) { should eq '123.0.456.789' }
   its(:private_ip_address) { should eq '10.0.1.1' }
-  it { should be_disabled_termination }
+  it { should be_disabled_api_termination }
   it { should have_security_group('sg-1a2b3cd4') }
   it { should have_security_group('my-security-group-name') }
   it { should have_security_group('my-security-group-tag-name') }


### PR DESCRIPTION
Hello.
Here's my attempt at adding 'disabled_termination' into ec2 type.

For example
```
describe ec2('i-ec12345a') do
  it { should be_disabled_termination }
end
```