### PR TITLE
Add vpn

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,10 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 30
 
+Metrics/ModuleLength:
+  CountComments: false 
+  Max: 200
+
 Metrics/PerceivedComplexity:
   Max: 15
 

--- a/doc/_resource_types/customer_gateway.md
+++ b/doc/_resource_types/customer_gateway.md
@@ -1,0 +1,25 @@
+### exist
+
+```ruby
+describe customer_gateway('my-customer-gateway') do
+  it { should exist }
+end
+```
+
+### be_pending, be_available, be_deleting, be_deleted
+
+```ruby
+describe customer_gateway('my-customer-gateway') do
+  it { should be_running }
+end
+```
+
+### have_tag
+
+```ruby
+describe customer_gateway('my-customer-gateway') do
+  it { should have_tag('Name').value('my-customer-gateway') }
+end
+```
+
+### its(:customer_gateway_id), its(:state), its(:type), its(:ip_address), its(:bgp_asn)

--- a/doc/_resource_types/vpn_connection.md
+++ b/doc/_resource_types/vpn_connection.md
@@ -1,0 +1,25 @@
+### exist
+
+```ruby
+describe vpn_connection('my-vpn-connection') do
+  it { should exist }
+end
+```
+
+### be_pending, be_available, be_deleting, be_deleted
+
+```ruby
+describe vpn_connection('my-vpn-connection') do
+  it { should be_running }
+end
+```
+
+### have_tag
+
+```ruby
+describe vpn_connection('my-vpn-connection') do
+  it { should have_tag('Name').value('my-vpn-connection') }
+end
+```
+
+### its(:vpn_connection_id), its(:state), its(:customer_gateway_configuration), its(:type), its(:customer_gateway_id), its(:vpn_gateway_id), its(:options)

