### PR TITLE
Implement Generator::Spec::S3Bucket#generate

### DIFF
--- a/lib/awspec/generator/spec/s3_bucket.rb
+++ b/lib/awspec/generator/spec/s3_bucket.rb
@@ -6,11 +6,14 @@ module Awspec::Generator
         buckets = select_all_buckets
         buckets.empty? && fail('Not Found Bucket')
         specs = buckets.map do |bucket|
-          acl = find_bucket_acl(bucket.name)
-          grant_specs = generate_grant_specs(acl)
-          content = ERB.new(bucket_spec_template, nil, '-').result(binding).gsub(/^\n/, '')
+          content(bucket)
         end
         specs.join("\n")
+      end
+
+      def generate(bucket_name)
+        bucket = find_bucket(bucket_name)
+        content(bucket)
       end
 
       def generate_grant_specs(acl)
@@ -41,6 +44,14 @@ describe s3_bucket('<%= bucket.name %>') do
 end
 EOF
         template
+      end
+
+      private
+
+      def content(bucket)
+        acl = find_bucket_acl(bucket.name)
+        grant_specs = generate_grant_specs(acl)
+        ERB.new(bucket_spec_template, nil, '-').result(binding).gsub(/^\n/, '')
       end
     end
   end

--- a/spec/generator/spec/s3_bucket_spec.rb
+++ b/spec/generator/spec/s3_bucket_spec.rb
@@ -17,5 +17,6 @@ describe s3_bucket('my-bucket') do
 end
 EOF
     expect(s3_bucket.generate_all.to_s).to eq spec
+    expect(s3_bucket.generate('my-bucket').to_s).to eq spec
   end
 end


### PR DESCRIPTION
Hi.

I have one idea.

I try `generate` command with `s3_bucket`.

```
awspec generate s3_bucket
```

But it was failed because some bucket acl was deny for `s3:GetBucketAcl` action.

I just want to generate spec for the other bucket.

So, I call this.

```ruby
a = Awspec::Generator::Spec::S3Bucket.new
bucket = a.find_bucket("my-bucket-name")
acl = a.find_bucket_acl(bucket.name)
grant_specs = a.generate_grant_specs(acl)
puts ERB.new(a.bucket_spec_template, nil, '-').result(binding).gsub(/^\n/, '')
```

I implemented to method `generate`.

But this patch not support call by CLI...

```
$ awspec generate s3_bucet my-bucket-name
```
