### PR TITLE
Show thor error when "awspec [resource_name]" was called with no arguments

### DIFF
--- a/lib/awspec/command/generate.rb
+++ b/lib/awspec/command/generate.rb
@@ -11,10 +11,9 @@ module Awspec
 
     types.each do |type|
       desc type + ' [vpc_id]', "Generate #{type} spec from VPC ID (or VPC \"Name\" tag)"
-      define_method type do |*args|
+      define_method type do |_vpc_id|
         Awsecrets.load(profile: options[:profile])
-        vpc_id = args.first
-        eval "puts Awspec::Generator::Spec::#{type.camelize}.new.generate_by_vpc_id(vpc_id)"
+        eval "puts Awspec::Generator::Spec::#{type.camelize}.new.generate_by_vpc_id(_vpc_id)"
       end
     end
 


### PR DESCRIPTION
```sh
$ bundle exec exe/awspec generate security_group
ERROR: "awspec security_group" was called with no arguments
Usage: "awspec security_group [vpc_id]"
```