### PR TITLE
Add rerouce matcher 'have_iam_instance_profile' and Update Document.

### DIFF
--- a/doc/_resource_types/ec2.md
+++ b/doc/_resource_types/ec2.md
@@ -91,14 +91,6 @@ describe ec2('my-ec2') do
 end
 ```
 
-### have_iam_instance_profile
-
-```ruby
-describe ec2('My-EC2') do
-  it { should have_iam_instance_profile('Ec2IamProfileName') } #=> Ec2IamProfileName
-end
-```
-
 ### have_tag
 
 ```ruby
@@ -122,6 +114,14 @@ end
 describe ec2('my-ec2') do
   it { should belong_to_vpc('vpc-ab123cde') }
   it { should belong_to_vpc('my-vpc') }
+end
+```
+
+### have_iam_instance_profile
+
+```ruby
+describe ec2('my-ec2') do
+  it { should have_iam_instance_profile('Ec2IamProfileName') }
 end
 ```
 

--- a/doc/_resource_types/ec2.md
+++ b/doc/_resource_types/ec2.md
@@ -91,6 +91,14 @@ describe ec2('my-ec2') do
 end
 ```
 
+### have_iam_instance_profile
+
+```ruby
+describe ec2('My-EC2') do
+  it { should have_iam_instance_profile('Ec2IamProfileName') } #=> Ec2IamProfileName
+end
+```
+
 ### have_tag
 
 ```ruby

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -411,6 +411,15 @@ end
 ```
 
 
+### have_iam_instance_profile
+
+```ruby
+describe ec2('my-ec2') do
+  it { should have_iam_instance_profile('Ec2IamProfileName') }
+end
+```
+
+
 ### have_network_interface
 
 ```ruby
@@ -461,7 +470,7 @@ end
 ```
 
 
-### its(:instance_id), its(:image_id), its(:private_dns_name), its(:public_dns_name), its(:state_transition_reason), its(:key_name), its(:ami_launch_index), its(:instance_type), its(:launch_time), its(:placement), its(:kernel_id), its(:ramdisk_id), its(:platform), its(:monitoring), its(:subnet_id), its(:vpc_id), its(:private_ip_address), its(:public_ip_address), its(:state_reason), its(:architecture), its(:root_device_type), its(:root_device_name), its(:virtualization_type), its(:instance_lifecycle), its(:spot_instance_request_id), its(:client_token), its(:source_dest_check), its(:hypervisor), its(:iam_instance_profile), its(:ebs_optimized), its(:sriov_net_support), its(:ena_support)
+### its(:instance_id), its(:image_id), its(:private_dns_name), its(:public_dns_name), its(:state_transition_reason), its(:key_name), its(:ami_launch_index), its(:instance_type), its(:launch_time), its(:placement), its(:kernel_id), its(:ramdisk_id), its(:platform), its(:monitoring), its(:subnet_id), its(:vpc_id), its(:private_ip_address), its(:public_ip_address), its(:state_reason), its(:architecture), its(:root_device_type), its(:root_device_name), its(:virtualization_type), its(:instance_lifecycle), its(:spot_instance_request_id), its(:client_token), its(:source_dest_check), its(:hypervisor), its(:ebs_optimized), its(:sriov_net_support), its(:ena_support)
 ### :unlock: Advanced use
 
 `ec2` can use `Aws::EC2::Instance` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Instance.html).

--- a/lib/awspec/stub/ec2.rb
+++ b/lib/awspec/stub/ec2.rb
@@ -21,6 +21,10 @@ Aws.config[:ec2] = {
                   group_name: 'my-security-group-name'
                 }
               ],
+              iam_instance_profile: {
+                arn: 'arn:aws:iam::123456789012:instance-profile/Ec2IamProfileName',
+                id: 'ABCDEFGHIJKLMNOPQRSTU'
+              },
               block_device_mappings: [
                 {
                   device_name: '/dev/sda',

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -57,7 +57,7 @@ module Awspec::Type
 
     def has_iam_instance_profile?(iam_instance_profile_name)
       iam = resource_via_client.iam_instance_profile
-      ret = iam.arn.split('/')[-1] == iam_instance_profile_name
+      ret = iam.arn.split('/').last == iam_instance_profile_name
       return true if ret
     end
 

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -55,6 +55,12 @@ module Awspec::Type
       end
     end
 
+    def has_iam_instance_profile?(iam_instance_profile_name)
+      iam = resource_via_client.iam_instance_profile
+      ret = iam.arn.split('/')[-1] == iam_instance_profile_name
+      return true if ret
+    end
+
     def has_ebs?(volume_id)
       blocks = resource_via_client.block_device_mappings
       ret = blocks.find do |block|

--- a/spec/type/ec2_spec.rb
+++ b/spec/type/ec2_spec.rb
@@ -31,6 +31,7 @@ describe ec2('i-ec12345a') do
     its('vpc.id') { should eq 'vpc-ab123cde' }
   end
   it { should have_tag('Name').value('my-ec2') }
+  it { should have_iam_instance_profile('Ec2IamProfileName') }
 end
 
 describe ec2('my-ec2') do


### PR DESCRIPTION
Hi, Koyama san

Otukaresama desu.
I added EC2 Resource matcher 'have_iam_instance_profile'.
Because I wanted to test with IamProfileName.

```ruby
require 'spec_helper'

describe ec2('My-EC2') do
  its('iam_instance_profile.arn') { should eq 'EC2' } #=> arn:aws:iam::123456789012:instance-profile/Ec2IamProfileName
  its('iam_instance_profile.id') { should eq 'EC2' } #=> ABCDEFGHIJKLMNOPQRSTU
end

describe ec2('My-EC2') do
  it { should have_iam_instance_profile('Ec2IamProfileName') } #=> Ec2IamProfileName
end
```

Please confirm.

Regards.

Yohei.