### PR TITLE
add not be allowed action

### DIFF
--- a/doc/_resource_types/iam_group.md
+++ b/doc/_resource_types/iam_group.md
@@ -15,6 +15,15 @@ describe iam_group('my-iam-group') do
 end
 ```
 
+### not_be_allowed_action
+
+```ruby
+describe iam_group('my-iam-group') do
+  it { should not_be_allowed_action('ec2:TerminateInstances') }
+  it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
+end
+```
+
 ### have_iam_policy
 
 ```ruby

--- a/doc/_resource_types/iam_role.md
+++ b/doc/_resource_types/iam_role.md
@@ -18,7 +18,7 @@ end
 ### not_be_allowed_action
 
 ```ruby
-describe iam_group('my-iam-role') do
+describe iam_role('my-iam-role') do
   it { should not_be_allowed_action('ec2:TerminateInstances') }
   it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
 end

--- a/doc/_resource_types/iam_role.md
+++ b/doc/_resource_types/iam_role.md
@@ -18,7 +18,7 @@ end
 ### not_be_allowed_action
 
 ```ruby
-describe iam_group('my-iam-group') do
+describe iam_group('my-iam-role') do
   it { should not_be_allowed_action('ec2:TerminateInstances') }
   it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
 end

--- a/doc/_resource_types/iam_role.md
+++ b/doc/_resource_types/iam_role.md
@@ -15,6 +15,15 @@ describe iam_role('my-iam-role') do
 end
 ```
 
+### not_be_allowed_action
+
+```ruby
+describe iam_group('my-iam-group') do
+  it { should not_be_allowed_action('ec2:TerminateInstances') }
+  it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
+end
+```
+
 ### have_iam_policy
 
 ```ruby

--- a/doc/_resource_types/iam_user.md
+++ b/doc/_resource_types/iam_user.md
@@ -18,7 +18,7 @@ end
 ### not_be_allowed_action
 
 ```ruby
-describe iam_group('my-iam-group') do
+describe iam_group('my-iam-user') do
   it { should not_be_allowed_action('ec2:TerminateInstances') }
   it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
 end

--- a/doc/_resource_types/iam_user.md
+++ b/doc/_resource_types/iam_user.md
@@ -18,7 +18,7 @@ end
 ### not_be_allowed_action
 
 ```ruby
-describe iam_group('my-iam-user') do
+describe iam_user('my-iam-user') do
   it { should not_be_allowed_action('ec2:TerminateInstances') }
   it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
 end

--- a/doc/_resource_types/iam_user.md
+++ b/doc/_resource_types/iam_user.md
@@ -15,6 +15,15 @@ describe iam_user('my-iam-user') do
 end
 ```
 
+### not_be_allowed_action
+
+```ruby
+describe iam_group('my-iam-group') do
+  it { should not_be_allowed_action('ec2:TerminateInstances') }
+  it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
+end
+```
+
 ### have_iam_policy
 
 ```ruby

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -662,14 +662,6 @@ describe iam_group('my-iam-group') do
 end
 ```
 
-### not_be_allowed_action
-
-```ruby
-describe iam_group('my-iam-group') do
-  it { should not_be_allowed_action('ec2:TerminateInstances') }
-  it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
-end
-```
 
 ### have_iam_policy
 
@@ -781,14 +773,6 @@ describe iam_role('my-iam-role') do
 end
 ```
 
-### not_be_allowed_action
-
-```ruby
-describe iam_group('my-iam-group') do
-  it { should not_be_allowed_action('ec2:TerminateInstances') }
-  it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
-end
-```
 
 ### have_iam_policy
 
@@ -859,6 +843,7 @@ describe iam_user('my-iam-user') do
 end
 ```
 
+
 ### be_allowed_action
 
 ```ruby
@@ -868,14 +853,6 @@ describe iam_user('my-iam-user') do
 end
 ```
 
-### not_be_allowed_action
-
-```ruby
-describe iam_group('my-iam-group') do
-  it { should not_be_allowed_action('ec2:TerminateInstances') }
-  it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
-end
-```
 
 ### have_iam_policy
 

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -663,6 +663,16 @@ end
 ```
 
 
+### not_be_allowed_action
+
+```ruby
+describe iam_group('my-iam-group') do
+  it { should not_be_allowed_action('ec2:TerminateInstances') }
+  it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
+end
+```
+
+
 ### have_iam_policy
 
 ```ruby
@@ -774,6 +784,16 @@ end
 ```
 
 
