### PR TITLE
Add Resource type ACM(AWS Certificate Manager)

### DIFF
--- a/doc/_resource_types/acm.md
+++ b/doc/_resource_types/acm.md
@@ -1,0 +1,33 @@
+### exist
+
+```ruby
+describe acm('example.com') do
+  it { should exist }
+end
+```
+
+### be_issued
+
+```ruby
+describe acm('example.com') do
+  it { should be_issued }
+end
+```
+
+### advanced
+
+`acm` can use `Aws::ACM::Types::CertificateDetail` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/ACM/Types/CertificateDetail.html).
+
+```ruby
+describe acm('example.com') do
+  its(:type) { should eq 'AMAZON_ISSUED' }
+end
+```
+
+or
+
+```ruby
+describe acm('example.com') do
+  its('type') { should eq 'AMAZON_ISSUED' }
+end
+```

--- a/doc/_resource_types/acm.md
+++ b/doc/_resource_types/acm.md
@@ -13,21 +13,3 @@ describe acm('example.com') do
   it { should be_issued }
 end
 ```
-
-### advanced
-
-`acm` can use `Aws::ACM::Types::CertificateDetail` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/ACM/Types/CertificateDetail.html).
-
-```ruby
-describe acm('example.com') do
-  its(:type) { should eq 'AMAZON_ISSUED' }
-end
-```
-
-or
-
-```ruby
-describe acm('example.com') do
-  its('type') { should eq 'AMAZON_ISSUED' }
-end
-```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -46,6 +46,7 @@
 | [vpn_gateway](#vpn_gateway)
 | [vpn_connection](#vpn_connection)
 | [internet_gateway](#internet_gateway)
+| [acm](#acm)
 
 ## <a name="alb">alb</a>
 
@@ -2216,3 +2217,43 @@ end
 ```
 
 ### its(:internet_gateway_id)
