### PR TITLE
Add context_entries to be_allowed_action

### DIFF
--- a/lib/awspec/helper/finder/iam.rb
+++ b/lib/awspec/helper/finder/iam.rb
@@ -19,12 +19,14 @@ module Awspec::Helper
         end
       end
 
-      def select_policy_evaluation_results(policy_arn, action_name, resource_arn = nil)
+      def select_policy_evaluation_results(policy_arn, action_name, resource_arn = nil, context_entries = nil)
         options = {
           policy_source_arn: policy_arn,
           action_names: [action_name]
         }
         options[:resource_arns] = [resource_arn] if resource_arn
+        options[:context_entries] = context_entries if context_entries
+
         res = iam_client.simulate_principal_policy(options)
         res.evaluation_results
       end

--- a/lib/awspec/matcher/be_allowed_action.rb
+++ b/lib/awspec/matcher/be_allowed_action.rb
@@ -1,6 +1,9 @@
 RSpec::Matchers.define :be_allowed_action do |action_name|
   match do |type|
-    results = type.select_policy_evaluation_results(type.resource_via_client[:arn], action_name, @resource_arn)
+    results = type.select_policy_evaluation_results(type.resource_via_client[:arn],
+                                                    action_name,
+                                                    @resource_arn,
+                                                    @context_entries)
     results.find do |result|
       result.eval_decision == 'allowed'
     end
@@ -8,5 +11,9 @@ RSpec::Matchers.define :be_allowed_action do |action_name|
 
   chain :resource_arn do |arn|
     @resource_arn = arn
+  end
+
+  chain :context_entries do |context|
+    @context_entries = context
   end
 end

--- a/lib/awspec/version.rb
+++ b/lib/awspec/version.rb
@@ -1,3 +1,3 @@
 module Awspec
-  VERSION = '0.37.6'
+  VERSION = '0.37.7'
 end

--- a/spec/type/iam_group_spec.rb
+++ b/spec/type/iam_group_spec.rb
@@ -36,6 +36,12 @@ DOC
   end
   it { should be_allowed_action('ec2:DescribeInstances') }
   it { should be_allowed_action('ec2:DescribeInstances').resource_arn('*') }
+  it do
+    should be_allowed_action('s3:ListBucket')
+      .resource_arn('*')
+      .context_entries(
+        [{ context_key_name: 's3:prefix', context_key_values: ['/file.txt'], context_key_type: 'string' }])
+  end
   context 'nested attribute call' do
     its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }
     its('users.first.user_name') { should eq 'my-iam-user' }

--- a/spec/type/iam_role_spec.rb
+++ b/spec/type/iam_role_spec.rb
@@ -27,6 +27,12 @@ DOC
   end
   it { should be_allowed_action('ec2:DescribeInstances') }
   it { should be_allowed_action('ec2:DescribeInstances').resource_arn('*') }
+  it do
+    should be_allowed_action('s3:ListBucket')
+      .resource_arn('*')
+      .context_entries(
+        [{ context_key_name: 's3:prefix', context_key_values: ['/file.txt'], context_key_type: 'string' }])
+  end
   context 'nested attribute call' do
     its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }
     its('resource.role_name') { should eq 'my-iam-role' }

--- a/spec/type/iam_user_spec.rb
+++ b/spec/type/iam_user_spec.rb
@@ -28,6 +28,12 @@ DOC
   end
   it { should be_allowed_action('ec2:DescribeInstances') }
   it { should be_allowed_action('ec2:DescribeInstances').resource_arn('*') }
+  it do
+    should be_allowed_action('s3:ListBucket')
+      .resource_arn('*')
+      .context_entries(
+        [{ context_key_name: 's3:prefix', context_key_values: ['/file.txt'], context_key_type: 'string' }])
+  end
   context 'nested attribute call' do
     its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }
     its('resource.user_name') { should eq 'my-iam-user' }


### PR DESCRIPTION
This PR add **context_entries** to be_allowed_action allowing to define more complex test scenarios like check permission to access a S3 bucket using specific conditions.

```
it { should be_allowed_action('s3:ListBucket').resource_arn('*').context_entries([{context_key_name:"s3:prefix",context_key_values:["/dir1/*/dir3/file.txt"],context_key_type:"string"}]) }
```

context_entries variable is an array to be able to accept multiples conditions.
