### PR TITLE
Change ecs_contaier_instance API

### DIFF
--- a/doc/_resource_types/ecs_container_instance.md
+++ b/doc/_resource_types/ecs_container_instance.md
@@ -1,0 +1,18 @@
+### exist
+
+ecs_container_instance need `cluster_name` ( default: `default` ).
+
+```ruby
+describe ecs_container_instance('my-container-instance'), cluster_name: 'my-ecs-cluster' do
+  it { should exist }
+end
+```
+
+### be_active, be_inactive
+
+```ruby
+describe ecs_container_instance('my-container-instance'), cluster_name: 'my-ecs-cluster' do
+  it { should be_active }
+end
+```
+

--- a/doc/_resource_types/ecs_container_instance.md
+++ b/doc/_resource_types/ecs_container_instance.md
@@ -1,9 +1,9 @@
 ### exist
 
-ecs_container_instance need `cluster_name` ( default: `default` ).
+You can set `cluster` ( default: `default` ).
 
 ```ruby
-describe ecs_container_instance('my-container-instance'), cluster_name: 'my-ecs-cluster' do
+describe ecs_container_instance('my-container-instance'), cluster: 'my-ecs-cluster' do
   it { should exist }
 end
 ```
@@ -11,7 +11,7 @@ end
 ### be_active, be_inactive
 
 ```ruby
-describe ecs_container_instance('my-container-instance'), cluster_name: 'my-ecs-cluster' do
+describe ecs_container_instance('my-container-instance'), cluster: 'my-ecs-cluster' do
   it { should be_active }
 end
 ```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -507,17 +507,15 @@ end
 ```
 
 ### its(:cluster_arn), its(:cluster_name), its(:status), its(:registered_container_instances_count), its(:running_tasks_count), its(:pending_tasks_count), its(:active_services_count)
-## <a name="ecs_container_instance">ecs_container_instance</a>
+## <a name="ecs container instance">ecs container instance</a>
 
-EcsContainerInstance resource type.
+ECS Container Instance resource type.
 
 ### exist
 
-### be_active
+### be_active, be_inactive
 
-### be_inactive
-
-
+### its(:container_instance_arn), its(:ec2_instance_id), its(:version), its(:version_info), its(:status), its(:agent_connected), its(:running_tasks_count), its(:pending_tasks_count), its(:agent_update_status), its(:attributes)
 ## <a name="ecs service">ecs service</a>
 
 ECS Service resource type.

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -513,7 +513,23 @@ ECS Container Instance resource type.
 
 ### exist
 
+ecs_container_instance need `cluster_name` ( default: `default` ).
+
+```ruby
+describe ecs_container_instance('my-container-instance'), cluster_name: 'my-ecs-cluster' do
+  it { should exist }
+end
+```
+
+
 ### be_active, be_inactive
+
+```ruby
+describe ecs_container_instance('my-container-instance'), cluster_name: 'my-ecs-cluster' do
+  it { should be_active }
+end
+```
+
 
 ### its(:container_instance_arn), its(:ec2_instance_id), its(:version), its(:version_info), its(:status), its(:agent_connected), its(:running_tasks_count), its(:pending_tasks_count), its(:agent_update_status), its(:attributes)
 ## <a name="ecs service">ecs service</a>

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -513,10 +513,10 @@ ECS Container Instance resource type.
 
 ### exist
 
-ecs_container_instance need `cluster_name` ( default: `default` ).
+You can set `cluster` ( default: `default` ).
 
 ```ruby
-describe ecs_container_instance('my-container-instance'), cluster_name: 'my-ecs-cluster' do
+describe ecs_container_instance('my-container-instance'), cluster: 'my-ecs-cluster' do
   it { should exist }
 end
 ```
@@ -525,7 +525,7 @@ end
 ### be_active, be_inactive
 
 ```ruby
