### PR TITLE
Added EC2 Resource matcher 'have_iam_instance_profile'

### DIFF
--- a/doc/_resource_types/ec2.md
+++ b/doc/_resource_types/ec2.md
@@ -48,6 +48,14 @@ describe ec2('my-ec2') do
 end
 ```
 
+### have_iam_instance_profile
+
+```ruby
+describe ec2('my-ec2') do
+  it { should have_iam_instance_profile('Ec2IamProfileName') }
+end
+```
+
 ### have_tag
 
 ```ruby
@@ -55,7 +63,6 @@ describe ec2('my-ec2') do
   it { should have_tag('Name').value('my-ec2') }
 end
 ```
-
 ### belong_to_subnet
 
 ```ruby

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -279,6 +279,13 @@ describe ec2('my-ec2') do
 end
 ```
 
+### have_iam_instance_profile
+
+```ruby
+describe ec2('my-ec2') do
+  it { should have_iam_instance_profile('Ec2IamProfileName') }
+end
+```
 
 ### have_tag
 

--- a/lib/awspec/stub/ec2.rb
+++ b/lib/awspec/stub/ec2.rb
@@ -15,6 +15,10 @@ Aws.config[:ec2] = {
               state: {
                 name: 'running'
               },
+              iam_instance_profile: {
+                arn: 'arn:aws:iam::123456789012:instance-profile/Ec2IamProfileName',
+                id: 'ABCDEFGHIJKLMNOPQRSTU'
+              },
               security_groups: [
                 {
                   group_id: 'sg-1a2b3cd4',

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -48,6 +48,12 @@ module Awspec::Type
       end
     end
 
+    def has_iam_instance_profile?(iam_instance_profile_name)
+      iam = resource_via_client.iam_instance_profile
+      ret = iam.arn.split('/')[-1] == iam_instance_profile_name
+      return true if ret
+    end
+
     def has_ebs?(volume_id)
       blocks = @resource_via_client[:block_device_mappings]
       ret = blocks.find do |block|

--- a/spec/type/ec2_spec.rb
+++ b/spec/type/ec2_spec.rb
@@ -27,6 +27,7 @@ describe ec2('i-ec12345a') do
     its('vpc.id') { should eq 'vpc-ab123cde' }
   end
   it { should have_tag('Name').value('my-ec2') }
+  it { should have_iam_instance_profile('Ec2IamProfileName') }
 end
 
 describe ec2('my-ec2') do


### PR DESCRIPTION
Hi, Koyama san

Otukaresama desu.
I added EC2 Resource matcher 'have_iam_instance_profile'.
Because I wanted to test with IamProfileName.

```ruby
require 'spec_helper'

describe ec2('My-EC2') do
  its('iam_instance_profile.arn') { should eq 'EC2' } #=> arn:aws:iam::123456789012:instance-profile/Ec2IamProfileName
  its('iam_instance_profile.id') { should eq 'EC2' } #=> ABCDEFGHIJKLMNOPQRSTU
end

describe ec2('My-EC2') do
  it { should have_iam_instance_profile('Ec2IamProfileName') } #=> Ec2IamProfileName
end
```

Please confirm.

Regards.

Yohei.