+### not_be_allowed_action
+
+```ruby
+describe iam_role('my-iam-role') do
+  it { should not_be_allowed_action('ec2:TerminateInstances') }
+  it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
+end
+```
+
+
 ### have_iam_policy
 
 ```ruby
@@ -850,6 +870,16 @@ end
 describe iam_user('my-iam-user') do
   it { should be_allowed_action('ec2:DescribeInstances') }
   it { should be_allowed_action('s3:Put*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
+end
+```
+
+
+### not_be_allowed_action
+
+```ruby
+describe iam_user('my-iam-user') do
+  it { should not_be_allowed_action('ec2:TerminateInstances') }
+  it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
 end
 ```
 

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -662,6 +662,14 @@ describe iam_group('my-iam-group') do
 end
 ```
 
+### not_be_allowed_action
+
+```ruby
+describe iam_group('my-iam-group') do
+  it { should not_be_allowed_action('ec2:TerminateInstances') }
+  it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
+end
+```
 
 ### have_iam_policy
 
@@ -773,6 +781,14 @@ describe iam_role('my-iam-role') do
 end
 ```
 
+### not_be_allowed_action
+
+```ruby
+describe iam_group('my-iam-group') do
+  it { should not_be_allowed_action('ec2:TerminateInstances') }
+  it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
+end
+```
 
 ### have_iam_policy
 
@@ -843,7 +859,6 @@ describe iam_user('my-iam-user') do
 end
 ```
 
-
 ### be_allowed_action
 
 ```ruby
