### PR TITLE
Fix ec2 have_events

### DIFF
--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -70,7 +70,7 @@ module Awspec::Type
 
     def has_events?
       status = find_ec2_status(@id)
-      status.events.count > 0
+      !status.nil?
     end
   end
 end


### PR DESCRIPTION
```sh
NoMethodError:
       undefined method `events' for nil:NilClass
```