### PR TITLE
Fix for ELB has_security_group? tag match logic 

### DIFF
--- a/lib/awspec/type/elb.rb
+++ b/lib/awspec/type/elb.rb
@@ -33,10 +33,7 @@ module Awspec::Type
       end
       return true if ret
       sg2 = find_security_group(sg_id)
-      return false unless sg2.tag_name == sg_id || sg2.group_name == sg_id
-      sgs.find do |sg|
-        sg == sg2.group_name
-      end
+      return true if sg2.tag_name == sg_id || sg2.group_name == sg_id
     end
 
     def has_subnet?(subnet_id)

--- a/lib/awspec/type/elb.rb
+++ b/lib/awspec/type/elb.rb
@@ -34,6 +34,7 @@ module Awspec::Type
       return true if ret
       sg2 = find_security_group(sg_id)
       return true if sg2.tag_name == sg_id || sg2.group_name == sg_id
+      return false
     end
 
     def has_subnet?(subnet_id)

--- a/lib/awspec/type/elb.rb
+++ b/lib/awspec/type/elb.rb
@@ -34,7 +34,7 @@ module Awspec::Type
       return true if ret
       sg2 = find_security_group(sg_id)
       return true if sg2.tag_name == sg_id || sg2.group_name == sg_id
-      return false
+      false
     end
 
     def has_subnet?(subnet_id)


### PR DESCRIPTION
Not sure what the intention of the block 

```
sgs.find do |sg|
  sg == sg2.group_name
end
```

was but the method doesnt returns true when  sg2.tag_name == sg_id || sg2.group_name == sg_id