### PR TITLE
Support security_group port range

### DIFF
--- a/lib/awspec/generator/spec/security_group.rb
+++ b/lib/awspec/generator/spec/security_group.rb
@@ -28,7 +28,13 @@ module Awspec::Generator
               linespecs.push('its(:' + inout + ') { should be_opened }')
               next
             end
-            port = permission.from_port
+
+            if permission.from_port == permission.to_port
+              port = permission.from_port
+            else
+              port = "'" + permission.from_port.to_s + '-' + permission.to_port.to_s + "'"
+            end
+
             protocol = permission.ip_protocol
             permission.ip_ranges.each do |ip_range|
               target = ip_range.cidr_ip

--- a/lib/awspec/stub/security_group.rb
+++ b/lib/awspec/stub/security_group.rb
@@ -32,6 +32,17 @@ Aws.config[:ec2] = {
                   group_name: 'group-name-sg'
                 }
               ]
+            },
+            {
+              from_port: 50_000,
+              to_port: 50_009,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '123.456.789.012/32'
+                }
+              ],
+              user_id_group_pairs: []
             }
           ],
           ip_permissions_egress: [

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -23,7 +23,7 @@ module Awspec::Type
         next true unless port
         next true unless permission[:from_port]
         next true unless permission[:to_port]
-        next false unless port.between?(permission[:from_port], permission[:to_port])
+        next false unless port_between?(port, permission[:from_port], permission[:to_port])
         next false if protocol && permission[:ip_protocol] != protocol
         next true unless cidr
         ret = permission[:ip_ranges].select do |ip_range|
@@ -47,7 +47,7 @@ module Awspec::Type
         next true unless port
         next true unless permission[:from_port]
         next true unless permission[:to_port]
-        next false unless port.between?(permission[:from_port], permission[:to_port])
+        next false unless port_between?(port, permission[:from_port], permission[:to_port])
         next false if protocol && permission[:ip_protocol] != protocol
         next true unless cidr
         ret = permission[:ip_ranges].select do |ip_range|
@@ -85,5 +85,17 @@ module Awspec::Type
       @resource[:ip_permissions_egress].count
     end
     alias_method :outbound_permissions_count, :ip_permissions_egress_count
+
+    private
+
+    def port_between?(port, from_port, to_port)
+      if port.is_a?(String) && port.include?('-')
+        f, t = port.split('-')
+        false unless from_port == f.to_i && to_port == t.to_i
+      else
+        false unless port.between?(from_port, to_port)
+      end
+      true
+    end
   end
 end

--- a/spec/generator/spec/security_group_spec.rb
+++ b/spec/generator/spec/security_group_spec.rb
@@ -14,8 +14,9 @@ describe security_group('sg-1a2b3cd4') do
   its(:inbound) { should be_opened(80).protocol('tcp').for('123.456.789.012/32') }
   its(:inbound) { should be_opened(80).protocol('tcp').for('456.789.123.456/32') }
   its(:inbound) { should be_opened(22).protocol('tcp').for('group-name-sg') }
+  its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.456.789.012/32') }
   its(:outbound) { should be_opened }
-  its(:inbound_permissions_count) { should eq 2 }
+  its(:inbound_permissions_count) { should eq 3 }
   its(:outbound_permissions_count) { should eq 1 }
   it { should belong_to_vpc('my-vpc') }
 end

--- a/spec/type/security_group_spec.rb
+++ b/spec/type/security_group_spec.rb
@@ -9,8 +9,9 @@ describe security_group('sg-1a2b3cd4') do
   its(:inbound) { should be_opened(80).protocol('tcp').for('456.789.123.456/32') }
   its(:inbound) { should be_opened(22) }
   its(:inbound) { should be_opened(22).protocol('tcp').for('sg-5a6b7cd8') }
-  its(:inbound_permissions_count) { should eq 2 }
-  its(:ip_permissions_count) { should eq 2 }
+  its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.456.789.012/32') }
+  its(:inbound_permissions_count) { should eq 3 }
+  its(:ip_permissions_count) { should eq 3 }
   its(:outbound_permissions_count) { should eq 1 }
   its(:ip_permissions_egress_count) { should eq 1 }
   # its(:inbound) { should be_opened(22).protocol('tcp').for('group-name-sg') }


### PR DESCRIPTION
```ruby
describe security_group('sg-1a2b3cd4') do
  it { should exist }
  its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.456.789.012/32') }
end
```