### PR TITLE
Fix for issue 201. Raises exception on duplicate instances.

### DIFF
--- a/lib/awspec/helper/finder/ec2.rb
+++ b/lib/awspec/helper/finder/ec2.rb
@@ -15,7 +15,13 @@ module Awspec::Helper
                                               })
         end
         # rubocop:enable Style/GuardClause
-        res.reservations.first.instances.single_resource(id) if res.reservations.count == 1
+        if res.reservations.count == 1
+          res.reservations.first.instances.single_resource(id)
+        elsif res.reservations.count > 1
+          raise Awspec::DuplicatedResourceTypeError, "Duplicate instances matching id or tag #{id}"
+        else
+          nil
+        end
       end
 
       def find_ec2_attribute(id, attribute)

--- a/lib/awspec/helper/finder/ec2.rb
+++ b/lib/awspec/helper/finder/ec2.rb
@@ -19,8 +19,6 @@ module Awspec::Helper
           res.reservations.first.instances.single_resource(id)
         elsif res.reservations.count > 1
           raise Awspec::DuplicatedResourceTypeError, "Duplicate instances matching id or tag #{id}"
-        else
-          nil
         end
       end
 


### PR DESCRIPTION
This isn't a complete fix:
- If the id or Name label doesn't exist, this still returns a nil (and so throws the stack trace). Should this raise a new exception type instead?
- I haven't added a test to validate this change. I tried, but my rspec skills are too weak.
