### PR TITLE
Add be_allowed_action matcher into iam_user / iam_group / iam_role

### DIFF
--- a/awspec.gemspec
+++ b/awspec.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rspec', '~> 3.0'
   spec.add_runtime_dependency 'rspec-its'
-  spec.add_runtime_dependency 'aws-sdk', '~> 2'
+  spec.add_runtime_dependency 'aws-sdk', '~> 2.1.20'
   spec.add_runtime_dependency 'thor'
   spec.add_runtime_dependency 'activesupport'
   spec.add_development_dependency 'bundler', '~> 1.9'

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -280,6 +280,8 @@ IamUser resource type.
 
 ### exist
 
+### be_allowed_action
+
 ### have_iam_policy
 
 ### belong_to_iam_group
@@ -291,6 +293,8 @@ IamGroup resource type.
 
 ### exist
 
+### be_allowed_action
+
 ### have_iam_policy
 
 ### have_iam_user
@@ -301,6 +305,8 @@ IamGroup resource type.
 IamRole resource type.
 
 ### exist
+
+### be_allowed_action
 
 ### have_iam_policy
 

--- a/lib/awspec/generator/doc/type/iam_group.rb
+++ b/lib/awspec/generator/doc/type/iam_group.rb
@@ -7,7 +7,7 @@ module Awspec::Generator
           @type_name = 'IamGroup'
           @type = Awspec::Type::IamGroup.new('my-iam-group')
           @ret = @type.resource
-          @matchers = []
+          @matchers = %w(be_allowed_action)
           @ignore_matchers = []
           @describes = []
         end

--- a/lib/awspec/generator/doc/type/iam_role.rb
+++ b/lib/awspec/generator/doc/type/iam_role.rb
@@ -7,7 +7,7 @@ module Awspec::Generator
           @type_name = 'IamRole'
           @type = Awspec::Type::IamRole.new('my-iam-role')
           @ret = @type.resource
-          @matchers = []
+          @matchers = %w(be_allowed_action)
           @ignore_matchers = []
           @describes = []
         end

--- a/lib/awspec/generator/doc/type/iam_user.rb
+++ b/lib/awspec/generator/doc/type/iam_user.rb
@@ -7,7 +7,7 @@ module Awspec::Generator
           @type_name = 'IamUser'
           @type = Awspec::Type::IamUser.new('my-iam-user')
           @ret = @type.resource
-          @matchers = %w(belong_to_iam_group)
+          @matchers = %w(belong_to_iam_group be_allowed_action)
           @ignore_matchers = []
           @describes = []
         end

--- a/lib/awspec/helper/finder/iam.rb
+++ b/lib/awspec/helper/finder/iam.rb
@@ -19,6 +19,14 @@ module Awspec::Helper
         end
       end
 
+      def select_policy_evaluation_results(policy_arn, action_name)
+        res = @iam_client.simulate_principal_policy({
+                                                      policy_source_arn: policy_arn,
+                                                      action_names: [action_name]
+                                                    })
+        res.evaluation_results
+      end
+
       def select_iam_group_by_user_name(user_name)
         res = @iam_client.list_groups_for_user({
                                                  user_name: user_name

--- a/lib/awspec/helper/finder/iam.rb
+++ b/lib/awspec/helper/finder/iam.rb
@@ -19,11 +19,13 @@ module Awspec::Helper
         end
       end
 
-      def select_policy_evaluation_results(policy_arn, action_name)
-        res = @iam_client.simulate_principal_policy({
-                                                      policy_source_arn: policy_arn,
-                                                      action_names: [action_name]
-                                                    })
+      def select_policy_evaluation_results(policy_arn, action_name, resource_arn = nil)
+        options = {
+          policy_source_arn: policy_arn,
+          action_names: [action_name]
+        }
+        options[:resource_arns] = [resource_arn] if resource_arn
+        res = @iam_client.simulate_principal_policy(options)
         res.evaluation_results
       end
 

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -16,3 +16,6 @@ require 'awspec/matcher/have_route'
 
 # IAM User
 require 'awspec/matcher/belong_to_iam_group'
+
+# IAM User/Group/Role
+require 'awspec/matcher/be_allowed_action'

--- a/lib/awspec/matcher/be_allowed_action.rb
+++ b/lib/awspec/matcher/be_allowed_action.rb
@@ -1,0 +1,8 @@
+RSpec::Matchers.define :be_allowed_action do |action_name|
+  match do |resource|
+    results = resource.select_policy_evaluation_results(resource.resource[:arn], action_name)
+    results.find do |result|
+      result.eval_decision == 'allowed'
+    end
+  end
+end

--- a/lib/awspec/matcher/be_allowed_action.rb
+++ b/lib/awspec/matcher/be_allowed_action.rb
@@ -1,8 +1,12 @@
 RSpec::Matchers.define :be_allowed_action do |action_name|
   match do |resource|
-    results = resource.select_policy_evaluation_results(resource.resource[:arn], action_name)
+    results = resource.select_policy_evaluation_results(resource.resource[:arn], action_name, @resource_arn)
     results.find do |result|
       result.eval_decision == 'allowed'
     end
+  end
+
+  chain :resource_arn do |arn|
+    @resource_arn = arn
   end
 end

--- a/lib/awspec/stub/iam_group.rb
+++ b/lib/awspec/stub/iam_group.rb
@@ -38,6 +38,19 @@ Aws.config[:iam] = {
       ],
       is_truncated: false,
       marker: nil
+    },
+    simulate_principal_policy: {
+      evaluation_results: [
+        {
+          eval_action_name: 'ec2:DescribeInstances',
+          eval_resource_name: '*',
+          eval_decision: 'allowed',
+          matched_statements: [
+          ]
+        }
+      ],
+      is_truncated: false,
+      marker: nil
     }
   }
 }

