### PR TITLE
Handle an uri as key of a grantee

### DIFF
--- a/doc/_resource_types/s3_bucket.md
+++ b/doc/_resource_types/s3_bucket.md
@@ -10,11 +10,11 @@ end
 
 ```ruby
 describe s3_bucket('my-bucket') do
+  its(:acl_owner) { should eq 'my-bucket-owner' }
   its(:acl_grants_count) { should eq 3 }
   it { should have_acl_grant(grantee: 'my-bucket-owner', permission: 'FULL_CONTROL') }
-  it { should have_acl_grant(grantee: 'my-bucket-write-only', permission: 'WRITE') }
-  it { should have_acl_grant(grantee: 'my-bucket-read-only', permission: 'READ') }
-  its(:acl_owner) { should eq 'my-bucket-owner' }
+  it { should have_acl_grant(grantee: 'http://acs.amazonaws.com/groups/s3/LogDelivery', permission: 'WRITE') }
+  it { should have_acl_grant(grantee: '68f4bb06b094152df53893bfba57760e', permission: 'READ') }
 end
 ```
 

--- a/doc/_resource_types/s3_bucket.md
+++ b/doc/_resource_types/s3_bucket.md
@@ -1,7 +1,7 @@
 ### exist
 
 ```ruby
-describe s3('my-bucket') do
+describe s3_bucket('my-bucket') do
   it { should exist }
 end
 ```
@@ -9,7 +9,7 @@ end
 ### have_acl_grant
 
 ```ruby
-describe s3('my-bucket') do
+describe s3_bucket('my-bucket') do
   its(:acl_grants_count) { should eq 3 }
   it { should have_acl_grant(grantee: 'my-bucket-owner', permission: 'FULL_CONTROL') }
   it { should have_acl_grant(grantee: 'my-bucket-write-only', permission: 'WRITE') }
@@ -21,7 +21,7 @@ end
 ### have_object
 
 ```ruby
-describe s3('my-bucket') do
+describe s3_bucket('my-bucket') do
   it { should have_object('path/to/object') }
 end
 ```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -276,11 +276,35 @@ S3Bucket resource type.
 
 ### exist
 
+```ruby
+describe s3_bucket('my-bucket') do
+  it { should exist }
+end
+```
+
+
 ### have_acl_grant
+
+```ruby
+describe s3_bucket('my-bucket') do
+  its(:acl_grants_count) { should eq 3 }
+  it { should have_acl_grant(grantee: 'my-bucket-owner', permission: 'FULL_CONTROL') }
+  it { should have_acl_grant(grantee: 'my-bucket-write-only', permission: 'WRITE') }
+  it { should have_acl_grant(grantee: 'my-bucket-read-only', permission: 'READ') }
+  its(:acl_owner) { should eq 'my-bucket-owner' }
+end
+```
+
 
 ### have_cors_rule
 
 ### have_object
+
+```ruby
+describe s3_bucket('my-bucket') do
+  it { should have_object('path/to/object') }
+end
+```
 
 ### have_policy
 

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -287,11 +287,11 @@ end
 
 ```ruby
 describe s3_bucket('my-bucket') do
+  its(:acl_owner) { should eq 'my-bucket-owner' }
   its(:acl_grants_count) { should eq 3 }
   it { should have_acl_grant(grantee: 'my-bucket-owner', permission: 'FULL_CONTROL') }
