### PR TITLE
Enable to write S3 Bucket Policy specs readably

### DIFF
--- a/lib/awspec/stub/s3_bucket.rb
+++ b/lib/awspec/stub/s3_bucket.rb
@@ -54,20 +54,10 @@ Aws.config[:s3] = {
       ]
     },
     get_bucket_policy: {
-      policy: <<-POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AllowPublicRead",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::my-bucket/*"
-    }
-  ]
-}
-      POLICY
+      policy: '{"Version":"2012-10-17","Statement":' \
+              '[{"Sid":"AllowPublicRead","Effect":"Allow",' \
+              '"Principal":"*","Action":"s3:GetObject",' \
+              '"Resource":"arn:aws:s3:::my-bucket/*"}]}'
     }
   }
 }

--- a/lib/awspec/type/s3_bucket.rb
+++ b/lib/awspec/type/s3_bucket.rb
@@ -55,7 +55,8 @@ module Awspec::Type
 
     def has_policy?(policy)
       bp = find_bucket_policy(@id)
-      bp ? (bp.policy.read == policy) : false
+      # newlines, spaces, etc.. are removed from policy which is returned from API
+      bp ? (bp.policy.read == policy.gsub(/(\n|\r|\r\n|\s|\t)/, '')) : false
     end
 
     private


### PR DESCRIPTION
spaces, newlines, etc.. are removed from policy which is returned from API