@@ -853,6 +868,14 @@ describe iam_user('my-iam-user') do
 end
 ```
 
+### not_be_allowed_action
+
+```ruby
+describe iam_group('my-iam-group') do
+  it { should not_be_allowed_action('ec2:TerminateInstances') }
+  it { should not_be_allowed_action('s3:Delete*').resource_arn('arn:aws:s3:::my-bucket-name/*') }
+end
+```
 
 ### have_iam_policy
 

--- a/lib/awspec/generator/doc/type/iam_group.rb
+++ b/lib/awspec/generator/doc/type/iam_group.rb
@@ -7,7 +7,7 @@ module Awspec::Generator
           @type_name = 'IamGroup'
           @type = Awspec::Type::IamGroup.new('my-iam-group')
           @ret = @type.resource_via_client
-          @matchers = %w(be_allowed_action)
+          @matchers = %w(be_allowed_action not_be_allowed_action)
           @ignore_matchers = []
           @describes = []
         end

--- a/lib/awspec/generator/doc/type/iam_role.rb
+++ b/lib/awspec/generator/doc/type/iam_role.rb
@@ -7,7 +7,7 @@ module Awspec::Generator
           @type_name = 'IamRole'
           @type = Awspec::Type::IamRole.new('my-iam-role')
           @ret = @type.resource_via_client
-          @matchers = %w(be_allowed_action)
+          @matchers = %w(be_allowed_action not_be_allowed_action)
           @ignore_matchers = []
           @describes = []
         end

--- a/lib/awspec/generator/doc/type/iam_user.rb
+++ b/lib/awspec/generator/doc/type/iam_user.rb
@@ -7,7 +7,7 @@ module Awspec::Generator
           @type_name = 'IamUser'
           @type = Awspec::Type::IamUser.new('my-iam-user')
           @ret = @type.resource_via_client
-          @matchers = %w(belong_to_iam_group be_allowed_action)
+          @matchers = %w(belong_to_iam_group be_allowed_action not_be_allowed_action)
           @ignore_matchers = []
           @describes = []
         end

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -22,6 +22,7 @@ require 'awspec/matcher/have_inline_policy'
 
 # IAM User/Group/Role
 require 'awspec/matcher/be_allowed_action'
+require 'awspec/matcher/not_be_allowed_action'
 
 # ElastiCache
 require 'awspec/matcher/belong_to_replication_group'

--- a/lib/awspec/matcher/not_be_allowed_action.rb
+++ b/lib/awspec/matcher/not_be_allowed_action.rb
@@ -1,0 +1,19 @@
+RSpec::Matchers.define :not_be_allowed_action do |action_name|
+  match do |type|
+    results = type.select_policy_evaluation_results(type.resource_via_client[:arn],
+                                                    action_name,
+                                                    @resource_arn,
+                                                    @context_entries)
+    results.find do |result|
+      result.eval_decision == 'explicitDeny' || result.eval_decision == 'implicitDeny'
+    end
+  end
+
+  chain :resource_arn do |arn|
+    @resource_arn = arn
+  end
+
+  chain :context_entries do |context|
+    @context_entries = context
+  end
+end

--- a/lib/awspec/stub/iam_group.rb
+++ b/lib/awspec/stub/iam_group.rb
@@ -81,7 +81,14 @@ Aws.config[:iam] = {
           eval_decision: 'allowed',
           matched_statements: [
           ]
-        }
+       },
+       {
+         eval_action_name: 'ec2:TerminateInstances',
+         eval_resource_name: '*',
+         eval_decision: 'denied',
+         matched_statements: [
+         ]
+       }
       ],
       is_truncated: false,
       marker: nil

--- a/lib/awspec/stub/iam_group.rb
+++ b/lib/awspec/stub/iam_group.rb
@@ -81,14 +81,14 @@ Aws.config[:iam] = {
           eval_decision: 'allowed',
           matched_statements: [
           ]
-       },
-       {
-         eval_action_name: 'ec2:TerminateInstances',
-         eval_resource_name: '*',
-         eval_decision: 'denied',
-         matched_statements: [
-         ]
-       }
+        },
+        {
+          eval_action_name: 'ec2:TerminateInstances',
+          eval_resource_name: '*',
+          eval_decision: 'denied',
+          matched_statements: [
+          ]
+        }
       ],
       is_truncated: false,
       marker: nil

--- a/lib/awspec/stub/iam_role.rb
+++ b/lib/awspec/stub/iam_role.rb
@@ -51,14 +51,14 @@ Aws.config[:iam] = {
           eval_decision: 'allowed',
           matched_statements: [
           ]
-       },
-       {
-         eval_action_name: 'ec2:TerminateInstances',
-         eval_resource_name: '*',
-         eval_decision: 'denied',
-         matched_statements: [
-         ]
-       }
+        },
+        {
+          eval_action_name: 'ec2:TerminateInstances',
+          eval_resource_name: '*',
+          eval_decision: 'denied',
+          matched_statements: [
+          ]
+        }
       ],
       is_truncated: false,
       marker: nil

--- a/lib/awspec/stub/iam_role.rb
+++ b/lib/awspec/stub/iam_role.rb
@@ -51,7 +51,14 @@ Aws.config[:iam] = {
           eval_decision: 'allowed',
           matched_statements: [
           ]
-        }
+       },
+       {
+         eval_action_name: 'ec2:TerminateInstances',
+         eval_resource_name: '*',
+         eval_decision: 'denied',
+         matched_statements: [
+         ]
+       }
       ],
       is_truncated: false,
       marker: nil

--- a/lib/awspec/stub/iam_user.rb
+++ b/lib/awspec/stub/iam_user.rb
@@ -62,7 +62,14 @@ Aws.config[:iam] = {
           eval_decision: 'allowed',
           matched_statements: [
           ]
-        }
+       },
+       {
+         eval_action_name: 'ec2:TerminateInstances',
+         eval_resource_name: '*',
+         eval_decision: 'denied',
+         matched_statements: [
+         ]
+       }
       ],
       is_truncated: false,
       marker: nil

--- a/lib/awspec/stub/iam_user.rb
+++ b/lib/awspec/stub/iam_user.rb
@@ -62,14 +62,14 @@ Aws.config[:iam] = {
           eval_decision: 'allowed',
           matched_statements: [
           ]
-       },
-       {
-         eval_action_name: 'ec2:TerminateInstances',
-         eval_resource_name: '*',
-         eval_decision: 'denied',
-         matched_statements: [
-         ]
-       }
+        },
+        {
+          eval_action_name: 'ec2:TerminateInstances',
+          eval_resource_name: '*',
+          eval_decision: 'denied',
+          matched_statements: [
+          ]
+        }
       ],
       is_truncated: false,
       marker: nil

--- a/spec/type/iam_group_spec.rb
+++ b/spec/type/iam_group_spec.rb
@@ -46,4 +46,5 @@ DOC
     its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }
     its('users.first.user_name') { should eq 'my-iam-user' }
   end
+  it { should_not be_allowed_action('ec2:TerminateInstances') }
 end

--- a/spec/type/iam_role_spec.rb
+++ b/spec/type/iam_role_spec.rb
@@ -26,6 +26,7 @@ describe iam_role('my-iam-role') do
 DOC
   end
   it { should be_allowed_action('ec2:DescribeInstances') }
+  it { should not_be_allowed_action('ec2:TerminateInstances') }
   it { should be_allowed_action('ec2:DescribeInstances').resource_arn('*') }
   it do
     should be_allowed_action('s3:ListBucket')

--- a/spec/type/iam_user_spec.rb
+++ b/spec/type/iam_user_spec.rb
@@ -27,6 +27,7 @@ describe iam_user('my-iam-user') do
 DOC
   end
   it { should be_allowed_action('ec2:DescribeInstances') }
+  it { should not_be_allowed_action('ec2:TerminateInstances') }
   it { should be_allowed_action('ec2:DescribeInstances').resource_arn('*') }
   it do
     should be_allowed_action('s3:ListBucket')


### PR DESCRIPTION
Instead of checking for actions that a role is allowed, I needed to check to ensure certain actions were denied for a role.  So I added a not_be_allowed_action matcher.  It's a very simple change, I used the code from the be_allowed_action and just changed the eval_decision to look for explicitDeny or implicitDeny.

I can write a test for this if you give me an action that should be denied in your AWS setup.

Thanks!
