### PR TITLE
Fix Awspec::Type::SecurityGroup#port_between?

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -277,7 +277,7 @@ Lambda resource type.
 
 This matcher does not support Amazon S3 event sources. ( [See SDK doc](http://docs.aws.amazon.com/sdkforruby/api/Aws/Lambda/Client.html#list_event_source_mappings-instance_method) )
 
-#### its(:function_name), its(:function_arn), its(:runtime), its(:role), its(:handler), its(:code_size), its(:description), its(:timeout), its(:memory_size), its(:last_modified)
+#### its(:function_name), its(:function_arn), its(:runtime), its(:role), its(:handler), its(:code_size), its(:description), its(:timeout), its(:memory_size), its(:last_modified), its(:code_sha_256), its(:version)
 ## <a name="iam_user">iam_user</a>
 
 IamUser resource type.

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -92,10 +92,11 @@ module Awspec::Type
       if port.is_a?(String) && port.include?('-')
         f, t = port.split('-')
         return false unless from_port == f.to_i && to_port == t.to_i
+        true
       else
         return false unless port.between?(from_port, to_port)
+        true
       end
-      true
     end
   end
 end

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -91,11 +91,9 @@ module Awspec::Type
     def port_between?(port, from_port, to_port)
       if port.is_a?(String) && port.include?('-')
         f, t = port.split('-')
-        return false unless from_port == f.to_i && to_port == t.to_i
-        true
+        from_port == f.to_i && to_port == t.to_i
       else
-        return false unless port.between?(from_port, to_port)
-        true
+        port.between?(from_port, to_port)
       end
     end
   end

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -91,9 +91,9 @@ module Awspec::Type
     def port_between?(port, from_port, to_port)
       if port.is_a?(String) && port.include?('-')
         f, t = port.split('-')
-        false unless from_port == f.to_i && to_port == t.to_i
+        return false unless from_port == f.to_i && to_port == t.to_i
       else
-        false unless port.between?(from_port, to_port)
+        return false unless port.between?(from_port, to_port)
       end
       true
     end

--- a/spec/type/security_group_spec.rb
+++ b/spec/type/security_group_spec.rb
@@ -10,6 +10,7 @@ describe security_group('sg-1a2b3cd4') do
   its(:inbound) { should be_opened(22) }
   its(:inbound) { should be_opened(22).protocol('tcp').for('sg-5a6b7cd8') }
   its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.456.789.012/32') }
+  its(:inbound) { should_not be_opened('50010-50019').protocol('tcp').for('123.456.789.012/32') }
   its(:inbound_permissions_count) { should eq 3 }
   its(:ip_permissions_count) { should eq 3 }
   its(:outbound_permissions_count) { should eq 1 }


### PR DESCRIPTION
`#port_between?` が必ずtrueを返す気が。

問題としては、

```
its(:inbound) { should be_opened('50010-50019').protocol('tcp').for('123.456.789.012/32') }
```

みたいな記法で書いた時、cidrに該当するものがあった時、必ずpassしてしまう気がしていて、これを直したいです :construction: 