### PR TITLE
route_table support belong_to_vpc

### DIFF
--- a/lib/awspec/generator/spec/route_table.rb
+++ b/lib/awspec/generator/spec/route_table.rb
@@ -1,5 +1,3 @@
-require 'pp'
-
 module Awspec::Generator
   module Spec
     class RouteTable

--- a/lib/awspec/generator/spec/route_table.rb
+++ b/lib/awspec/generator/spec/route_table.rb
@@ -44,6 +44,11 @@ describe route_table('<%= route_table_tag_name %>') do
 describe route_table('<%= route_table_id %>') do
 <%- end -%>
   it { should exist }
+<%- if @vpc_tag_name -%>
+  it { should belong_to_vpc('<%= @vpc_tag_name %>') }
+<%- else -%>
+  it { should belong_to_vpc('<%= @vpc_id %>') }
+<%- end -%>
 <% linespecs.each do |line| %>
   <%= line %>
 <% end %>

--- a/spec/generator/spec/route_table_spec.rb
+++ b/spec/generator/spec/route_table_spec.rb
@@ -9,6 +9,7 @@ describe 'Awspec::Generator::Spec::RouteTable' do
     spec = <<-'EOF'
 describe route_table('my-route-table') do
   it { should exist }
+  it { should belong_to_vpc('my-vpc') }
   it { shold have_route('local').destination('10.0.0.0/16') }
   it { shold have_route('igw-1ab2345c').destination('0.0.0.0/0') }
 end

--- a/spec/type/route_table_spec.rb
+++ b/spec/type/route_table_spec.rb
@@ -3,6 +3,7 @@ Awspec::Stub.load 'route_table'
 
 describe route_table('my-route-table') do
   it { should exist }
+  it { should belong_to_vpc('my-vpc') }
   its(:route_table_id) { should eq 'rtb-a12bcd34' }
   it { should have_route('local').destination('10.0.0.0/16') }
   it { should have_route('my-igw').destination('0.0.0.0/0') }


### PR DESCRIPTION
```ruby
describe route_table('my-route-table') do
  it { should exist }
  it { should belong_to_vpc('my-vpc') }
  its(:route_table_id) { should eq 'rtb-a12bcd34' }
  it { should have_route('local').destination('10.0.0.0/16') }
  it { should have_route('my-igw').destination('0.0.0.0/0') }
end
```