### PR TITLE
Added `have_network_interface()` support for ec2

### DIFF
--- a/doc/_resource_types/ec2.md
+++ b/doc/_resource_types/ec2.md
@@ -72,6 +72,15 @@ describe ec2('my-ec2') do
 end
 ```
 
+### have_network_interface
+
+```ruby
+describe ec2('my-ec2') do
+  it { should have_network_interface('my-eni') }
+  it { should have_network_interface('eni-12ab3cde') }
+end
+```
+
 ### have_security_group
 
 ```ruby

--- a/doc/_resource_types/ec2.md
+++ b/doc/_resource_types/ec2.md
@@ -78,6 +78,7 @@ end
 describe ec2('my-ec2') do
   it { should have_network_interface('my-eni') }
   it { should have_network_interface('eni-12ab3cde') }
+  it { should have_network_interface('my-eni').as_eth0 }
 end
 ```
 

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -417,6 +417,7 @@ end
 describe ec2('my-ec2') do
   it { should have_network_interface('my-eni') }
   it { should have_network_interface('eni-12ab3cde') }
+  it { should have_network_interface('my-eni').as_eth0 }
 end
 ```
 

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -411,6 +411,16 @@ end
 ```
 
 
+### have_network_interface
+
+```ruby
+describe ec2('my-ec2') do
+  it { should have_network_interface('my-eni') }
+  it { should have_network_interface('eni-12ab3cde') }
+end
+```
+
+
 ### have_security_group
 
 ```ruby

--- a/lib/awspec/generator/spec/ec2.rb
+++ b/lib/awspec/generator/spec/ec2.rb
@@ -18,6 +18,7 @@ module Awspec::Generator
           subnet = find_subnet(instance.subnet_id)
           eips = select_eip_by_instance_id(instance_id)
           volumes = select_ebs_by_instance_id(instance_id)
+          network_interfaces = select_network_interface_by_instance_id(instance_id)
           content = ERB.new(ec2_spec_template, nil, '-').result(binding).gsub(/^\n/, '')
         end
         specs.join("\n")
@@ -64,6 +65,9 @@ describe ec2('<%= instance_id %>') do
 <%- else -%>
   it { should have_ebs('<%= volume.volume_id %>') }
 <%- end -%>
+<% end %>
+<% network_interfaces.each do |interface| %>
+  it { should have_network_interface('<%= interface.network_interface_id %>') }
 <% end %>
 end
 EOF

--- a/lib/awspec/helper/finder/ec2.rb
+++ b/lib/awspec/helper/finder/ec2.rb
@@ -109,6 +109,13 @@ module Awspec::Helper
         res.addresses
       end
 
+      def select_network_interface_by_instance_id(id)
+        res = ec2_client.describe_network_interfaces({
+                                                       filters: [{ name: 'attachment.instance-id', values: [id] }]
+                                                     })
+        res.network_interfaces
+      end
+
       def select_nat_gateway_by_vpc_id(vpc_id)
         res = ec2_client.describe_nat_gateways({
                                                  filter: [{ name: 'vpc-id', values: [vpc_id] }]

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -2,6 +2,7 @@
 require 'awspec/matcher/belong_to_vpc'
 require 'awspec/matcher/belong_to_subnet'
 require 'awspec/matcher/have_tag'
+require 'awspec/matcher/have_network_interface'
 
 # RDS
 require 'awspec/matcher/belong_to_db_subnet_group'

--- a/lib/awspec/matcher/have_network_interface.rb
+++ b/lib/awspec/matcher/have_network_interface.rb
@@ -1,0 +1,15 @@
+RSpec::Matchers.define :have_network_interface do |network_interface_id|
+  match do |type|
+    type.has_network_interface?(network_interface_id, @device_index)
+  end
+
+  chain :device_index do |device_index|
+    @device_index = device_index
+  end
+
+  (0..10).each do |idx|
+    chain "as_eth#{idx}".to_sym do
+      @device_index = idx
+    end
+  end
+end

--- a/lib/awspec/stub/ec2.rb
+++ b/lib/awspec/stub/ec2.rb
@@ -29,6 +29,13 @@ Aws.config[:ec2] = {
                   }
                 }
               ],