--- a/doc/_resource_types/vpn_gateway.md
+++ b/doc/_resource_types/vpn_gateway.md
@@ -1,0 +1,25 @@
+### exist
+
+```ruby
+describe vpn_gateway('my-vpn-gateway') do
+  it { should exist }
+end
+```
+
+### be_pending, be_available, be_deleting, be_deleted
+
+```ruby
+describe vpn_gateway('my-vpn-gateway') do
+  it { should be_running }
+end
+```
+
+### have_tag
+
+```ruby
+describe vpn_gateway('my-vpn-gateway') do
+  it { should have_tag('Name').value('my-vpn-gateway') }
+end
+```
+
+### its(:vpn_gateway_id), its(:state), its(:type), its(:availability_zone)

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -35,6 +35,9 @@
 | [cloudfront_distribution](#cloudfront_distribution)
 | [elastictranscoder_pipeline](#elastictranscoder_pipeline)
 | [waf_web_acl](#waf_web_acl)
+| [customer_gateway](#customer_gateway)
+| [vpn_gateway](#vpn_gateway)
+| [vpn_connection](#vpn_connection)
 
 ## <a name="ami">ami</a>
 
@@ -1872,3 +1875,99 @@ end
 
 
 ### its(:default_action), its(:web_acl_id), its(:name), its(:metric_name)
+## <a name="customer_gateway">customer_gateway</a>
+
+CustomerGateway resource type.
+
+### exist
+
+```ruby
+describe customer_gateway('my-customer-gateway') do
+  it { should exist }
+end
+```
+
+
+### be_pending, be_available, be_deleting, be_deleted
+
+```ruby
+describe customer_gateway('my-customer-gateway') do
+  it { should be_running }
+end
+```
+
+
+### have_tag
+
+```ruby
+describe customer_gateway('my-customer-gateway') do
+  it { should have_tag('Name').value('my-customer-gateway') }
+end
+```
+
+
+### its(:customer_gateway_id), its(:state), its(:type), its(:ip_address), its(:bgp_asn)
+## <a name="vpn_gateway">vpn_gateway</a>
+
+VpnGateway resource type.
+
+### exist
+
+```ruby
+describe vpn_gateway('my-vpn-gateway') do
+  it { should exist }
+end
+```
+
+
+### be_pending, be_available, be_deleting, be_deleted
+
+```ruby
+describe vpn_gateway('my-vpn-gateway') do
+  it { should be_running }
+end
+```
+
+
+### have_tag
+
+```ruby
+describe vpn_gateway('my-vpn-gateway') do
+  it { should have_tag('Name').value('my-vpn-gateway') }
+end
+```
+
+
+### its(:vpn_gateway_id), its(:state), its(:type), its(:availability_zone)
+## <a name="vpn_connection">vpn_connection</a>
+
+VpnConnection resource type.
+
+### exist
+
+```ruby
+describe vpn_connection('my-vpn-connection') do
+  it { should exist }
+end
+```
+
+
+### be_pending, be_available, be_deleting, be_deleted
+
+```ruby
+describe vpn_connection('my-vpn-connection') do
+  it { should be_running }
+end
+```
+
+
+### have_tag
+
+```ruby
+describe vpn_connection('my-vpn-connection') do
+  it { should have_tag('Name').value('my-vpn-connection') }
+end
+```
+
+
+### its(:vpn_connection_id), its(:state), its(:customer_gateway_configuration), its(:type), its(:customer_gateway_id), its(:vpn_gateway_id), its(:options)

--- a/lib/awspec/generator/doc/type/customer_gateway.rb
+++ b/lib/awspec/generator/doc/type/customer_gateway.rb
@@ -1,0 +1,19 @@
+module Awspec::Generator
+  module Doc
+    module Type
+      class CustomerGateway < Base
+        def initialize
+          super
+          @type_name = 'CustomerGateway'
+          @type = Awspec::Type::CustomerGateway.new('my-customer-gateway')
+          @ret = @type.resource_via_client
+          @matchers = [
+            Awspec::Type::CustomerGateway::STATES.map { |state| 'be_' + state.tr('-', '_') }.join(', ')
+          ]
+          @ignore_matchers = Awspec::Type::CustomerGateway::STATES.map { |state| 'be_' + state.tr('-', '_') }
+          @describes = []
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/generator/doc/type/vpn_connection.rb
+++ b/lib/awspec/generator/doc/type/vpn_connection.rb
@@ -1,0 +1,19 @@
+module Awspec::Generator
+  module Doc
+    module Type
+      class VpnConnection < Base
+        def initialize
+          super
+          @type_name = 'VpnConnection'
+          @type = Awspec::Type::VpnConnection.new('my-vpn-connection')
+          @ret = @type.resource_via_client
+          @matchers = [
+            Awspec::Type::VpnConnection::STATES.map { |state| 'be_' + state.tr('-', '_') }.join(', ')
+          ]
+          @ignore_matchers = Awspec::Type::VpnConnection::STATES.map { |state| 'be_' + state.tr('-', '_') }
+          @describes = []
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/generator/doc/type/vpn_gateway.rb
+++ b/lib/awspec/generator/doc/type/vpn_gateway.rb
@@ -1,0 +1,19 @@
+module Awspec::Generator
+  module Doc
+    module Type
+      class VpnGateway < Base
+        def initialize
+          super
+          @type_name = 'VpnGateway'
+          @type = Awspec::Type::VpnGateway.new('my-vpn-gateway')
+          @ret = @type.resource_via_client
+          @matchers = [
+            Awspec::Type::VpnGateway::STATES.map { |state| 'be_' + state.tr('-', '_') }.join(', ')
+          ]
+          @ignore_matchers = Awspec::Type::VpnGateway::STATES.map { |state| 'be_' + state.tr('-', '_') }
+          @describes = []
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/helper/finder/ec2.rb
+++ b/lib/awspec/helper/finder/ec2.rb
@@ -51,8 +51,8 @@ module Awspec::Helper
 
       def find_vpn_connection(vpn_connection_id)
         res = ec2_client.describe_vpn_connections({
-                                                 filters: [{ name: 'vpn-connection-id', values: [vpn_connection_id] }]
-                                               })
+                                                    filters: [{ name: 'vpn-connection-id', values: [vpn_connection_id] }]
+                                                  })
         res.vpn_connections.single_resource(vpn_connection_id)
       end
 

--- a/lib/awspec/helper/finder/ec2.rb
+++ b/lib/awspec/helper/finder/ec2.rb
@@ -51,7 +51,12 @@ module Awspec::Helper
 
       def find_vpn_connection(vpn_connection_id)
         res = ec2_client.describe_vpn_connections({
-                                                    filters: [{ name: 'vpn-connection-id', values: [vpn_connection_id] }]
+                                                    filters: [
+                                                      {
+                                                        name: 'vpn-connection-id',
+                                                        values: [vpn_connection_id]
+                                                      }
+                                                    ]
                                                   })
         res.vpn_connections.single_resource(vpn_connection_id)
       end

--- a/lib/awspec/helper/finder/ec2.rb
+++ b/lib/awspec/helper/finder/ec2.rb
@@ -49,6 +49,13 @@ module Awspec::Helper
         end
       end
 
+      def find_vpn_connection(vpn_connection_id)
+        res = ec2_client.describe_vpn_connections({
+                                                 filters: [{ name: 'vpn-connection-id', values: [vpn_connection_id] }]
+                                               })
+        res.vpn_connections.single_resource(vpn_connection_id)
+      end
+
       def find_nat_gateway(gateway_id)
         res = ec2_client.describe_nat_gateways({
                                                  filter: [{ name: 'nat-gateway-id', values: [gateway_id] }]

--- a/lib/awspec/helper/type.rb
+++ b/lib/awspec/helper/type.rb
@@ -9,7 +9,7 @@ module Awspec
         iam_policy iam_role iam_user kms lambda launch_configuration nat_gateway
         network_acl network_interface rds rds_db_cluster_parameter_group rds_db_parameter_group route53_hosted_zone
         route_table s3_bucket security_group ses_identity subnet vpc cloudfront_distribution
-        elastictranscoder_pipeline waf_web_acl
+        elastictranscoder_pipeline waf_web_acl customer_gateway vpn_gateway vpn_connection
       )
 
       TYPES.each do |type|

--- a/lib/awspec/stub/customer_gateway.rb
+++ b/lib/awspec/stub/customer_gateway.rb
@@ -1,0 +1,16 @@
+# rubocop:disable all
+Aws.config[:ec2] = {
+  stub_responses: {
+    describe_customer_gateways: {
+      customer_gateways: [
+        {
+          customer_gateway_id: 'cgw-cg5692g4',
+          ip_address: '1.1.1.1',
+          state: 'available',
+          type: "ipsec.1",
+          bgp_asn: "65000"
+        }
+      ]
+    }
+  }
+}

--- a/lib/awspec/stub/vpn_connection.rb
+++ b/lib/awspec/stub/vpn_connection.rb
@@ -1,0 +1,16 @@
+# rubocop:disable all
+Aws.config[:ec2] = {
+  stub_responses: {
+    describe_vpn_connections: {
+      vpn_connections: [
+        {
+          vpn_connection_id: 'vpn-cg5692g4',
+          customer_gateway_id: 'cgw-cg5692g4',
+          vpn_gateway_id: 'vgw-cg5692g4',
+          state: 'available',
+          type: "ipsec.1"
+        }
+      ]
+    }
+  }
+}

--- a/lib/awspec/stub/vpn_gateway.rb
+++ b/lib/awspec/stub/vpn_gateway.rb
@@ -1,0 +1,15 @@
+# rubocop:disable all
+Aws.config[:ec2] = {
+  stub_responses: {
+    describe_vpn_gateways: {
+      vpn_gateways: [
+        {
+          vpn_gateway_id: 'vgw-cg5692g4',
+          availability_zone: 'us-east-1a',
+          state: 'available',
+          type: "ipsec.1"
+        }
+      ]
+    }
+  }
+}

--- a/lib/awspec/type/customer_gateway.rb
+++ b/lib/awspec/type/customer_gateway.rb
@@ -1,0 +1,40 @@
+module Awspec::Type
+  class CustomerGateway < Base
+    tags_allowed
+
+    def initialize(name)
+      super
+      @display_name = name
+    end
+
+    def resource_via_client
+      @resource_via_client ||= find_customer_gateway(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.customer_gateway_id if resource_via_client
+    end
+
+    STATES = %w(
+      pending available deleting deleted
+    )
+
+    STATES.each do |state|
+      define_method state.tr('-', '_') + '?' do
+        resource_via_client.state == state
+      end
+    end
+
+    def ip_address
+      resource_via_client.ip_address
+    end
+
+    def bpg_asn
+      resource_via_client.bpg_asn
+    end
+
+    def type
+      resource_via_client.type
+    end
+  end
+end

--- a/lib/awspec/type/vpn_connection.rb
+++ b/lib/awspec/type/vpn_connection.rb
@@ -1,0 +1,40 @@
+module Awspec::Type
+  class VpnConnection < Base
+    tags_allowed
+
+    def initialize(name)
+      super
+      @display_name = name
+    end
+
+    def resource_via_client
+      @resource_via_client ||= find_vpn_connection(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.vpn_connection_id if resource_via_client
+    end
+
+    STATES = %w(
+      pending available deleting deleted
+    )
+
+    STATES.each do |state|
+      define_method state.tr('-', '_') + '?' do
+        resource_via_client.state == state
+      end
+    end
+
+    def customer_gateway_id
+      resource_via_client.customer_gateway_id
+    end
+
+    def vpn_gateway_id
+      resource_via_client.vpn_gateway_id
+    end
+
+    def type
+      resource_via_client.type
+    end
+  end
+end

--- a/lib/awspec/type/vpn_gateway.rb
+++ b/lib/awspec/type/vpn_gateway.rb
@@ -1,0 +1,40 @@
+module Awspec::Type
+  class VpnGateway < Base
+    tags_allowed
+
+    def initialize(name)
+      super
+      @display_name = name
+    end
+
+    def resource_via_client
+      @resource_via_client ||= find_vpn_gateway(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.vpn_gateway_id if resource_via_client
+    end
+
+    STATES = %w(
+      pending available deleting deleted
+    )
+
+    STATES.each do |state|
+      define_method state.tr('-', '_') + '?' do
+        resource_via_client.state == state
+      end
+    end
+
+    def availability_zone
+      resource_via_client.availability_zone
+    end
+
+    def vpc_attachments
+      resource_via_client.vpc_attachments
+    end
+
+    def type
+      resource_via_client.type
+    end
+  end
+end

--- a/lib/awspec/version.rb
+++ b/lib/awspec/version.rb
@@ -1,3 +1,3 @@
 module Awspec
-  VERSION = '0.55.0'
+  VERSION = '0.56.0'
 end

--- a/lib/awspec/version.rb
+++ b/lib/awspec/version.rb
@@ -1,3 +1,3 @@
 module Awspec
-  VERSION = '0.56.0'
+  VERSION = '0.56.1'
 end

--- a/lib/awspec/version.rb
+++ b/lib/awspec/version.rb
@@ -1,3 +1,3 @@
 module Awspec
-  VERSION = '0.54.0'
+  VERSION = '0.55.0'
 end

--- a/spec/type/customer_gateway_spec.rb
+++ b/spec/type/customer_gateway_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+Awspec::Stub.load 'customer_gateway'
+
+describe customer_gateway('cgw-cg5692g4') do
+  it { should exist }
+  it { should be_available }
+  its(:ip_address) { should eq '1.1.1.1' }
+  its(:type) { should eq 'ipsec.1' }
+  its(:bgp_asn) { should eq '65000' }
+end

--- a/spec/type/vpn_connection_spec.rb
+++ b/spec/type/vpn_connection_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+Awspec::Stub.load 'vpn_connection'
+
+describe vpn_connection('vpn-cg5692g4') do
+  it { should exist }
+  it { should be_available }
+  its(:vpn_gateway_id) { should eq 'vgw-cg5692g4' }
+  its(:customer_gateway_id) { should eq 'cgw-cg5692g4' }
+  its(:type) { should eq 'ipsec.1' }
+end

--- a/spec/type/vpn_gateway_spec.rb
+++ b/spec/type/vpn_gateway_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+Awspec::Stub.load 'vpn_gateway'
+
+describe vpn_gateway('vgw-cg5692g4') do
+  it { should exist }
+  it { should be_available }
+  its(:availability_zone) { should eq 'us-east-1a' }
+  its(:type) { should eq 'ipsec.1' }
+end


### PR DESCRIPTION
Add the following resource types:

customer_gateway
vpn_gateway
vpn_connection

All of these use the existing Ec2Client.  customer_gateway and vpn_gateway use existing finder methods in the ec2 finder while a new method was added for find_vpn_connection.  The tests are simple for now and just include the basic attributes.

TODO:
- Add spec generators for all new resource types

vpn_gateway:
- Search for VPC attachments (vpc_id method perhaps?)

vpn_connection:
- customer_gateway_configuration check (returns xml)
- ability to check options
- ability to check vpn routes
- ability to check vgw telemetry 