### PR TITLE
add shared_context to specify region by context

### DIFF
--- a/lib/awspec.rb
+++ b/lib/awspec.rb
@@ -14,6 +14,7 @@ require 'awspec/ext'
 require 'awspec/generator'
 require 'awspec/toolbox'
 require 'awspec/resource_reader'
+require 'awspec/shared_context'
 
 module Awspec
 end

--- a/lib/awspec/generator/template.rb
+++ b/lib/awspec/generator/template.rb
@@ -16,9 +16,12 @@ module Awspec::Generator
       content = <<-"EOF"
 module Awspec::Type
   class #{@type.camelize} < Base
-    def initialize(id)
-      super
-      # @id = # @FIXME
+    def resource_via_client
+      @resource_via_client ||= # FIXME
+    end
+
+    def id
+     @id ||= # FIXME
     end
   end
 end

--- a/lib/awspec/shared_context.rb
+++ b/lib/awspec/shared_context.rb
@@ -1,0 +1,11 @@
+shared_context 'region', :region do
+  before do |example|
+    region = example.metadata[:region]
+    @_region = Aws.config[:region]
+    Aws.config[:region] = region
+  end
+
+  after do
+    Aws.config[:region] = @_region
+  end
+end

--- a/lib/awspec/type/ami.rb
+++ b/lib/awspec/type/ami.rb
@@ -2,10 +2,12 @@ module Awspec::Type
   class Ami < Base
     aws_resource Aws::EC2::Image
 
