### PR TITLE
Add ec2 `have_classiclink_security_group()`

### DIFF
--- a/doc/_resource_types/ec2.md
+++ b/doc/_resource_types/ec2.md
@@ -30,6 +30,15 @@ describe ec2('my-ec2-classic') do
 end
 ```
 
+### have_classiclink_security_group
+
+```ruby
+describe ec2('my-ec2-classic') do
+  it { should have_classiclink_security_group('sg-2a3b4cd5') }
+  it { should have_classiclink_security_group('my-vpc-security-group-name') }
+end
+```
+
 ### have_ebs
 
 ```ruby

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -262,6 +262,16 @@ end
 ```
 
 
+### have_classiclink_security_group
+
+```ruby
+describe ec2('my-ec2-classic') do
+  it { should have_classiclink_security_group('sg-2a3b4cd5') }
+  it { should have_classiclink_security_group('my-vpc-security-group-name') }
+end
+```
+
+
 ### have_ebs
 
 ```ruby

--- a/lib/awspec/stub/ec2.rb
+++ b/lib/awspec/stub/ec2.rb
@@ -145,7 +145,11 @@ Aws.config[:ec2] = {
     describe_classic_link_instances: {
       instances: [
         instance_id: 'my-ec2-classic',
-        vpc_id: 'my-vpc'
+        vpc_id: 'my-vpc',
+        groups: [
+          { group_name: nil, group_id: 'sg-2a3b4cd5' },
+          { group_name: 'my-vpc-security-group-name', group_id: nil }
+        ]
       ]
     }
   }

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -82,5 +82,19 @@ module Awspec::Type
       ret = ec2_client.describe_classic_link_instances(option)
       return ret.instances.count == 1 if vpc_id
     end
+
+    def has_classiclink_security_group?(sg_id)
+      option = {
+        instance_ids: [@id]
+      }
+      classic_link_instances = ec2_client.describe_classic_link_instances(option)
+      return false if classic_link_instances.instances.count == 0
+      instances = classic_link_instances[0]
+      sgs = instances[0].groups
+      ret = sgs.find do |sg|
+        sg.group_id == sg_id || sg.group_name == sg_id
+      end
+      return true if ret
+    end
   end
 end

--- a/spec/type/ec2_spec.rb
+++ b/spec/type/ec2_spec.rb
@@ -39,4 +39,6 @@ end
 
 describe ec2('my-ec2-classic') do
   it { should have_classiclink('my-vpc') }
+  it { should have_classiclink_security_group('sg-2a3b4cd5') }
+  it { should have_classiclink_security_group('my-vpc-security-group-name') }
 end


### PR DESCRIPTION
I add have_classiclink_security_group.
Can you review ?
Yorosiku!

### have_classiclink_security_group

```ruby
describe ec2('my-ec2-classic') do
  it { should have_classiclink_security_group('sg-2a3b4cd5') }
  it { should have_classiclink_security_group('my-vpc-security-group-name') }
end
```