+## <a name="acm">acm</a>
+
+Acm resource type.
+
+### exist
+
+```ruby
+describe acm('example.com') do
+  it { should exist }
+end
+```
+
+
+### be_issued
+
+```ruby
+describe acm('example.com') do
+  it { should be_issued }
+end
+```
+
+
+### its(:certificate_arn), its(:domain_name), its(:subject_alternative_names), its(:domain_validation_options), its(:serial), its(:subject), its(:issuer), its(:created_at), its(:issued_at), its(:imported_at), its(:status), its(:revoked_at), its(:revocation_reason), its(:not_before), its(:not_after), its(:key_algorithm), its(:signature_algorithm), its(:in_use_by), its(:failure_reason), its(:type), its(:renewal_summary)
+### :unlock: Advanced use
+
+`acm` can use `Aws::ACM::Types::CertificateDetail` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/ACM/Types/CertificateDetail.html).
+
+```ruby
+describe acm('example.com') do
+  its(:type) { should eq 'AMAZON_ISSUED' }
+end
+```
+
+or
+
+```ruby
+describe acm('example.com') do
+  its('type') { should eq 'AMAZON_ISSUED' }
+end
+```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -2230,30 +2230,6 @@ end
 ```
 
 
-### be_issued
-
-```ruby
-describe acm('example.com') do
-  it { should be_issued }
-end
-```
-
+### be_pending_validation, be_issued, be_inactive, be_expired, be_validation_timed_out, be_revoked, be_failed
 
 ### its(:certificate_arn), its(:domain_name), its(:subject_alternative_names), its(:domain_validation_options), its(:serial), its(:subject), its(:issuer), its(:created_at), its(:issued_at), its(:imported_at), its(:status), its(:revoked_at), its(:revocation_reason), its(:not_before), its(:not_after), its(:key_algorithm), its(:signature_algorithm), its(:in_use_by), its(:failure_reason), its(:type), its(:renewal_summary)
-### :unlock: Advanced use
-
-`acm` can use `Aws::ACM::Types::CertificateDetail` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/ACM/Types/CertificateDetail.html).
-
-```ruby
-describe acm('example.com') do
-  its(:type) { should eq 'AMAZON_ISSUED' }
-end
-```
-
-or
-
-```ruby
-describe acm('example.com') do
-  its('type') { should eq 'AMAZON_ISSUED' }
-end
-```

--- a/lib/awspec/generator/doc/type/acm.rb
+++ b/lib/awspec/generator/doc/type/acm.rb
@@ -1,0 +1,17 @@
+module Awspec::Generator
+  module Doc
+    module Type
+      class Acm < Base
+        def initialize
+          super
+          @type_name = 'Acm'
+          @type = Awspec::Type::Acm.new('example.com')
+          @ret = @type.resource_via_client
+          @matchers = []
+          @ignore_matchers = []
+          @describes = []
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/generator/doc/type/acm.rb
+++ b/lib/awspec/generator/doc/type/acm.rb
@@ -7,8 +7,10 @@ module Awspec::Generator
           @type_name = 'Acm'
           @type = Awspec::Type::Acm.new('example.com')
           @ret = @type.resource_via_client
-          @matchers = []
-          @ignore_matchers = []
+          @matchers = [
+            Awspec::Type::Acm::STATUSES.map { |status| 'be_' + status.downcase }.join(', ')
+          ]
+          @ignore_matchers = Awspec::Type::Acm::STATUSES.map { |status| 'be_' + status.downcase }
           @describes = []
         end
       end

--- a/lib/awspec/helper/finder.rb
+++ b/lib/awspec/helper/finder.rb
@@ -27,6 +27,7 @@ require 'awspec/helper/finder/cloudfront'
 require 'awspec/helper/finder/elastictranscoder'
 require 'awspec/helper/finder/cloudtrail'
 require 'awspec/helper/finder/waf'
+require 'awspec/helper/finder/acm'
 
 module Awspec::Helper
   module Finder
@@ -58,6 +59,7 @@ module Awspec::Helper
     include Awspec::Helper::Finder::Elastictranscoder
     include Awspec::Helper::Finder::Cloudtrail
     include Awspec::Helper::Finder::Waf
+    include Awspec::Helper::Finder::Acm
 
     CLIENTS = {
       ec2_client: Aws::EC2::Client,
@@ -82,7 +84,8 @@ module Awspec::Helper
       elastictranscoder_client: Aws::ElasticTranscoder::Client,
       elasticsearch_client: Aws::ElasticsearchService::Client,
       cloudtrail_client: Aws::CloudTrail::Client,
-      waf_client: Aws::WAF::Client
+      waf_client: Aws::WAF::Client,
+      acm_client: Aws::ACM::Client
     }
 
     CLIENTS.each do |method_name, client|

--- a/lib/awspec/helper/finder/acm.rb
+++ b/lib/awspec/helper/finder/acm.rb
@@ -1,0 +1,10 @@
+module Awspec::Helper
+  module Finder
+    module Acm
+      def find_certificate(domain)
+        cert = acm_client.list_certificates.certificate_summary_list.find { |c| c[:domain_name] == domain }
+        acm_client.describe_certificate({ certificate_arn: cert.certificate_arn }).certificate
+      end
+    end
+  end
+end

--- a/lib/awspec/helper/type.rb
+++ b/lib/awspec/helper/type.rb
@@ -10,7 +10,7 @@ module Awspec
         iam_policy iam_role iam_user kms lambda launch_configuration nat_gateway
         network_acl network_interface rds rds_db_cluster_parameter_group rds_db_parameter_group route53_hosted_zone
         route_table s3_bucket security_group ses_identity subnet vpc cloudfront_distribution
-        elastictranscoder_pipeline waf_web_acl customer_gateway vpn_gateway vpn_connection internet_gateway
+        elastictranscoder_pipeline waf_web_acl customer_gateway vpn_gateway vpn_connection internet_gateway acm
       )
 
       TYPES.each do |type|

--- a/lib/awspec/stub/acm.rb
+++ b/lib/awspec/stub/acm.rb
@@ -1,0 +1,20 @@
+Aws.config[:acm] = {
+  stub_responses: {
+    list_certificates: {
+      certificate_summary_list: [
+        {
+          certificate_arn: 'arn:aws:acm:region:123456789010:certificate/12345678-1234-1234-1234-123456789010',
+          domain_name: 'example.com'
+        }
+      ]
+    },
+    describe_certificate: {
+      certificate: {
+        certificate_arn: 'arn:aws:acm:region:123456789010:certificate/12345678-1234-1234-1234-123456789010',
+        domain_name: 'example.com',
+        status: 'ISSUED',
+        type: 'AMAZON_ISSUED'
+      }
+    }
+  }
+}

--- a/lib/awspec/type/acm.rb
+++ b/lib/awspec/type/acm.rb
@@ -1,0 +1,15 @@
+module Awspec::Type
+  class Acm < Base
+    def resource_via_client
+      @resource_via_client ||= find_certificate(@display_name)
+    end
+
+    def id
+      @id = resource_via_client.certificate_arn if resource_via_client
+    end
+
+    def issued?
+      resource_via_client.status == 'ISSUED'
+    end
+  end
+end

--- a/lib/awspec/type/acm.rb
+++ b/lib/awspec/type/acm.rb
@@ -8,8 +8,20 @@ module Awspec::Type
       @id = resource_via_client.certificate_arn if resource_via_client
     end
 
-    def issued?
-      resource_via_client.status == 'ISSUED'
+    STATUSES = %w(
+      PENDING_VALIDATION
+      ISSUED
+      INACTIVE
+      EXPIRED
+      VALIDATION_TIMED_OUT
+      REVOKED
+      FAILED
+    )
+
+    STATUSES.each do |status|
+      define_method status.downcase + '?' do
+        resource_via_client.status == status
+      end
     end
   end
 end

--- a/spec/type/acm_spec.rb
+++ b/spec/type/acm_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+Awspec::Stub.load 'acm'
+
+describe acm('example.com') do
+  it { should exist }
+  it { should be_issued }
+  its(:type) { should eq 'AMAZON_ISSUED' }
+end


### PR DESCRIPTION
Hi, Koyama san

I added AWS Certificate Manager Resource type.

### exist

```ruby
describe acm('example.com') do
  it { should exist }
end
```

### be_issued

```ruby
describe acm('example.com') do
  it { should be_issued }
end
```

### advanced

```ruby
describe acm('example.com') do
  its(:type) { should eq 'AMAZON_ISSUED' }
end
```

or

```ruby
describe acm('example.com') do
  its('type') { should eq 'AMAZON_ISSUED' }
end
```

Please confirm. :pray:

Regards.

Yohei.