### PR TITLE
Add iam_group `have_inline_policy()`

### DIFF
--- a/doc/_resource_types/iam_group.md
+++ b/doc/_resource_types/iam_group.md
@@ -30,3 +30,39 @@ describe iam_group('my-iam-group') do
   it { should have_iam_user('my-iam-user') }
 end
 ```
+
+### have_inline_group
+
+```ruby
+describe iam_group('my-iam-group') do
+  it { should have_inline_policy('InlineEC2FullAccess') }
+  it do
+    should have_inline_policy('InlineEC2FullAccess').policy_document(<<-'DOC')
+{
+  "Statement": [
+    {
+      "Action": "ec2:*",
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "elasticloadbalancing:*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "cloudwatch:*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "autoscaling:*",
+      "Resource": "*"
+    }
+  ]
+}
+DOC
+  end
+end
+```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -527,6 +527,9 @@ describe iam_group('my-iam-group') do
 end
 ```
 
+
+### have_inline_policy
+
 ### its(:path), its(:group_name), its(:group_id), its(:arn), its(:create_date)
 ## <a name="iam_policy">iam_policy</a>
 

--- a/lib/awspec/matcher/have_inline_policy.rb
+++ b/lib/awspec/matcher/have_inline_policy.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :have_inline_policy do |policy_name|
-  match do |iam_user|
-    iam_user.has_inline_policy?(policy_name, @document)
+  match do |iam_type|
+    iam_type.has_inline_policy?(policy_name, @document)
   end
 
   chain :policy_document do |document|

--- a/lib/awspec/stub/iam_group.rb
+++ b/lib/awspec/stub/iam_group.rb
@@ -39,6 +39,15 @@ Aws.config[:iam] = {
       is_truncated: false,
       marker: nil
     },
+    get_group_policy: {
+      group_name: 'my-iam-group',
+      policy_name: 'InlineEC2FullAccess',
+      policy_document: '{"Statement": [{"Action": "ec2:*","Effect": "Allow",' \
+                       '"Resource": "*"},{"Effect": "Allow","Action": "elasticloadbalancing:*",' \
+                       '"Resource": "*"},{"Effect": "Allow","Action": "cloudwatch:*",' \
+                       '"Resource": "*"},{"Effect": "Allow","Action": "autoscaling:*",' \
+                       '"Resource": "*"}]}'
+    },
     simulate_principal_policy: {
       evaluation_results: [
         {

--- a/lib/awspec/type/iam_group.rb
+++ b/lib/awspec/type/iam_group.rb
@@ -22,5 +22,14 @@ module Awspec::Type
         policy.policy_arn == policy_id || policy.policy_name == policy_id
       end
     end
+
+    def has_inline_policy?(policy_name, document = nil)
+      res = iam_client.get_group_policy({
+                                          group_name: @resource_via_client.group_name,
+                                          policy_name: policy_name
+                                        })
+      return JSON.parse(URI.decode(res.policy_document)) == JSON.parse(document) if document
+      res
+    end
   end
 end

--- a/spec/type/iam_group_spec.rb
+++ b/spec/type/iam_group_spec.rb
@@ -5,6 +5,35 @@ describe iam_group('my-iam-group') do
   it { should exist }
   it { should have_iam_user('my-iam-user') }
   it { should have_iam_policy('ReadOnlyAccess') }
+  it { should have_inline_policy('InlineEC2FullAccess') }
+  it do
+    should have_inline_policy('InlineEC2FullAccess').policy_document(<<-'DOC')
+{
+  "Statement": [
+    {
+      "Action": "ec2:*",
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "elasticloadbalancing:*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "cloudwatch:*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "autoscaling:*",
+      "Resource": "*"
+    }
+  ]
+}
+DOC
+  end
   it { should be_allowed_action('ec2:DescribeInstances') }
   it { should be_allowed_action('ec2:DescribeInstances').resource_arn('*') }
 end


### PR DESCRIPTION
```ruby
describe iam_group('my-iam-group') do
  it { should have_inline_policy('InlineEC2FullAccess') }
  it do
    should have_inline_policy('InlineEC2FullAccess').policy_document(<<-'DOC')
{
  "Statement": [
    {
      "Action": "ec2:*",
      "Effect": "Allow",
      "Resource": "*"
    },
    {
      "Effect": "Allow",
      "Action": "elasticloadbalancing:*",
      "Resource": "*"
    },
    {
      "Effect": "Allow",
      "Action": "cloudwatch:*",
      "Resource": "*"
    },
    {
      "Effect": "Allow",
      "Action": "autoscaling:*",
      "Resource": "*"
    }
  ]
}
DOC
  end
end
```