### PR TITLE
Fix bug throwing error when iterating over EFS tags

### DIFF
--- a/lib/awspec/helper/finder/efs.rb
+++ b/lib/awspec/helper/finder/efs.rb
@@ -7,6 +7,7 @@ module Awspec::Helper
                                                    file_system_id: id,
                                                    max_items: 1
                                                  })
+          test = 1
         rescue
           # Aws::EFS::Errors::BadRequest (invalid file system ID: my-efs)
           file_system_id = get_id_by_name_tag(id)
@@ -39,8 +40,9 @@ module Awspec::Helper
           tag_query = efs_client.describe_tags({
                                                  file_system_id: fs.file_system_id
                                                })
-          name_tag = tag_query.find { |tag| tag.key == 'Name' }
-          return fs.file_system_id if name_tag.value == name
+          name_tag = nil
+          name_tag = tag_query.tags.find { |tag| tag.key == 'Name' } if tag_query.tags
+          return fs.file_system_id if name_tag && name_tag.value == name
         end
       end
 

--- a/lib/awspec/helper/finder/efs.rb
+++ b/lib/awspec/helper/finder/efs.rb
@@ -7,7 +7,6 @@ module Awspec::Helper
                                                    file_system_id: id,
                                                    max_items: 1
                                                  })
-          test = 1
         rescue
           # Aws::EFS::Errors::BadRequest (invalid file system ID: my-efs)
           file_system_id = get_id_by_name_tag(id)


### PR DESCRIPTION
When creating an AWS EFS resource with Terraform like so:
```
resource "aws_efs_file_system" "efs_storage" {
  creation_token = "development-efs-storage"
  performance_mode = "generalPurpose"

  tags {
    Environment = "development"
    Name = "development-efs-storage"
  }
}
```

And with a spec file like the following:
```
describe efs('development-efs-storage') do
  it { should exist }
end
```

The following error occurs:
```
1) efs 'development-efs-storage' creation_token
     Failure/Error: it { should exist }

     NoMethodError:
       undefined method `each' for #<Aws::EFS::Types::DescribeTagsResponse:0x007fe715209640>
     # ./spec/efs_spec.rb:4:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Aws::EFS::Errors::BadRequest:
     #   invalid file system ID: development-efs-storage
     #   ./spec/efs_spec.rb:4:in `block (2 levels) in <top (required)>
```

This should fix the error by making sure the tags returned by `Aws::EFS::Types::DescribeTagsResponse` are being iterated over.

This affects the latest version of the gem.