-  it { should have_acl_grant(grantee: 'my-bucket-write-only', permission: 'WRITE') }
-  it { should have_acl_grant(grantee: 'my-bucket-read-only', permission: 'READ') }
-  its(:acl_owner) { should eq 'my-bucket-owner' }
+  it { should have_acl_grant(grantee: 'http://acs.amazonaws.com/groups/s3/LogDelivery', permission: 'WRITE') }
+  it { should have_acl_grant(grantee: '68f4bb06b094152df53893bfba57760e', permission: 'READ') }
 end
 ```
 

--- a/lib/awspec/generator/spec/s3_bucket.rb
+++ b/lib/awspec/generator/spec/s3_bucket.rb
@@ -33,11 +33,11 @@ it { should have_acl_grant(grantee: '<%= #{grantee} %>', permission: '<%= grant.
         template = <<-'EOF'
 describe s3_bucket('<%= bucket.name %>') do
   it { should exist }
+  its(:acl_owner) { should eq '<%= acl.owner.display_name %>' }
   its(:acl_grants_count) { should eq <%= acl.grants.count %> }
 <% grant_specs.each do |line| %>
   <%= line %>
 <% end %>
-  its(:acl_owner) { should eq '<%= acl.owner.display_name %>' }
 end
 EOF
         template

--- a/lib/awspec/generator/spec/s3_bucket.rb
+++ b/lib/awspec/generator/spec/s3_bucket.rb
@@ -22,9 +22,10 @@ module Awspec::Generator
       end
 
       def grant_linetemplate
-        template = <<-'EOF'
-it { should have_acl_grant(grantee: '<%= grant.grantee.display_name %>', permission: '<%= grant.permission %>') }
-EOF
+        grantee = 'grant.grantee.display_name || grant.grantee.uri'
+        template = <<-EOF
+it { should have_acl_grant(grantee: '<%= #{grantee} %>', permission: '<%= grant.permission %>') }
+        EOF
         template
       end
 

--- a/lib/awspec/generator/spec/s3_bucket.rb
+++ b/lib/awspec/generator/spec/s3_bucket.rb
@@ -22,7 +22,7 @@ module Awspec::Generator
       end
 
       def grant_linetemplate
-        grantee = 'grant.grantee.display_name || grant.grantee.uri'
+        grantee = 'grant.grantee.display_name || grant.grantee.uri || grant.grantee.id'
         template = <<-EOF
 it { should have_acl_grant(grantee: '<%= #{grantee} %>', permission: '<%= grant.permission %>') }
         EOF

--- a/lib/awspec/stub/s3_bucket.rb
+++ b/lib/awspec/stub/s3_bucket.rb
@@ -24,7 +24,7 @@ Aws.config[:s3] = {
         },
         {
           grantee: {
-            display_name: 'my-bucket-write-only',
+            uri: 'http://acs.amazonaws.com/groups/s3/LogDelivery',
             type: 'CanonicalUser'
           },
           permission: 'WRITE'

--- a/lib/awspec/stub/s3_bucket.rb
+++ b/lib/awspec/stub/s3_bucket.rb
@@ -31,7 +31,7 @@ Aws.config[:s3] = {
         },
         {
           grantee: {
-            display_name: 'my-bucket-read-only',
+            id: '68f4bb06b094152df53893bfba57760e',
             type: 'CanonicalUser'
           },
           permission: 'READ'

--- a/lib/awspec/type/s3_bucket.rb
+++ b/lib/awspec/type/s3_bucket.rb
@@ -19,9 +19,8 @@ module Awspec::Type
     def has_acl_grant?(grantee:, permission:)
       @acl = find_bucket_acl(@id)
       @acl.grants.find do |grant|
-        next false if !grantee.nil? && grant.grantee.display_name != grantee && grant.grantee.id != grantee
-        next false if !permission.nil? && grant.permission != permission
-        true
+        grant.permission == permission &&
+          (grant.grantee.display_name == grantee || grant.grantee.uri == grantee || grant.grantee.id == grantee)
       end
     end
 

--- a/spec/generator/spec/s3_bucket_spec.rb
+++ b/spec/generator/spec/s3_bucket_spec.rb
@@ -9,11 +9,11 @@ describe Awspec::Generator::Spec::S3Bucket do
     spec = <<-'EOF'
 describe s3_bucket('my-bucket') do
   it { should exist }
+  its(:acl_owner) { should eq 'my-bucket-owner' }
   its(:acl_grants_count) { should eq 3 }
   it { should have_acl_grant(grantee: 'my-bucket-owner', permission: 'FULL_CONTROL') }
-  it { should have_acl_grant(grantee: 'my-bucket-write-only', permission: 'WRITE') }
-  it { should have_acl_grant(grantee: 'my-bucket-read-only', permission: 'READ') }
-  its(:acl_owner) { should eq 'my-bucket-owner' }
+  it { should have_acl_grant(grantee: 'http://acs.amazonaws.com/groups/s3/LogDelivery', permission: 'WRITE') }
+  it { should have_acl_grant(grantee: '68f4bb06b094152df53893bfba57760e', permission: 'READ') }
 end
 EOF
     expect(s3_bucket.generate_all.to_s).to eq spec

--- a/spec/type/s3_bucket_spec.rb
+++ b/spec/type/s3_bucket_spec.rb
@@ -8,7 +8,7 @@ describe s3_bucket('my-bucket') do
   its(:acl_owner) { should eq 'my-bucket-owner' }
   its(:acl_grants_count) { should eq 3 }
   it { should have_acl_grant(grantee: 'my-bucket-owner', permission: 'FULL_CONTROL') }
-  it { should have_acl_grant(grantee: 'my-bucket-write-only', permission: 'WRITE') }
+  it { should have_acl_grant(grantee: 'http://acs.amazonaws.com/groups/s3/LogDelivery', permission: 'WRITE') }
   it { should have_acl_grant(grantee: 'my-bucket-read-only', permission: 'READ') }
 
   its(:cors_rules_count) { should eq 2 }
@@ -52,7 +52,7 @@ describe s3('my-bucket') do
   it { should have_object('path/to/object') }
   its(:acl_grants_count) { should eq 3 }
   it { should have_acl_grant(grantee: 'my-bucket-owner', permission: 'FULL_CONTROL') }
-  it { should have_acl_grant(grantee: 'my-bucket-write-only', permission: 'WRITE') }
+  it { should have_acl_grant(grantee: 'http://acs.amazonaws.com/groups/s3/LogDelivery', permission: 'WRITE') }
   it { should have_acl_grant(grantee: 'my-bucket-read-only', permission: 'READ') }
   its(:acl_owner) { should eq 'my-bucket-owner' }
 end

--- a/spec/type/s3_bucket_spec.rb
+++ b/spec/type/s3_bucket_spec.rb
@@ -9,7 +9,7 @@ describe s3_bucket('my-bucket') do
   its(:acl_grants_count) { should eq 3 }
   it { should have_acl_grant(grantee: 'my-bucket-owner', permission: 'FULL_CONTROL') }
   it { should have_acl_grant(grantee: 'http://acs.amazonaws.com/groups/s3/LogDelivery', permission: 'WRITE') }
-  it { should have_acl_grant(grantee: 'my-bucket-read-only', permission: 'READ') }
+  it { should have_acl_grant(grantee: '68f4bb06b094152df53893bfba57760e', permission: 'READ') }
 
   its(:cors_rules_count) { should eq 2 }
   it do
@@ -53,6 +53,6 @@ describe s3('my-bucket') do
   its(:acl_grants_count) { should eq 3 }
   it { should have_acl_grant(grantee: 'my-bucket-owner', permission: 'FULL_CONTROL') }
   it { should have_acl_grant(grantee: 'http://acs.amazonaws.com/groups/s3/LogDelivery', permission: 'WRITE') }
-  it { should have_acl_grant(grantee: 'my-bucket-read-only', permission: 'READ') }
+  it { should have_acl_grant(grantee: '68f4bb06b094152df53893bfba57760e', permission: 'READ') }
   its(:acl_owner) { should eq 'my-bucket-owner' }
 end


### PR DESCRIPTION
A grantee `LogDelivery` has only `uri`, so I'd like to handle an `uri` as key of a grantee.