+              network_interfaces: [
+                {
+                  network_interface_id: 'eni-12ab3cde',
+                  subnet_id: 'subnet-1234a567',
+                  vpc_id: 'vpc-ab123cde'
+                }
+              ],
               tags: [
                 {
                   key: 'Name',
@@ -150,6 +157,63 @@ Aws.config[:ec2] = {
           { group_name: nil, group_id: 'sg-2a3b4cd5' },
           { group_name: 'my-vpc-security-group-name', group_id: nil }
         ]
+      ]
+    },
+    describe_network_interfaces: {
+      network_interfaces: [
+        {
+          network_interface_id: 'eni-12ab3cde',
+          subnet_id: 'subnet-1234a567',
+          vpc_id: 'vpc-ab123cde',
+          availability_zone: 'ap-northeast-1c',
+          description: '',
+          owner_id: '1234567890',
+          requester_id: nil,
+          requester_managed: false,
+          status: 'in-use',
+          mac_address: '00:11:aa:bb:cc:22',
+          private_ip_address: '10.0.1.1',
+          private_dns_name: nil,
+          source_dest_check: true,
+          groups:
+            [
+              {
+                group_name: 'my-security-group-name',
+                group_id: 'sg-1a2b3cd4'
+              }
+            ],
+          attachment: {
+            attachment_id: 'eni-attach-12ab3cde',
+            instance_id: 'i-ec12345a',
+            instance_owner_id: '1234567890',
+            device_index: 0,
+            status: 'attached',
+            attach_time: nil,
+            delete_on_termination: true
+          },
+          association: nil,
+          tag_set: [
+            {
+              key: 'Name',
+              value: 'my-eni'
+            }
+          ],
+          private_ip_addresses: [
+            {
+              private_ip_address: '10.0.1.1',
+              private_dns_name: nil,
+              primary: true,
+              association: nil
+            },
+            {
+              private_ip_address: '10.0.1.2',
+              private_dns_name: '',
+              primary: false,
+              association: nil
+            }
+          ],
+          interface_type: nil
+        }
       ]
     }
   }

--- a/lib/awspec/stub/ec2.rb
+++ b/lib/awspec/stub/ec2.rb
@@ -33,7 +33,10 @@ Aws.config[:ec2] = {
                 {
                   network_interface_id: 'eni-12ab3cde',
                   subnet_id: 'subnet-1234a567',
-                  vpc_id: 'vpc-ab123cde'
+                  vpc_id: 'vpc-ab123cde',
+                  attachment: {
+                    device_index: 1
+                  }
                 }
               ],
               tags: [

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -68,11 +68,12 @@ module Awspec::Type
       end
     end
 
-    def has_network_interface?(network_interface_id)
+    def has_network_interface?(network_interface_id, device_index = nil)
       res = find_network_interface(network_interface_id)
       interfaces = resource_via_client.network_interfaces
       ret = interfaces.find do |interface|
-        interface.network_interface_id = res.network_interface_id
+        next false if device_index && interface.attachment.device_index != device_index
+        interface.network_interface_id == res.network_interface_id
       end
     end
 

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -68,6 +68,14 @@ module Awspec::Type
       end
     end
 
+    def has_network_interface?(network_interface_id)
+      res = find_network_interface(network_interface_id)
+      interfaces = resource_via_client.network_interfaces
+      ret = interfaces.find do |interface|
+        interface.network_interface_id = res.network_interface_id
+      end
+    end
+
     def has_event?(event_code)
       status = find_ec2_status(id)
       ret = status.events.find do |event|

--- a/spec/generator/spec/ec2_spec.rb
+++ b/spec/generator/spec/ec2_spec.rb
@@ -20,6 +20,7 @@ describe ec2('my-ec2') do
   it { should belong_to_subnet('my-subnet') }
   it { should have_eip('123.0.456.789') }
   it { should have_ebs('my-volume') }
+  it { should have_network_interface('eni-12ab3cde') }
 end
 EOF
     expect(ec2.generate_by_vpc_id('my-vpc').to_s.gsub(/\n/, "\n")).to eq spec

--- a/spec/type/ec2_spec.rb
+++ b/spec/type/ec2_spec.rb
@@ -24,7 +24,7 @@ describe ec2('i-ec12345a') do
   it { should have_ebs('vol-123a123b') }
   it { should have_ebs('my-volume') }
   it { should have_network_interface('eni-12ab3cde') }
-  it { should have_network_interface('my-eni') }
+  it { should have_network_interface('my-eni').as_eth1 }
   its(:private_ip_address) { should eq '10.0.1.1' }
   context 'nested attribute call' do
     its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }

--- a/spec/type/ec2_spec.rb
+++ b/spec/type/ec2_spec.rb
@@ -23,6 +23,8 @@ describe ec2('i-ec12345a') do
   it { should have_eip('123.0.456.789') }
   it { should have_ebs('vol-123a123b') }
   it { should have_ebs('my-volume') }
+  it { should have_network_interface('eni-12ab3cde') }
+  it { should have_network_interface('my-eni') }
   its(:private_ip_address) { should eq '10.0.1.1' }
   context 'nested attribute call' do
     its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }


### PR DESCRIPTION
```ruby
describe ec2('my-ec2') do
  it { should have_network_interface('my-eni') }
  it { should have_network_interface('eni-12ab3cde') }
  it { should have_network_interface('my-eni').as_eth0 }
end
```