### PR TITLE
Add iam_role `have_inline_policy()`

### DIFF
--- a/doc/_resource_types/iam_role.md
+++ b/doc/_resource_types/iam_role.md
@@ -22,3 +22,31 @@ describe iam_role('my-iam-role') do
   it { should have_iam_policy('ReadOnlyAccess') }
 end
 ```
+
+### have_inline_policy
+
+```ruby
+describe iam_role('my-iam-role') do
+  it { should have_inline_policy('AllowS3BucketAccess') }
+  it do
+    should have_inline_policy('AllowS3BucketAccess').policy_document(<<-'DOC')
+{
+"Statement": [
+    {
+     "Action": [
+        "s3:ListAllMyBuckets"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::*"
+    },
+    {
+      "Action": "s3:*",
+      "Effect": "Allow",
+      "Resource": ["arn:aws:s3:::my-bucket", "arn:aws:s3:::my-bucket/*"]
+    }
+  ]
+}
+DOC
+  end
+end
+```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -611,6 +611,35 @@ describe iam_role('my-iam-role') do
 end
 ```
 
+
+### have_inline_policy
+
+```ruby
+describe iam_role('my-iam-role') do
+  it { should have_inline_policy('AllowS3BucketAccess') }
+  it do
+    should have_inline_policy('AllowS3BucketAccess').policy_document(<<-'DOC')
+{
+"Statement": [
+    {
+     "Action": [
+        "s3:ListAllMyBuckets"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::*"
+    },
+    {
+      "Action": "s3:*",
+      "Effect": "Allow",
+      "Resource": ["arn:aws:s3:::my-bucket", "arn:aws:s3:::my-bucket/*"]
+    }
+  ]
+}
+DOC
+  end
+end
+```
+
 ### its(:path), its(:role_name), its(:role_id), its(:arn), its(:create_date), its(:assume_role_policy_document)
 ## <a name="iam_user">iam_user</a>
 

--- a/lib/awspec/stub/iam_role.rb
+++ b/lib/awspec/stub/iam_role.rb
@@ -19,6 +19,14 @@ Aws.config[:iam] = {
       is_truncated: false,
       marker: nil
     },
+    get_role_policy: {
+      role_name: 'my-iam-role',
+      policy_name: 'AllowS3BucketAccess',
+      policy_document: '{"Statement": [{"Action": ["s3:ListAllMyBuckets"],' \
+                       '"Effect": "Allow","Resource": "arn:aws:s3:::*"},' \
+                       '{"Action": "s3:*","Effect": "Allow","Resource":' \
+                       '["arn:aws:s3:::my-bucket", "arn:aws:s3:::my-bucket/*"]}]}'
+    },
     simulate_principal_policy: {
       evaluation_results: [
         {

--- a/lib/awspec/type/iam_role.rb
+++ b/lib/awspec/type/iam_role.rb
@@ -12,5 +12,14 @@ module Awspec::Type
         policy.policy_arn == policy_id || policy.policy_name == policy_id
       end
     end
+
+    def has_inline_policy?(policy_name, document = nil)
+      res = iam_client.get_role_policy({
+                                         role_name: @resource_via_client.role_name,
+                                         policy_name: policy_name
+                                       })
+      return JSON.parse(URI.decode(res.policy_document)) == JSON.parse(document) if document
+      res
+    end
   end
 end

--- a/spec/type/iam_role_spec.rb
+++ b/spec/type/iam_role_spec.rb
@@ -4,6 +4,27 @@ Awspec::Stub.load 'iam_role'
 describe iam_role('my-iam-role') do
   it { should exist }
   it { should have_iam_policy('ReadOnlyAccess') }
+  it { should have_inline_policy('AllowS3BucketAccess') }
+  it do
+    should have_inline_policy('AllowS3BucketAccess').policy_document(<<-'DOC')
+{
+"Statement": [
+    {
+     "Action": [
+        "s3:ListAllMyBuckets"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::*"
+    },
+    {
+      "Action": "s3:*",
+      "Effect": "Allow",
+      "Resource": ["arn:aws:s3:::my-bucket", "arn:aws:s3:::my-bucket/*"]
+    }
+  ]
+}
+DOC
+  end
   it { should be_allowed_action('ec2:DescribeInstances') }
   it { should be_allowed_action('ec2:DescribeInstances').resource_arn('*') }
 end


### PR DESCRIPTION
```ruby
describe iam_role('my-iam-role') do
  it { should have_inline_policy('AllowS3BucketAccess') }
  it do
    should have_inline_policy('AllowS3BucketAccess').policy_document(<<-'DOC')
{
"Statement": [
    {
     "Action": [
        "s3:ListAllMyBuckets"
      ],
      "Effect": "Allow",
      "Resource": "arn:aws:s3:::*"
    },
    {
      "Action": "s3:*",
      "Effect": "Allow",
      "Resource": ["arn:aws:s3:::my-bucket", "arn:aws:s3:::my-bucket/*"]
    }
  ]
}
DOC
  end
end
```