### PR TITLE
Support "IAM Roles for EC2" with secrets.yml

### DIFF
--- a/lib/awspec/helper/credentials_loader.rb
+++ b/lib/awspec/helper/credentials_loader.rb
@@ -16,11 +16,13 @@ module Awspec::Helper
         creds = YAML.load_file('spec/secrets.yml') if File.exist?('spec/secrets.yml')
         creds = YAML.load_file('secrets.yml') if File.exist?('secrets.yml')
         Aws.config.update({
-                            region: creds['region'],
+                            region: creds['region']
+                          }) if creds.include?('region')
+        Aws.config.update({
                             credentials: Aws::Credentials.new(
                               creds['aws_access_key_id'],
                               creds['aws_secret_access_key'])
-                          }) if creds
+                          }) if creds.include?('aws_access_key_id') && creds.include?('aws_secret_access_key')
       end
     end
   end

--- a/lib/awspec/helper/credentials_loader.rb
+++ b/lib/awspec/helper/credentials_loader.rb
@@ -15,6 +15,7 @@ module Awspec::Helper
         # secrets.yml
         creds = YAML.load_file('spec/secrets.yml') if File.exist?('spec/secrets.yml')
         creds = YAML.load_file('secrets.yml') if File.exist?('secrets.yml')
+        return if creds.nil?
         Aws.config.update({
                             region: creds['region']
                           }) if creds.include?('region')


### PR DESCRIPTION
## Usage

First, specify IAM Role when you launch your EC2 instance.

Second, run command on EC2 instance like 

    $ AWS_REGION=ap-northeast-1 awspec generate iam_policy

or 

    $ cat <<EOF > spec/secrets.yml
    region: ap-northeast-1
    EOF
    $ awspec generate iam_policy