-describe ecs_container_instance('my-container-instance'), cluster_name: 'my-ecs-cluster' do
+describe ecs_container_instance('my-container-instance'), cluster: 'my-ecs-cluster' do
   it { should be_active }
 end
 ```

--- a/lib/awspec/generator/doc/type/ecs_container_instance.rb
+++ b/lib/awspec/generator/doc/type/ecs_container_instance.rb
@@ -4,9 +4,13 @@ module Awspec::Generator
       class EcsContainerInstance < Base
         def initialize
           super
+          @type_name = 'ECS Container Instance'
           @type = Awspec::Type::EcsContainerInstance.new('my-ecs-container-instance')
-          @matchers = []
-          @ignore_matchers = []
+          @ret = @type.resource_via_client
+          @matchers = [
+            Awspec::Type::EcsContainerInstance::STATES.map { |state| 'be_' + state.downcase }.join(', ')
+          ]
+          @ignore_matchers = Awspec::Type::EcsContainerInstance::STATES.map { |state| 'be_' + state.downcase }
           @describes = []
         end
       end

--- a/lib/awspec/helper/finder/ecs.rb
+++ b/lib/awspec/helper/finder/ecs.rb
@@ -1,14 +1,14 @@
 module Awspec::Helper
   module Finder
     module Ecs
-      def find_ecs_cluster(cluster_name)
-        res = ecs_client.describe_clusters(clusters: [cluster_name])
-        res.clusters.single_resource(cluster_name)
+      def find_ecs_cluster(cluster)
+        res = ecs_client.describe_clusters(clusters: [cluster])
+        res.clusters.single_resource(cluster)
       end
 
-      def find_ecs_container_instance(cluster_name, uuid)
-        res = ecs_client.describe_container_instances(cluster: cluster_name, container_instances: [uuid])
-        res.container_instances.single_resource(uuid)
+      def find_ecs_container_instance(cluster, arn_or_uuid)
+        res = ecs_client.describe_container_instances(cluster: cluster, container_instances: [arn_or_uuid])
+        res.container_instances.single_resource(arn_or_uuid)
       end
 
       def find_ecs_task_definition(taskdef)
@@ -21,8 +21,8 @@ module Awspec::Helper
         res.services.single_resource(service)
       end
 
-      def select_ecs_container_instance_arn_by_cluster_name(cluster_name)
-        req = { cluster: cluster_name }
+      def select_ecs_container_instance_arn_by_cluster_name(cluster)
+        req = { cluster: cluster }
         arns = []
         loop do
           res = ecs_client.list_container_instances(req)
@@ -34,8 +34,8 @@ module Awspec::Helper
       end
 
       # deprecated method
-      def find_ecs_container_instances(cluster_name, container_instances)
-        res = ecs_client.describe_container_instances(cluster: cluster_name, container_instances: container_instances)
+      def find_ecs_container_instances(cluster, container_instances)
+        res = ecs_client.describe_container_instances(cluster: cluster, container_instances: container_instances)
         res.container_instances if res.container_instances
       end
 

--- a/lib/awspec/shared_context.rb
+++ b/lib/awspec/shared_context.rb
@@ -10,12 +10,8 @@ shared_context 'region', :region do
   end
 end
 
-shared_context 'cluster_name', :cluster_name do
+shared_context 'cluster', :cluster do
   before do |example|
-    cluster_name = example.metadata[:cluster_name]
-    example.metadata[:described_class].cluster_name = cluster_name
-  end
-
-  after do
+    example.metadata[:described_class].cluster = example.metadata[:cluster]
   end
 end

--- a/lib/awspec/shared_context.rb
+++ b/lib/awspec/shared_context.rb
@@ -1,5 +1,3 @@
-require 'pp'
-
 shared_context 'region', :region do
   before do |example|
     region = example.metadata[:region]

--- a/lib/awspec/shared_context.rb
+++ b/lib/awspec/shared_context.rb
@@ -1,3 +1,5 @@
+require 'pp'
+
 shared_context 'region', :region do
   before do |example|
     region = example.metadata[:region]
@@ -7,5 +9,15 @@ shared_context 'region', :region do
 
   after do
     Aws.config[:region] = @_region
+  end
+end
+
+shared_context 'cluster_name', :cluster_name do
+  before do |example|
+    cluster_name = example.metadata[:cluster_name]
+    example.metadata[:described_class].cluster_name = cluster_name
+  end
+
+  after do
   end
 end

--- a/lib/awspec/type/ecs_container_instance.rb
+++ b/lib/awspec/type/ecs_container_instance.rb
@@ -1,7 +1,5 @@
 module Awspec::Type
   class EcsContainerInstance < Base
-    aws_resource Aws::ECS::Types::ContainerInstance
-
     attr_accessor :cluster_name
 
     def initialize(container_instance)
@@ -10,7 +8,7 @@ module Awspec::Type
     end
 
     def resource_via_client
-      @resource_via_client ||= find_ecs_container_instances(@cluster_name, [@display_name]).first
+      @resource_via_client ||= find_ecs_container_instance(cluster_name, @display_name)
     end
 
     def id
@@ -21,12 +19,12 @@ module Awspec::Type
       @cluster_name || 'default'
     end
 
-    def active?
-      resource_via_client.status == 'ACTIVE'
-    end
+    STATES = %w(ACTIVE INACTIVE)
 
-    def inactive?
-      resource_via_client.status == 'INACTIVE'
+    STATES.each do |state|
+      define_method state.downcase + '?' do
+        resource_via_client.status == state
+      end
     end
   end
 end

--- a/lib/awspec/type/ecs_container_instance.rb
+++ b/lib/awspec/type/ecs_container_instance.rb
@@ -1,6 +1,6 @@
 module Awspec::Type
   class EcsContainerInstance < Base
-    attr_accessor :cluster_name
+    attr_accessor :cluster
 
     def initialize(container_instance)
       super
@@ -8,15 +8,15 @@ module Awspec::Type
     end
 
     def resource_via_client
-      @resource_via_client ||= find_ecs_container_instance(cluster_name, @display_name)
+      @resource_via_client ||= find_ecs_container_instance(cluster, @display_name)
     end
 
     def id
       @id ||= resource_via_client.container_instance_arn if resource_via_client
     end
 
-    def cluster_name
-      @cluster_name || 'default'
+    def cluster
+      @cluster || 'default'
     end
 
     STATES = %w(ACTIVE INACTIVE)

--- a/spec/type/ecs_container_instance_spec.rb
+++ b/spec/type/ecs_container_instance_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 Awspec::Stub.load 'ecs_container_instance'
 
-describe ecs_container_instance('my-container-instance') do
+describe ecs_container_instance('my-container-instance'), cluster_name: 'my-ecs-cluster' do
   it { should exist }
   it { should be_active }
   it { should_not be_inactive }
-  its(:status) { should eq 'ACTIVE' }
+  its(:cluster_name) { should eq 'my-ecs-cluster' }
   its(:container_instance_arn) do
     should eq 'arn:aws:ecs:us-east-1:123456789012:container-instance'\
               '/f2756532-8f13-4d53-87c9-aed50dc94cd7'

--- a/spec/type/ecs_container_instance_spec.rb
+++ b/spec/type/ecs_container_instance_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
-
 Awspec::Stub.load 'ecs_container_instance'
 
-describe ecs_container_instance('my-container-instance'), cluster_name: 'my-ecs-cluster' do
+describe ecs_container_instance('my-container-instance'), cluster: 'my-ecs-cluster' do
   it { should exist }
   it { should be_active }
   it { should_not be_inactive }
-  its(:cluster_name) { should eq 'my-ecs-cluster' }
+  its(:cluster) { should eq 'my-ecs-cluster' }
   its(:container_instance_arn) do
     should eq 'arn:aws:ecs:us-east-1:123456789012:container-instance'\
               '/f2756532-8f13-4d53-87c9-aed50dc94cd7'
@@ -15,10 +14,10 @@ end
 
 describe 'ESC Cluster `my-ecs-cluster`' do
   before do |example|
-    example.metadata[:described_class].cluster_name = 'my-ecs-cluster'
+    example.metadata[:described_class].cluster = 'my-ecs-cluster'
   end
   describe ecs_container_instance('my-container-instance') do
     it { should exist }
-    its(:cluster_name) { should eq 'my-ecs-cluster' }
+    its(:cluster) { should eq 'my-ecs-cluster' }
   end
 end

--- a/spec/type/ecs_container_instance_spec.rb
+++ b/spec/type/ecs_container_instance_spec.rb
@@ -12,3 +12,13 @@ describe ecs_container_instance('my-container-instance'), cluster_name: 'my-ecs-
               '/f2756532-8f13-4d53-87c9-aed50dc94cd7'
   end
 end
+
+describe 'ESC Cluster `my-ecs-cluster`' do
+  before do |example|
+    example.metadata[:described_class].cluster_name = 'my-ecs-cluster'
+  end
+  describe ecs_container_instance('my-container-instance') do
+    it { should exist }
+    its(:cluster_name) { should eq 'my-ecs-cluster' }
+  end
+end


### PR DESCRIPTION
link #228

ecs_container_instance need `cluster` ( default: `default` ).

```ruby
describe ecs_container_instance('my-container-instance'), cluster: 'my-ecs-cluster' do
  it { should exist }
end
```

or

```ruby
describe 'ESC Cluster `my-ecs-cluster`' do
  before do |example|
    example.metadata[:described_class].cluster = 'my-ecs-cluster'
  end
  describe ecs_container_instance('my-container-instance') do
    it { should exist }
    its(:cluster) { should eq 'my-ecs-cluster' }
  end
end
```