### PR TITLE
Fix Awspec::Finder::Rds#find_rds

### DIFF
--- a/lib/awspec/helper/finder/rds.rb
+++ b/lib/awspec/helper/finder/rds.rb
@@ -2,10 +2,15 @@ module Awspec::Helper
   module Finder
     module Rds
       def find_rds(id)
-        # db_instance_identifier
-        res = rds_client.describe_db_instances({
-                                                 db_instance_identifier: id
-                                               })
+        begin
+          res = rds_client.describe_db_instances({
+                                                   db_instance_identifier: id
+                                                 })
+        rescue
+          res = rds_client.describe_db_instances({
+                                                   filters: [{ name: 'db-instance-id', values: [id] }]
+                                                 })
+        end
         res.db_instances.single_resource(id)
       end
 


### PR DESCRIPTION
When `find_rds` can not find db_instance by db_instance_identifier,
`find_rds` should return nil.