### PR TITLE
enabled AWS IAM User

### DIFF
--- a/lib/awspec/helper/credentials_loader.rb
+++ b/lib/awspec/helper/credentials_loader.rb
@@ -5,13 +5,15 @@ module Awspec::Helper
   module CredentialsLoader
     def self.load(profile = nil)
       profile = ENV['AWS_PROFILE'] if profile.nil?
+      role_profile = ENV['IAM_PROFILE'] if role_profile.nil?
       if profile
         # SharedCredentials
         aws_config = AWSConfig.profiles[profile]
         aws_config = AWSConfig.profiles['default'] unless aws_config
         Aws.config[:region] = aws_config.config_hash[:region] if aws_config
         Aws.config[:credentials] = Aws::SharedCredentials.new(profile_name: profile)
-      else
+      # else
+      elsif profile.nil? and role_profile.nil?
         # secrets.yml
         creds = YAML.load_file('spec/secrets.yml') if File.exist?('spec/secrets.yml')
         creds = YAML.load_file('secrets.yml') if File.exist?('secrets.yml')
@@ -21,6 +23,14 @@ module Awspec::Helper
                               creds['aws_access_key_id'],
                               creds['aws_secret_access_key'])
                           }) if creds
+      elsif role_profile == 'true' and profile.nil?
+        creds = YAML.load_file('spec/secrets.yml') if File.exist?('spec/secrets.yml')
+        creds = YAML.load_file('secrets.yml') if File.exist?('secrets.yml')
+        Aws.config.update({
+                            region: creds['region']
+                          }) if creds
+      else
+        # nothing
       end
     end
   end

--- a/lib/awspec/helper/credentials_loader.rb
+++ b/lib/awspec/helper/credentials_loader.rb
@@ -13,7 +13,7 @@ module Awspec::Helper
         Aws.config[:region] = aws_config.config_hash[:region] if aws_config
         Aws.config[:credentials] = Aws::SharedCredentials.new(profile_name: profile)
       # else
-      elsif profile.nil? and role_profile.nil?
+      elsif profile.nil? && role_profile.nil?
         # secrets.yml
         creds = YAML.load_file('spec/secrets.yml') if File.exist?('spec/secrets.yml')
         creds = YAML.load_file('secrets.yml') if File.exist?('secrets.yml')
@@ -23,14 +23,14 @@ module Awspec::Helper
                               creds['aws_access_key_id'],
                               creds['aws_secret_access_key'])
                           }) if creds
-      elsif role_profile == 'true' and profile.nil?
+      elsif role_profile == 'true' && profile.nil?
         creds = YAML.load_file('spec/secrets.yml') if File.exist?('spec/secrets.yml')
         creds = YAML.load_file('secrets.yml') if File.exist?('secrets.yml')
         Aws.config.update({
                             region: creds['region']
                           }) if creds
       else
-        # nothing
+        STDERR.puts 'You need set any credentials'
       end
     end
   end


### PR DESCRIPTION
Hi,

I enabled AWS IAM User credentials for execute awspec on EC2 Instance.

if we set IAM_PROFILE=true,

```
$ export IAM_PROFILE=true; bundle exec awspec 
```

and set ONLY region to secrets.yml

```
$ cat <<EOF > spec/secrets.yml
region: ap-northeast-1
EOF
```
we can exec awspec without any credentials.

Thanks!
