### PR TITLE
Add cloudwatch_alarm type

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -19,6 +19,7 @@
 | [iam_policy](#iam_policy)
 | [elasticache](#elasticache)
 | [elasticache_cache_parameter_group](#elasticache_cache_parameter_group)
+| [cloudwatch_alarm](#cloudwatch_alarm)
 
 ## <a name="ec2">ec2</a>
 
@@ -395,3 +396,20 @@ end
 ```
 
 ### exist
+
+
+## <a name="cloudwatch_alarm">cloudwatch_alarm</a>
+
+CloudwatchAlarm resource type.
+
+### exist
+
+### have_alarm_action
+
+### have_insufficient_data_action
+
+### have_ok_action
+
+### belong_to_metric
+
+#### its(:alarm_name), its(:alarm_arn), its(:alarm_description), its(:alarm_configuration_updated_timestamp), its(:actions_enabled), its(:state_value), its(:state_reason), its(:state_reason_data), its(:state_updated_timestamp), its(:metric_name), its(:namespace), its(:statistic), its(:period), its(:unit), its(:evaluation_periods), its(:threshold), its(:comparison_operator)

--- a/lib/awspec/generator/doc/type/cloudwatch_alarm.rb
+++ b/lib/awspec/generator/doc/type/cloudwatch_alarm.rb
@@ -1,0 +1,17 @@
+module Awspec::Generator
+  module Doc
+    module Type
+      class CloudwatchAlarm < Base
+        def initialize
+          super
+          @type_name = 'CloudwatchAlarm'
+          @type = Awspec::Type::CloudwatchAlarm.new('my-cloudwatch-alarm')
+          @ret = @type.resource
+          @matchers = %w(belong_to_metric)
+          @ignore_matchers = []
+          @describes = []
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/helper/finder.rb
+++ b/lib/awspec/helper/finder.rb
@@ -11,6 +11,7 @@ require 'awspec/helper/finder/elb'
 require 'awspec/helper/finder/lambda'
 require 'awspec/helper/finder/iam'
 require 'awspec/helper/finder/elasticache'
+require 'awspec/helper/finder/cloudwatch'
 
 module Awspec::Helper
   module Finder
@@ -27,6 +28,7 @@ module Awspec::Helper
     include Awspec::Helper::Finder::Lambda
     include Awspec::Helper::Finder::Iam
     include Awspec::Helper::Finder::Elasticache
+    include Awspec::Helper::Finder::Cloudwatch
 
     # rubocop:disable all
     def initialize(id = nil)
@@ -39,6 +41,7 @@ module Awspec::Helper
       @lambda_client = Aws::Lambda::Client.new
       @iam_client = Aws::IAM::Client.new
       @elasticache_client = Aws::ElastiCache::Client.new
+      @cloudwatch_client = Aws::CloudWatch::Client.new
     end
   end
 end

--- a/lib/awspec/helper/finder/cloudwatch.rb
+++ b/lib/awspec/helper/finder/cloudwatch.rb
@@ -1,0 +1,17 @@
+module Awspec::Helper
+  module Finder
+    module Cloudwatch
+      def find_cloudwatch_alarm(id)
+        res = @cloudwatch_client.describe_alarms({
+                                                   alarm_names: [id]
+                                                 })
+        return res[:metric_alarms].first if res[:metric_alarms].count == 1
+
+        res = @cloudwatch_client.describe_alarms
+        res[:metric_alarms].find do |alarm|
+          alarm[:alarm_arn] == id
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/helper/type.rb
+++ b/lib/awspec/helper/type.rb
@@ -6,6 +6,7 @@ module Awspec
         vpc s3 route53_hosted_zone auto_scaling_group subnet
         route_table ebs elb lambda iam_user iam_group iam_role
         iam_policy elasticache elasticache_cache_parameter_group
+        cloudwatch_alarm
       )
 
       TYPES.each do |type|

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -23,3 +23,6 @@ require 'awspec/matcher/be_allowed_action'
 # ElastiCache
 require 'awspec/matcher/belong_to_replication_group'
 require 'awspec/matcher/belong_to_cache_subnet_group'
+
+# CloudWatch
+require 'awspec/matcher/belong_to_metric'

--- a/lib/awspec/matcher/belong_to_metric.rb
+++ b/lib/awspec/matcher/belong_to_metric.rb
@@ -1,0 +1,13 @@
+RSpec::Matchers.define :belong_to_metric do |name|
+  match do |resource|
+    if @namespace
+      resource.namespace == @namespace && resource.metric_name == name
+    else
+      resource.metric_name == name
+    end
+  end
+
+  chain :namespace do |namespace|
+    @namespace = namespace
+  end
+end

--- a/lib/awspec/stub/cloudwatch_alarm.rb
+++ b/lib/awspec/stub/cloudwatch_alarm.rb
@@ -1,0 +1,39 @@
+# rubocop:disable all
+Aws.config[:cloudwatch] = {
+  stub_responses: {
+    describe_alarms: {
+      metric_alarms: [
+        {
+          alarm_name: 'my-cloudwatch-alarm',
+          alarm_arn: 'arn:aws:cloudwatch:ap-northeast-1:1234567890:alarm:my_NumberOfProcesses',
+          alarm_description: 'my_NumberOfProcesses',
+          alarm_configuration_updated_timestamp: Time.new(2015, 1, 2, 10, 00, 00, '+00:00'),
+          actions_enabled: true,
+          ok_actions: ['arn:aws:sns:ap-northeast-1:1234567890:sns_alert'],
+          alarm_actions: ['arn:aws:sns:ap-northeast-1:1234567890:sns_alert'],
+          insufficient_data_actions: ['arn:aws:sns:ap-northeast-1:1234567890:sns_alert'],
+          state_value: 'OK',
+          state_reason: 'Threshold Crossed: 1 datapoint (53.0) was not less than or equal to the threshold (5.0).',
+          state_reason_data:
+            '{\'version\':\'1.0\',\'queryDate\':\'2015-04-04T01:06:26.904+0000\',\'startDate\':\'2015-04-04T01:01:00.000+0000\',\'statistic\':\'Average\',\'period\':300,\'recentDatapoints\':[53.0],\'threshold\':5.0}',
+          state_updated_timestamp: Time.new(2015, 1, 2, 10, 10, 00, '+00:00'),
+          metric_name: 'NumberOfProcesses',
+          namespace: 'my-cloudwatch-namespace',
+          statistic: 'Average',
+          dimensions:
+            [
+              {
+                name: 'name',
+                value: 'my-dimension'
+              }
+            ],
+          period: 300,
+          unit: nil,
+          evaluation_periods: 1,
+          threshold: 5.0,
+          comparison_operator: 'LessThanOrEqualToThreshold'
+        }
+      ]
+    }
+  }
+}

--- a/lib/awspec/type/cloudwatch_alarm.rb
+++ b/lib/awspec/type/cloudwatch_alarm.rb
@@ -1,0 +1,21 @@
+module Awspec::Type
+  class CloudwatchAlarm < Base
+    def initialize(id)
+      super
+      @resource = find_cloudwatch_alarm(id)
+      @id = @resource[:alarm_arn] if @resource
+    end
+
+    def has_ok_action?(name)
+      @resource[:ok_actions].include?(name)
+    end
+
+    def has_alarm_action?(name)
+      @resource[:alarm_actions].include?(name)
+    end
+
+    def has_insufficient_data_action?(name)
+      @resource[:insufficient_data_actions].include?(name)
+    end
+  end
+end

--- a/spec/type/cloudwatch_alarm_spec.rb
+++ b/spec/type/cloudwatch_alarm_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+Awspec::Stub.load 'cloudwatch_alarm'
+
+describe cloudwatch_alarm('my-cloudwatch-alarm') do
+  it { should exist }
+  it { should have_ok_action('arn:aws:sns:ap-northeast-1:1234567890:sns_alert') }
+  it { should have_alarm_action('arn:aws:sns:ap-northeast-1:1234567890:sns_alert') }
+  it { should have_insufficient_data_action('arn:aws:sns:ap-northeast-1:1234567890:sns_alert') }
+  it { should belong_to_metric('NumberOfProcesses') }
+  it { should belong_to_metric('NumberOfProcesses').namespace('my-cloudwatch-namespace') }
+  its(:state_value) { should eq 'OK' }
+end


### PR DESCRIPTION
```ruby
describe cloudwatch_alarm('my-cloudwatch-alarm') do
  it { should exist }
  it { should have_ok_action('arn:aws:sns:ap-northeast-1:1234567890:sns_alert') }
  it { should have_alarm_action('arn:aws:sns:ap-northeast-1:1234567890:sns_alert') }
  it { should have_insufficient_data_action('arn:aws:sns:ap-northeast-1:1234567890:sns_alert') }
  it { should belong_to_metric('NumberOfProcesses') }
  it { should belong_to_metric('NumberOfProcesses').namespace('my-namespace') }
  its(:state_value) { should eq 'OK' }
end
```