--- a/lib/awspec/stub/iam_role.rb
+++ b/lib/awspec/stub/iam_role.rb
@@ -18,6 +18,19 @@ Aws.config[:iam] = {
       ],
       is_truncated: false,
       marker: nil
+    },
+    simulate_principal_policy: {
+      evaluation_results: [
+        {
+          eval_action_name: 'ec2:DescribeInstances',
+          eval_resource_name: '*',
+          eval_decision: 'allowed',
+          matched_statements: [
+          ]
+        }
+      ],
+      is_truncated: false,
+      marker: nil
     }
   }
 }

--- a/lib/awspec/stub/iam_user.rb
+++ b/lib/awspec/stub/iam_user.rb
@@ -29,6 +29,19 @@ Aws.config[:iam] = {
       ],
       is_truncated: false,
       marker: nil
+    },
+    simulate_principal_policy: {
+      evaluation_results: [
+        {
+          eval_action_name: 'ec2:DescribeInstances',
+          eval_resource_name: '*',
+          eval_decision: 'allowed',
+          matched_statements: [
+          ]
+        }
+      ],
+      is_truncated: false,
+      marker: nil
     }
   }
 }

--- a/spec/type/iam_group_spec.rb
+++ b/spec/type/iam_group_spec.rb
@@ -5,4 +5,5 @@ describe iam_group('my-iam-group') do
   it { should exist }
   it { should have_iam_user('my-iam-user') }
   it { should have_iam_policy('ReadOnlyAccess') }
+  it { should be_allowed_action('ec2:DescribeInstances') }
 end

--- a/spec/type/iam_group_spec.rb
+++ b/spec/type/iam_group_spec.rb
@@ -6,4 +6,5 @@ describe iam_group('my-iam-group') do
   it { should have_iam_user('my-iam-user') }
   it { should have_iam_policy('ReadOnlyAccess') }
   it { should be_allowed_action('ec2:DescribeInstances') }
+  it { should be_allowed_action('ec2:DescribeInstances').resource_arn('*') }
 end

--- a/spec/type/iam_role_spec.rb
+++ b/spec/type/iam_role_spec.rb
@@ -4,4 +4,5 @@ Awspec::Stub.load 'iam_role'
 describe iam_role('my-iam-role') do
   it { should exist }
   it { should have_iam_policy('ReadOnlyAccess') }
+  it { should be_allowed_action('ec2:DescribeInstances') }
 end

--- a/spec/type/iam_role_spec.rb
+++ b/spec/type/iam_role_spec.rb
@@ -5,4 +5,5 @@ describe iam_role('my-iam-role') do
   it { should exist }
   it { should have_iam_policy('ReadOnlyAccess') }
   it { should be_allowed_action('ec2:DescribeInstances') }
+  it { should be_allowed_action('ec2:DescribeInstances').resource_arn('*') }
 end

--- a/spec/type/iam_user_spec.rb
+++ b/spec/type/iam_user_spec.rb
@@ -5,4 +5,5 @@ describe iam_user('my-iam-user') do
   it { should exist }
   it { should belong_to_iam_group('my-iam-group') }
   it { should have_iam_policy('ReadOnlyAccess') }
+  it { should be_allowed_action('ec2:DescribeInstances') }
 end

--- a/spec/type/iam_user_spec.rb
+++ b/spec/type/iam_user_spec.rb
@@ -6,4 +6,5 @@ describe iam_user('my-iam-user') do
   it { should belong_to_iam_group('my-iam-group') }
   it { should have_iam_policy('ReadOnlyAccess') }
   it { should be_allowed_action('ec2:DescribeInstances') }
+  it { should be_allowed_action('ec2:DescribeInstances').resource_arn('*') }
 end


### PR DESCRIPTION
```ruby
describe iam_user('my-iam-user') do
  it { should be_allowed_action('ec2:DescribeInstances') }
end

describe iam_group('my-iam-group') do
  it { should be_allowed_action('ec2:Describe*') }
end

describe iam_role('my-iam-role') do
  it { should be_allowed_action('ec2:DescribeInstances') }
end
```

use [Aws::IAM::Client#simulate_principal_policy](http://docs.aws.amazon.com/sdkforruby/api/Aws/IAM/Client.html#simulate_principal_policy-instance_method)