### PR TITLE
Support for testing security group settings with targets in other accounts

### DIFF
--- a/lib/awspec/stub/security_group.rb
+++ b/lib/awspec/stub/security_group.rb
@@ -110,6 +110,22 @@ Aws.config[:ec2] = {
                   cidr_ip: '100.456.789.012/32'
                 }
               ]
+            },
+            {
+              from_port: 8080,
+              to_port: 8080,
+              ip_protocol: 'tcp',
+              ip_ranges: [],
+              user_id_group_pairs: [
+                {
+                  user_id: '5678901234',
+                  group_name: 'group-in-other-aws-account-with-vpc-peering',
+                  group_id: 'sg-9a8b7c6d',
+                  vpc_id: 'vpc-5b6a7c8f',
+                  vpc_peering_connection_id: 'pcx-f9e8d7c6',
+                  peering_status: 'active'
+                }
+              ]
             }
           ]
         }

--- a/lib/awspec/stub/security_group.rb
+++ b/lib/awspec/stub/security_group.rb
@@ -4,6 +4,7 @@ Aws.config[:ec2] = {
       security_groups: [
         {
           vpc_id: 'vpc-ab123cde',
+          owner_id: '112233445566',
           group_id: 'sg-1a2b3cd4',
           group_name: 'my-security-group-name',
           tags: [

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -98,7 +98,7 @@ module Awspec::Type
       ret = permission.user_id_group_pairs.select do |sg|
         # Compare the sg group_name if the remote group is in another account.
         # find_security_group call doesn't return info on a remote security group.
-        if (sg.user_id != nil) && (sg.user_id != resource_via_client.owner_id)
+        if !sg.user_id.nil? && (sg.user_id != resource_via_client.owner_id)
           next (sg.group_name == cidr) || (sg.group_id == cidr)
         end
         next true if sg.group_id == cidr

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -96,6 +96,9 @@ module Awspec::Type
       end
       return true if ret.count > 0
       ret = permission.user_id_group_pairs.select do |sg|
+        # Compare the sg group_name if the remote group is in another account.
+        # find_security_group call doesn't return info on a remote security group.
+        next true if (sg.user_id != resource_via_client.owner_id) && (sg.group_name == cidr)
         next true if sg.group_id == cidr
         sg2 = find_security_group(sg.group_id)
         next true if sg2.group_name == cidr

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -98,7 +98,9 @@ module Awspec::Type
       ret = permission.user_id_group_pairs.select do |sg|
         # Compare the sg group_name if the remote group is in another account.
         # find_security_group call doesn't return info on a remote security group.
-        next true if (sg.user_id != resource_via_client.owner_id) && (sg.group_name == cidr)
+        if (sg.user_id != nil) && (sg.user_id != resource_via_client.owner_id)
+          next (sg.group_name == cidr) || (sg.group_id == cidr)
+        end
         next true if sg.group_id == cidr
         sg2 = find_security_group(sg.group_id)
         next true if sg2.group_name == cidr

--- a/spec/generator/spec/security_group_spec.rb
+++ b/spec/generator/spec/security_group_spec.rb
@@ -20,10 +20,11 @@ describe security_group('my-security-group-name') do
   its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.456.789.012/32') }
   its(:inbound) { should be_opened.protocol('all').for('sg-3a4b5cd6') }
   its(:outbound) { should be_opened(50000).protocol('tcp').for('100.456.789.012/32') }
+  its(:outbound) { should be_opened(8080).protocol('tcp').for('group-in-other-aws-account-with-vpc-peering') }
   its(:inbound_rule_count) { should eq 8 }
-  its(:outbound_rule_count) { should eq 1 }
+  its(:outbound_rule_count) { should eq 2 }
   its(:inbound_permissions_count) { should eq 7 }
-  its(:outbound_permissions_count) { should eq 1 }
+  its(:outbound_permissions_count) { should eq 2 }
   it { should belong_to_vpc('my-vpc') }
 end
 EOF

--- a/spec/type/security_group_spec.rb
+++ b/spec/type/security_group_spec.rb
@@ -11,16 +11,18 @@ describe security_group('sg-1a2b3cd4') do
   its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.456.789.012/32') }
   its(:inbound) { should_not be_opened('50010-50019').protocol('tcp').for('123.456.789.012/32') }
   its(:outbound) { should be_opened(50_000) }
+  its(:outbound) { should be_opened(8080).protocol('tcp').for('sg-9a8b7c6d') }
+  its(:outbound) { should be_opened(8080).protocol('tcp').for('group-in-other-aws-account-with-vpc-peering') }
   its(:inbound) { should be_opened_only(60_000).protocol('tcp').for('100.456.789.012/32') }
   its(:inbound) { should be_opened_only(70_000).protocol('tcp').for(['100.456.789.012/32', '101.456.789.012/32']) }
   its(:outbound) { should be_opened_only(50_000).protocol('tcp').for('100.456.789.012/32') }
   its(:inbound) { should be_opened.protocol('all').for('sg-3a4b5cd6') }
   its(:inbound_permissions_count) { should eq 7 }
   its(:ip_permissions_count) { should eq 7 }
-  its(:outbound_permissions_count) { should eq 1 }
-  its(:ip_permissions_egress_count) { should eq 1 }
+  its(:outbound_permissions_count) { should eq 2 }
+  its(:ip_permissions_egress_count) { should eq 2 }
   its(:inbound_rule_count) { should eq 8 }
-  its(:outbound_rule_count) { should eq 1 }
+  its(:outbound_rule_count) { should eq 2 }
 
   # its(:inbound) { should be_opened(22).protocol('tcp').for('group-name-sg') }
   # its(:inbound) { should be_opened(22).protocol('tcp').for('my-db-sg') }


### PR DESCRIPTION
Security group rules can be created pointing to other security groups as their target. So far so good. But when these security groups are actually in another AWS account and linked using VPC peering, a call to `find_security_group` will not return a result and your test will fail.

The given code changes adds support for this case.

Includes a test to cover the changes.