-    def initialize(id)
-      super
-      @resource_via_client = find_ami(id)
-      @id = @resource_via_client.image_id if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_ami(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.image_id if resource_via_client
     end
 
     STATES = %w(
@@ -15,7 +17,7 @@ module Awspec::Type
 
     STATES.each do |state|
       define_method state + '?' do
-        @resource_via_client.state == state
+        resource_via_client.state == state
       end
     end
   end

--- a/lib/awspec/type/autoscaling_group.rb
+++ b/lib/awspec/type/autoscaling_group.rb
@@ -1,20 +1,22 @@
 module Awspec::Type
   class AutoscalingGroup < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_autoscaling_group(id)
-      @id = @resource_via_client.auto_scaling_group_arn if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_autoscaling_group(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.auto_scaling_group_arn if resource_via_client
     end
 
     def has_elb?(name)
-      @resource_via_client.load_balancer_names.find do |lb_name|
+      resource_via_client.load_balancer_names.find do |lb_name|
         lb_name == name
       end
     end
 
     def has_ec2?(id)
       ec2 = find_ec2(id)
-      @resource_via_client.instances.find do |instance|
+      resource_via_client.instances.find do |instance|
         instance.instance_id = ec2.instance_id
       end if ec2
     end

--- a/lib/awspec/type/cloudfront_distribution.rb
+++ b/lib/awspec/type/cloudfront_distribution.rb
@@ -1,9 +1,11 @@
 module Awspec::Type
   class CloudfrontDistribution < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_cloudfront_distribution(id)
-      @id = @resource_via_client.id if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_cloudfront_distribution(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.id if resource_via_client
     end
 
     STATUSES = %w(
@@ -12,7 +14,7 @@ module Awspec::Type
 
     STATUSES.each do |status|
       define_method status.underscore + '?' do
-        @resource_via_client.status == status
+        resource_via_client.status == status
       end
     end
 
@@ -21,7 +23,7 @@ module Awspec::Type
                     origin_path: nil,
                     origin_access_identity: nil)
       return false unless [origin_id, domain_name].any?
-      @resource_via_client.origins.items.find do |origin|
+      resource_via_client.origins.items.find do |origin|
         next false if !origin_id.nil? && origin.id != origin_id
         next false if !domain_name.nil? && origin.domain_name != domain_name
         next false if !origin_path.nil? && origin.origin_path != origin_path

--- a/lib/awspec/type/cloudtrail.rb
+++ b/lib/awspec/type/cloudtrail.rb
@@ -2,26 +2,28 @@ module Awspec::Type
   class Cloudtrail < Base
     aws_resource Aws::CloudTrail
 
-    def initialize(id)
-      super
-      @resource_via_client = find_trail(id)
-      @id = @resource_via_client.name if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_trail(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.name if resource_via_client
     end
 
     def has_global_service_events_included?
-      @resource_via_client.include_global_service_events
+      resource_via_client.include_global_service_events
     end
 
     def multi_region_trail?
-      @resource_via_client.is_multi_region_trail
+      resource_via_client.is_multi_region_trail
     end
 
     def has_log_file_validation_enabled?
-      @resource_via_client.log_file_validation_enabled
+      resource_via_client.log_file_validation_enabled
     end
 
     def logging?
-      is_logging?(@id)
+      is_logging?(id)
     end
   end
 end

--- a/lib/awspec/type/cloudwatch_alarm.rb
+++ b/lib/awspec/type/cloudwatch_alarm.rb
@@ -1,21 +1,23 @@
 module Awspec::Type
   class CloudwatchAlarm < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_cloudwatch_alarm(id)
-      @id = @resource_via_client.alarm_arn if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_cloudwatch_alarm(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.alarm_arn if resource_via_client
     end
 
     def has_ok_action?(name)
-      @resource_via_client.ok_actions.include?(name)
+      resource_via_client.ok_actions.include?(name)
     end
 
     def has_alarm_action?(name)
-      @resource_via_client.alarm_actions.include?(name)
+      resource_via_client.alarm_actions.include?(name)
     end
 
     def has_insufficient_data_action?(name)
-      @resource_via_client.insufficient_data_actions.include?(name)
+      resource_via_client.insufficient_data_actions.include?(name)
     end
   end
 end

--- a/lib/awspec/type/cloudwatch_event.rb
+++ b/lib/awspec/type/cloudwatch_event.rb
@@ -1,17 +1,19 @@
 module Awspec::Type
   class CloudwatchEvent < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_cloudwatch_event(id)
-      @id = @resource_via_client.arn if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_cloudwatch_event(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.arn if resource_via_client
     end
 
     def enable?
-      @resource_via_client.state == 'ENABLED'
+      resource_via_client.state == 'ENABLED'
     end
 
     def scheduled?(schedule)
-      @resource_via_client.schedule_expression == schedule
+      resource_via_client.schedule_expression == schedule
     end
   end
 end

--- a/lib/awspec/type/directconnect_virtual_interface.rb
+++ b/lib/awspec/type/directconnect_virtual_interface.rb
@@ -1,9 +1,16 @@
 module Awspec::Type
   class DirectconnectVirtualInterface < Base
-    def initialize(id)
+    def initialize(name)
       super
-      @resource_via_client = find_virtual_interface(id)
-      @id = @resource_via_client.virtual_interface_id if @resource_via_client
+      @display_name = name
+    end
+
+    def resource_via_client
+      @resource_via_client ||= find_virtual_interface(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.virtual_interface_id if resource_via_client
     end
 
     STATES = %w(
@@ -13,7 +20,7 @@ module Awspec::Type
 
     STATES.each do |state|
       define_method state + '?' do
-        @resource_via_client.virtual_interface_state == state
+        resource_via_client.virtual_interface_state == state
       end
     end
   end

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -3,10 +3,17 @@ module Awspec::Type
     aws_resource Aws::EC2::Instance
     tags_allowed
 
-    def initialize(id)
+    def initialize(name)
       super
-      @resource_via_client = find_ec2(id)
-      @id = @resource_via_client.instance_id if @resource_via_client
+      @display_name = name
+    end
+
+    def resource_via_client
+      @resource_via_client ||= find_ec2(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.instance_id if resource_via_client
     end
 
     STATES = %w(
@@ -16,18 +23,18 @@ module Awspec::Type
 
     STATES.each do |state|
       define_method state.tr('-', '_') + '?' do
-        @resource_via_client.state.name == state
+        resource_via_client.state.name == state
       end
     end
 
     def disabled_api_termination?
-      ret = find_ec2_attribute(@id, 'disableApiTermination')
+      ret = find_ec2_attribute(id, 'disableApiTermination')
       ret.disable_api_termination.value
     end
 
     def has_eip?(ip_address = nil)
       option = {
-        filters: [{ name: 'instance-id', values: [@id] }]
+        filters: [{ name: 'instance-id', values: [id] }]
       }
       option[:public_ips] = [ip_address] if ip_address
       ret = ec2_client.describe_addresses(option)
@@ -36,7 +43,7 @@ module Awspec::Type
     end
 
     def has_security_group?(sg_id)
-      sgs = @resource_via_client.security_groups
+      sgs = resource_via_client.security_groups
       ret = sgs.find do |sg|
         sg.group_id == sg_id || sg.group_name == sg_id
       end
@@ -49,7 +56,7 @@ module Awspec::Type
     end
 
     def has_ebs?(volume_id)
-      blocks = @resource_via_client.block_device_mappings
+      blocks = resource_via_client.block_device_mappings
       ret = blocks.find do |block|
         next false unless block.ebs
         block.ebs.volume_id == volume_id
@@ -57,26 +64,26 @@ module Awspec::Type
       return true if ret
       blocks2 = find_ebs(volume_id)
       blocks2.attachments.find do |attachment|
-        attachment.instance_id == @id
+        attachment.instance_id == id
       end
     end
 
     def has_event?(event_code)
-      status = find_ec2_status(@id)
+      status = find_ec2_status(id)
       ret = status.events.find do |event|
         event.code == event_code
       end
     end
 
     def has_events?
-      status = find_ec2_status(@id)
+      status = find_ec2_status(id)
       return false if status.nil?
       status.events.count > 0
     end
 
     def has_classiclink?(vpc_id = nil)
       option = {
-        instance_ids: [@id]
+        instance_ids: [id]
       }
       option[:filters] = [{ name: 'vpc-id', values: [vpc_id] }] if vpc_id
       ret = ec2_client.describe_classic_link_instances(option)
@@ -85,7 +92,7 @@ module Awspec::Type
 
     def has_classiclink_security_group?(sg_id)
       option = {
-        instance_ids: [@id]
+        instance_ids: [id]
       }
       classic_link_instances = ec2_client.describe_classic_link_instances(option)
       return false if classic_link_instances.instances.count == 0

--- a/lib/awspec/type/elasticache.rb
+++ b/lib/awspec/type/elasticache.rb
@@ -1,9 +1,16 @@
 module Awspec::Type
   class Elasticache < Base
-    def initialize(id)
+    def initialize(name)
       super
-      @resource_via_client = find_cache_cluster(id)
-      @id = @resource_via_client.cache_cluster_id if @resource_via_client
+      @display_name = name
+    end
+
+    def resource_via_client
+      @resource_via_client ||= find_cache_cluster(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.cache_cluster_id if resource_via_client
     end
 
     STATES = %w(
@@ -15,16 +22,16 @@ module Awspec::Type
 
     STATES.each do |state|
       define_method state.tr('-', '_') + '?' do
-        @resource_via_client.cache_cluster_status == state
+        resource_via_client.cache_cluster_status == state
       end
     end
 
     def has_cache_parameter_group?(group_name)
-      @resource_via_client.cache_parameter_group.cache_parameter_group_name == group_name
+      resource_via_client.cache_parameter_group.cache_parameter_group_name == group_name
     end
 
     def vpc_id
-      cache_subnet_group = find_cache_subnet_group(@resource_via_client.cache_subnet_group_name)
+      cache_subnet_group = find_cache_subnet_group(resource_via_client.cache_subnet_group_name)
       cache_subnet_group.vpc_id if cache_subnet_group
     end
   end

--- a/lib/awspec/type/elasticsearch.rb
+++ b/lib/awspec/type/elasticsearch.rb
@@ -1,21 +1,23 @@
 module Awspec::Type
   class Elasticsearch < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_elasticsearch_domain(id)
-      @id = @resource_via_client.arn if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_elasticsearch_domain(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.arn if resource_via_client
     end
 
     def has_access_policies?(policy)
-      @resource_via_client.access_policies == policy.gsub(/\n/, '').gsub(/ /, '')
+      resource_via_client.access_policies == policy.gsub(/\n/, '').gsub(/ /, '')
     end
 
     def created?
-      @resource_via_client.created
+      resource_via_client.created
     end
 
     def deleted?
-      @resource_via_client.deleted
+      resource_via_client.deleted
     end
   end
 end

--- a/lib/awspec/type/elastictranscoder_pipeline.rb
+++ b/lib/awspec/type/elastictranscoder_pipeline.rb
@@ -1,9 +1,11 @@
 module Awspec::Type
   class ElastictranscoderPipeline < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_pipeline(id)
-      @id = @resource_via_client.id if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_pipeline(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.id if resource_via_client
     end
 
     STATUSES = %w(
@@ -12,7 +14,7 @@ module Awspec::Type
 
     STATUSES.each do |status|
       define_method status.underscore + '?' do
-        @resource_via_client.status == status
+        resource_via_client.status == status
       end
     end
   end

--- a/lib/awspec/type/elb.rb
+++ b/lib/awspec/type/elb.rb
@@ -1,9 +1,11 @@
 module Awspec::Type
   class Elb < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_elb(id)
-      @id = @resource_via_client.load_balancer_name if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_elb(@display_name)
+    end
+
+    def id
+      @id = resource_via_client.load_balancer_name if resource_via_client
     end
 
     health_check_options = %w(
@@ -13,19 +15,19 @@ module Awspec::Type
 
     health_check_options.each do |option|
       define_method 'health_check_' + option do
-        @resource_via_client.health_check[option]
+        resource_via_client.health_check[option]
       end
     end
 
     def has_ec2?(id)
       ec2 = find_ec2(id)
-      @resource_via_client.instances.find do |instance|
+      resource_via_client.instances.find do |instance|
         instance.instance_id = ec2.instance_id
       end if ec2
     end
 
     def has_security_group?(sg_id)
-      sgs = @resource_via_client.security_groups
+      sgs = resource_via_client.security_groups
       ret = sgs.find do |sg|
         sg == sg_id
       end
@@ -38,7 +40,7 @@ module Awspec::Type
     end
 
     def has_subnet?(subnet_id)
-      subnets = @resource_via_client.subnets
+      subnets = resource_via_client.subnets
       ret = subnets.find do |s|
         s == subnet_id
       end
@@ -50,7 +52,7 @@ module Awspec::Type
     end
 
     def has_listener?(protocol:, port:, instance_protocol:, instance_port:)
-      @resource_via_client.listener_descriptions.find do |desc|
+      resource_via_client.listener_descriptions.find do |desc|
         listener = desc.listener
         listener.protocol == protocol && listener.load_balancer_port == port && \
           listener.instance_protocol == instance_protocol && listener.instance_port == instance_port

--- a/lib/awspec/type/iam_policy.rb
+++ b/lib/awspec/type/iam_policy.rb
@@ -1,17 +1,19 @@
 module Awspec::Type
   class IamPolicy < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_iam_policy(id)
-      @id = @resource_via_client.policy_id if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_iam_policy(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.policy_id if resource_via_client
     end
 
     def attachable?
-      @resource_via_client.is_attachable
+      resource_via_client.is_attachable
     end
 
     def attached_to_user?(user_id = nil)
-      users = select_attached_users(@id)
+      users = select_attached_users(id)
       if user_id
         user = find_iam_user(user_id)
         return false unless user

--- a/lib/awspec/type/iam_role.rb
+++ b/lib/awspec/type/iam_role.rb
@@ -2,14 +2,16 @@ module Awspec::Type
   class IamRole < Base
     aws_resource Aws::IAM::Role
 
-    def initialize(id)
-      super
-      @resource_via_client = find_iam_role(id)
-      @id = @resource_via_client.role_id if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_iam_role(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.role_id if resource_via_client
     end
 
     def has_iam_policy?(policy_id)
-      policies = select_iam_policy_by_role_name(@resource_via_client.role_name)
+      policies = select_iam_policy_by_role_name(resource_via_client.role_name)
       policies.find do |policy|
         policy.policy_arn == policy_id || policy.policy_name == policy_id
       end
@@ -17,7 +19,7 @@ module Awspec::Type
 
     def has_inline_policy?(policy_name, document = nil)
       res = iam_client.get_role_policy({
-                                         role_name: @resource_via_client.role_name,
+                                         role_name: resource_via_client.role_name,
                                          policy_name: policy_name
                                        })
       return JSON.parse(URI.decode(res.policy_document)) == JSON.parse(document) if document

--- a/lib/awspec/type/iam_user.rb
+++ b/lib/awspec/type/iam_user.rb
@@ -2,14 +2,16 @@ module Awspec::Type
   class IamUser < Base
     aws_resource Aws::IAM::User
 
-    def initialize(id)
-      super
-      @resource_via_client = find_iam_user(id)
-      @id = @resource_via_client.user_name if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_iam_user(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.user_name if resource_via_client
     end
 
     def has_iam_policy?(policy_id)
-      policies = select_iam_policy_by_user_name(@resource_via_client.user_name)
+      policies = select_iam_policy_by_user_name(resource_via_client.user_name)
       policies.find do |policy|
         policy.policy_arn == policy_id || policy.policy_name == policy_id
       end
@@ -17,7 +19,7 @@ module Awspec::Type
 
     def has_inline_policy?(policy_name, document = nil)
       res = iam_client.get_user_policy({
-                                         user_name: @resource_via_client.user_name,
+                                         user_name: resource_via_client.user_name,
                                          policy_name: policy_name
                                        })
       return JSON.parse(URI.decode(res.policy_document)) == JSON.parse(document) if document

--- a/lib/awspec/type/kms.rb
+++ b/lib/awspec/type/kms.rb
@@ -1,17 +1,19 @@
 module Awspec::Type
   class Kms < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_kms_key_by_alias(id)
-      @id = @resource_via_client.arn if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_kms_key_by_alias(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.arn if resource_via_client
     end
 
     def enabled?
-      @resource_via_client.enabled
+      resource_via_client.enabled
     end
 
     def has_key_policy?(policy_name, document = nil)
-      res = kms_client.get_key_policy(key_id: @id, policy_name: policy_name)
+      res = kms_client.get_key_policy(key_id: id, policy_name: policy_name)
       return JSON.parse(URI.decode(res.policy)) == JSON.parse(document) if document
       res
     end

--- a/lib/awspec/type/lambda.rb
+++ b/lib/awspec/type/lambda.rb
@@ -1,17 +1,19 @@
 module Awspec::Type
   class Lambda < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_lambda(id)
-      @id = @resource_via_client.function_arn if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_lambda(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.function_arn if resource_via_client
     end
 
     def timeout
-      @resource_via_client.timeout
+      resource_via_client.timeout
     end
 
     def has_event_source?(event_source_arn)
-      sources = select_event_source_by_function_arn(@id)
+      sources = select_event_source_by_function_arn(id)
       sources.find do |source|
         source.event_source_arn == event_source_arn
       end

--- a/lib/awspec/type/launch_configuration.rb
+++ b/lib/awspec/type/launch_configuration.rb
@@ -1,13 +1,15 @@
 module Awspec::Type
   class LaunchConfiguration < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_launch_configuration(id)
-      @id = @resource_via_client.launch_configuration_arn if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_launch_configuration(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.launch_configuration_arn if resource_via_client
     end
 
     def has_security_group?(sg_id)
-      sgs = @resource_via_client.security_groups
+      sgs = resource_via_client.security_groups
       ret = sgs.find do |sg|
         sg == sg_id
       end

--- a/lib/awspec/type/nat_gateway.rb
+++ b/lib/awspec/type/nat_gateway.rb
@@ -1,9 +1,11 @@
 module Awspec::Type
   class NatGateway < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_nat_gateway(id)
-      @id = @resource_via_client.nat_gateway_id if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_nat_gateway(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.nat_gateway_id if resource_via_client
     end
 
     STATES = %w(
@@ -12,12 +14,12 @@ module Awspec::Type
 
     STATES.each do |state|
       define_method state.tr('-', '_') + '?' do
-        @resource_via_client.state == state
+        resource_via_client.state == state
       end
     end
 
     def has_eip?(ip_address = nil)
-      @resource_via_client.nat_gateway_addresses.find do |address|
+      resource_via_client.nat_gateway_addresses.find do |address|
         return address.public_ip == ip_address
       end
     end

--- a/lib/awspec/type/network_interface.rb
+++ b/lib/awspec/type/network_interface.rb
@@ -1,9 +1,11 @@
 module Awspec::Type
   class NetworkInterface < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_network_interface(id)
-      @id = @resource_via_client.network_interface_id if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_network_interface(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.network_interface_id if resource_via_client
     end
 
     STATES = %w(
@@ -12,28 +14,28 @@ module Awspec::Type
 
     STATES.each do |state|
       define_method state.tr('-', '_') + '?' do
-        @resource_via_client.status == state
+        resource_via_client.status == state
       end
     end
 
     def attached_to?(instance_id, device_index = 0)
       instance = find_ec2(instance_id)
       return false unless instance
-      return false unless @resource_via_client.attachment
-      @resource_via_client.attachment.instance_id == instance.instance_id && \
-        @resource_via_client.attachment.status == 'attached' && \
-        @resource_via_client.attachment.device_index == device_index
+      return false unless resource_via_client.attachment
+      resource_via_client.attachment.instance_id == instance.instance_id && \
+        resource_via_client.attachment.status == 'attached' && \
+        resource_via_client.attachment.device_index == device_index
     end
 
     def has_private_ip_address?(ip_address, primary = nil)
-      @resource_via_client.private_ip_addresses.find do |i|
+      resource_via_client.private_ip_addresses.find do |i|
         next false if !primary.nil? && i.primary != primary
         i.private_ip_address == ip_address
       end
     end
 
     def has_security_group?(sg_id)
-      sgs = @resource_via_client.groups
+      sgs = resource_via_client.groups
       ret = sgs.find do |sg|
         sg.group_id == sg_id || sg.group_name == sg_id
       end
@@ -46,7 +48,7 @@ module Awspec::Type
     end
 
     def private_ip_addresses_count
-      @resource_via_client.private_ip_addresses.count
+      resource_via_client.private_ip_addresses.count
     end
   end
 end

--- a/lib/awspec/type/rds_db_cluster_parameter_group.rb
+++ b/lib/awspec/type/rds_db_cluster_parameter_group.rb
@@ -1,27 +1,31 @@
 module Awspec::Type
   class RdsDbClusterParameterGroup < Base
-    def initialize(name)
-      super
-      @parameters = {}
+    def resource_via_client
+      return @resource_via_client if @resource_via_client
+
+      parameters = {}
       res = rds_client.describe_db_cluster_parameters({
-                                                        db_cluster_parameter_group_name: name
+                                                        db_cluster_parameter_group_name: @display_name
                                                       })
 
       loop do
         res.parameters.each do |param|
-          @parameters[param.parameter_name] = param.parameter_value
+          parameters[param.parameter_name] = param.parameter_value
         end
         (res.respond_to?(:next_page?) && res.next_page? && res = res.next_page) || break
       end
 
-      @id = name unless @parameters.empty?
-      @resource_via_client = @parameters
+      @resource_via_client ||= parameters
+    end
+
+    def id
+      @id ||= @display_name unless resource_via_client.empty?
     end
 
     def method_missing(name)
       param_name = name.to_s
-      if @parameters.include?(param_name)
-        @parameters[param_name].to_s
+      if resource_via_client.include?(param_name)
+        resource_via_client[param_name].to_s
       else
         super
       end

--- a/lib/awspec/type/rds_db_parameter_group.rb
+++ b/lib/awspec/type/rds_db_parameter_group.rb
@@ -1,27 +1,31 @@
 module Awspec::Type
   class RdsDbParameterGroup < Base
-    def initialize(name)
-      super
-      @parameters = {}
+    def resource_via_client
+      return @resource_via_client if @resource_via_client
+
+      parameters = {}
       res = rds_client.describe_db_parameters({
-                                                db_parameter_group_name: name
+                                                db_parameter_group_name: @display_name
                                               })
 
       loop do
         res.parameters.each do |param|
-          @parameters[param.parameter_name] = param.parameter_value
+          parameters[param.parameter_name] = param.parameter_value
         end
         (res.next_page? && res = res.next_page) || break
       end
 
-      @id = name unless @parameters.empty?
-      @resource_via_client = @parameters
+      @resource_via_client ||= parameters
+    end
+
+    def id
+      @id ||= @display_name unless resource_via_client.empty?
     end
 
     def method_missing(name)
       param_name = name.to_s
-      if @parameters.include?(param_name)
-        @parameters[param_name].to_s
+      if resource_via_client.include?(param_name)
+        resource_via_client[param_name].to_s
       else
         super
       end

--- a/lib/awspec/type/route53_hosted_zone.rb
+++ b/lib/awspec/type/route53_hosted_zone.rb
@@ -1,16 +1,20 @@
 module Awspec::Type
   class Route53HostedZone < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_hosted_zone(id)
-      @id = @resource_via_client.id if @resource_via_client
-      return unless @id
-      @resource_via_client_record_sets = select_record_sets_by_hosted_zone_id(@id)
+    def resource_via_client
+      @resource_via_client ||= find_hosted_zone(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.id if resource_via_client
+    end
+
+    def resource_via_client_record_sets
+      @resource_via_client_record_sets ||= select_record_sets_by_hosted_zone_id(id)
     end
 
     def has_record_set?(name, type, value, options = {})
       name.gsub!(/\*/, '\\\052') # wildcard support
-      ret = @resource_via_client_record_sets.find do |record_set|
+      ret = resource_via_client_record_sets.find do |record_set|
         # next if record_set.type != type.upcase
         next unless record_set.type.casecmp(type) == 0
         options[:ttl] = record_set[:ttl] unless options[:ttl]

--- a/lib/awspec/type/route_table.rb
+++ b/lib/awspec/type/route_table.rb
@@ -3,10 +3,12 @@ module Awspec::Type
     aws_resource Aws::EC2::RouteTable
     tags_allowed
 
-    def initialize(id)
-      super
-      @resource_via_client = find_route_table(id)
-      @id = @resource_via_client.route_table_id if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_route_table(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.route_table_id if resource_via_client
     end
 
     def has_route?(destination,
@@ -14,7 +16,7 @@ module Awspec::Type
                    instance_id = nil,
                    vpc_peering_connection_id = nil,
                    nat_gateway_id = nil)
-      @resource_via_client.routes.find do |route|
+      resource_via_client.routes.find do |route|
         if destination
           next false unless route.destination_cidr_block == destination
         end
@@ -28,7 +30,7 @@ module Awspec::Type
     def has_subnet?(subnet_id)
       subnet = find_subnet(subnet_id)
       return false unless subnet
-      @resource_via_client.associations.find do |a|
+      resource_via_client.associations.find do |a|
         a.subnet_id == subnet.subnet_id
       end
     end

--- a/lib/awspec/type/ses_identity.rb
+++ b/lib/awspec/type/ses_identity.rb
@@ -1,14 +1,16 @@
 module Awspec::Type
   class SesIdentity < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_ses_identity(id)
-      @id = @resource_via_client if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_ses_identity(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client if resource_via_client
     end
 
     def has_identity_policy?(name)
       res = ses_client.list_identity_policies({
-                                                identity: @id
+                                                identity: id
                                               })
       res.policy_names.find do |policy_name|
         policy_name == name
@@ -23,17 +25,17 @@ module Awspec::Type
     dkim_attributes.each do |attribute|
       define_method attribute do
         res = ses_client.get_identity_dkim_attributes({
-                                                        identities: [@id]
+                                                        identities: [id]
                                                       })
-        res.dkim_attributes[@id][attribute.to_sym]
+        res.dkim_attributes[id][attribute.to_sym]
       end
     end
 
     def has_dkim_tokens?(token)
       res = ses_client.get_identity_dkim_attributes({
-                                                      identities: [@id]
+                                                      identities: [id]
                                                     })
-      res.dkim_attributes[@id][:tokens].include?(token)
+      res.dkim_attributes[id][:tokens].include?(token)
     end
 
     # notification_attributes
@@ -45,9 +47,9 @@ module Awspec::Type
     notification_attributes.each do |attribute|
       define_method attribute do
         res = ses_client.get_identity_notification_attributes({
-                                                                identities: [@id]
+                                                                identities: [id]
                                                               })
-        res.notification_attributes[@id][attribute.to_sym]
+        res.notification_attributes[id][attribute.to_sym]
       end
     end
 
@@ -59,9 +61,9 @@ module Awspec::Type
     verification_attributes.each do |attribute|
       define_method attribute do
         res = ses_client.get_identity_verification_attributes({
-                                                                identities: [@id]
+                                                                identities: [id]
                                                               })
-        res.verification_attributes[@id][attribute.to_sym]
+        res.verification_attributes[id][attribute.to_sym]
       end
     end
   end

--- a/lib/awspec/type/subnet.rb
+++ b/lib/awspec/type/subnet.rb
@@ -3,10 +3,12 @@ module Awspec::Type
     aws_resource Aws::EC2::Subnet
     tags_allowed
 
-    def initialize(id)
-      super
-      @resource_via_client = find_subnet(id)
-      @id = @resource_via_client.subnet_id if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_subnet(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.subnet_id if resource_via_client
     end
 
     STATES = %w(
@@ -15,7 +17,7 @@ module Awspec::Type
 
     STATES.each do |state|
       define_method state + '?' do
-        @resource_via_client.state == state
+        resource_via_client.state == state
       end
     end
   end

--- a/lib/awspec/type/vpc.rb
+++ b/lib/awspec/type/vpc.rb
@@ -3,10 +3,12 @@ module Awspec::Type
     aws_resource Aws::EC2::Vpc
     tags_allowed
 
-    def initialize(id)
-      super
-      @resource_via_client = find_vpc(id)
-      @id = @resource_via_client.vpc_id if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_vpc(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.vpc_id if resource_via_client
     end
 
     STATES = %w(
@@ -15,20 +17,20 @@ module Awspec::Type
 
     STATES.each do |state|
       define_method state + '?' do
-        @resource_via_client.state == state
+        resource_via_client.state == state
       end
     end
 
-    def has_route_table?(id)
-      route_table = find_route_table(id)
+    def has_route_table?(table_id)
+      route_table = find_route_table(table_id)
       return false unless route_table
-      route_table.vpc_id == @id
+      route_table.vpc_id == id
     end
 
-    def has_network_acl?(id)
-      n = find_network_acl(id)
+    def has_network_acl?(table_id)
+      n = find_network_acl(table_id)
       return false unless n
-      n.vpc_id == @id
+      n.vpc_id == id
     end
   end
 end

--- a/lib/awspec/type/waf_web_acl.rb
+++ b/lib/awspec/type/waf_web_acl.rb
@@ -1,17 +1,19 @@
 module Awspec::Type
   class WafWebAcl < Base
-    def initialize(id)
-      super
-      @resource_via_client = find_waf_web_acl(id)
-      @id = @resource_via_client.web_acl_id if @resource_via_client
+    def resource_via_client
+      @resource_via_client ||= find_waf_web_acl(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.web_acl_id if resource_via_client
     end
 
     def default_action
-      @resource_via_client.default_action.type
+      resource_via_client.default_action.type
     end
 
     def has_rule?(rule_id, priority = nil, action = nil)
-      @resource_via_client.rules.find do |rule|
+      resource_via_client.rules.find do |rule|
         next false if !priority.nil? && rule.priority != priority
         next false if !action.nil? && rule.action.type != action
         next true if rule.rule_id == rule_id

--- a/spec/core/duplicated_resource_type_spec.rb
+++ b/spec/core/duplicated_resource_type_spec.rb
@@ -3,7 +3,7 @@ Awspec::Stub.load 'duplicated_resource_type'
 
 describe 'Awspec::Type' do
   it 'Duplicated resource type' do
-    expect { Awspec::Type::Vpc.new('my-vpc') }.to raise_error(
+    expect { Awspec::Type::Vpc.new('my-vpc').id }.to raise_error(
       Awspec::DuplicatedResourceTypeError,
       'Duplicated resource type my-vpc'
     )

--- a/spec/shared_context/shared_context_spec.rb
+++ b/spec/shared_context/shared_context_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'shared_context region' do
+  before do
+    Aws.config[:region] = 'ap-northeast-1'
+  end
+
+  context 'use default region' do
+    it 'used ap-northeast-1' do
+      expect(Aws.config[:region]).to eq 'ap-northeast-1'
+    end
+  end
+
+  context 'use custom region', region: 'us-east-1' do
+    it 'used us-east-1' do
+      expect(Aws.config[:region]).to eq 'us-east-1'
+    end
+  end
+end


### PR DESCRIPTION
When we have resource in multi region, run test with specified region.

```ruby
# use default region(defined secret.yml)
describe ec2('my-instance-1') do
    it { should exist }
end

# use custom region(defined metadata)
describe ec2('my-instance-2'), region: 'us-east-1' do
    it { should exist }
end
```