### PR TITLE
Remove deprecated methods.

### DIFF
--- a/spec/type/autoscaling_group_spec.rb
+++ b/spec/type/autoscaling_group_spec.rb
@@ -14,8 +14,7 @@ describe autoscaling_group('my-auto-scaling-group') do
   it { should have_tag('name').value('my-autoscaling-group') }
 end
 
-# deprecated
-describe auto_scaling_group('my-auto-scaling-group') do
+describe autoscaling_group('my-auto-scaling-group') do
   it { should exist }
   its(:desired_capacity) { should eq 4 }
   its(:min_size) { should eq 4 }

--- a/spec/type/route_table_spec.rb
+++ b/spec/type/route_table_spec.rb
@@ -21,8 +21,7 @@ describe route_table('my-route-table') do
   it { should have_tag('Name').value('my-route-table') }
 end
 
-# deprecated
 describe route_table('my-route-table') do
-  it { should have_route('local').destination('10.0.0.0/16') }
-  it { should have_route('my-igw').destination('0.0.0.0/0') }
+  it { should have_route('10.0.0.0/16').target(gateway: 'local') }
+  it { should have_route('0.0.0.0/0').target(gateway: 'my-igw') }
 end

--- a/spec/type/s3_bucket_spec.rb
+++ b/spec/type/s3_bucket_spec.rb
@@ -70,8 +70,7 @@ describe s3_bucket('my-bucket') do
   end
 end
 
-# deprecated
-describe s3('my-bucket') do
+describe s3_bucket('my-bucket') do
   it { should exist }
   it { should have_object('path/to/object') }
   its(:acl_grants_count) { should eq 3 }


### PR DESCRIPTION
This removes all warnings when executing running the tests.