### PR TITLE
Add CloudWatch Logs Resouce type.

### DIFF
--- a/doc/_resource_types/cloudwatch_logs.md
+++ b/doc/_resource_types/cloudwatch_logs.md
@@ -1,0 +1,40 @@
+### exist
+
+```ruby
+describe cloudwatch_logs('my-cloudwatch-logs-group') do
+  it { should exist }
+end
+```
+
+### have_log_stream
+
+```ruby
+describe cloudwatch_logs('my-cloudwatch-logs-group') do
+  it { should have_log_stream('my-cloudwatch-logs-stream') }
+end
+```
+
+### have_metric_filter
+
+```ruby
+describe cloudwatch_logs('my-cloudwatch-logs-group') do
+  it { should have_metric_filter('my-cloudwatch-logs-metric-filter') }
+end
+```
+
+### have_subscription_filter
+
+```ruby
+describe cloudwatch_logs('my-cloudwatch-logs-group') do
+  it { should have_subscription_filter('my-cloudwatch-logs-subscription-filter') }
+end
+```
+or
+```ruby
+describe cloudwatch_logs('my-cloudwatch-logs-group') do
+  it do
+    should have_subscription_filter('my-cloudwatch-logs-subscription-filter')\
+      .filter_pattern('[host, ident, authuser, date, request, status, bytes]')
+  end
+end
+```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -8,6 +8,7 @@
 | [cloudtrail](#cloudtrail)
 | [cloudwatch_alarm](#cloudwatch_alarm)
 | [cloudwatch_event](#cloudwatch_event)
+| [cloudwatch_logs](#cloudwatch_logs)
 | [customer_gateway](#customer_gateway)
 | [directconnect_virtual_interface](#directconnect_virtual_interface)
 | [ebs](#ebs)
@@ -2234,6 +2235,55 @@ end
 ### be_pending_validation, be_issued, be_inactive, be_expired, be_validation_timed_out, be_revoked, be_failed
 
 ### its(:certificate_arn), its(:domain_name), its(:subject_alternative_names), its(:domain_validation_options), its(:serial), its(:subject), its(:issuer), its(:created_at), its(:issued_at), its(:imported_at), its(:status), its(:revoked_at), its(:revocation_reason), its(:not_before), its(:not_after), its(:key_algorithm), its(:signature_algorithm), its(:in_use_by), its(:failure_reason), its(:type), its(:renewal_summary)
+## <a name="cloudwatch_logs">cloudwatch_logs</a>
+
+CloudwatchLogs resource type.
+
+### exist
+
+```ruby
+describe cloudwatch_logs('my-cloudwatch-logs-group') do
+  it { should exist }
+end
+```
+
+
+### have_log_stream
+
+```ruby
+describe cloudwatch_logs('my-cloudwatch-logs-group') do
+  it { should have_log_stream('my-cloudwatch-logs-stream') }
+end
+```
+
+
+### have_metric_filter
+
+```ruby
+describe cloudwatch_logs('my-cloudwatch-logs-group') do
+  it { should have_metric_filter('my-cloudwatch-logs-metric-filter') }
+end
+```
+
+
+### have_subscription_filter
+
+```ruby
+describe cloudwatch_logs('my-cloudwatch-logs-group') do
+  it { should have_subscription_filter('my-cloudwatch-logs-subscription-filter') }
+end
+```
+or
+```ruby
+describe cloudwatch_logs('my-cloudwatch-logs-group') do
+  it do
+    should have_subscription_filter('my-cloudwatch-logs-subscription-filter')\
+      .filter_pattern('[host, ident, authuser, date, request, status, bytes]')
+  end
+end
+```
+
+### its(:log_group_name), its(:creation_time), its(:retention_in_days), its(:metric_filter_count), its(:arn), its(:stored_bytes)
 # Account and Attributes
 
 ## <a name="account">account</a>

--- a/lib/awspec/generator/doc/type/cloudwatch_logs.rb
+++ b/lib/awspec/generator/doc/type/cloudwatch_logs.rb
@@ -1,0 +1,17 @@
+module Awspec::Generator
+  module Doc
+    module Type
+      class CloudwatchLogs < Base
+        def initialize
+          super
+          @type_name = 'CloudwatchLogs'
+          @type = Awspec::Type::CloudwatchLogs.new('my-cloudwatch-logs-group')
+          @ret = @type.resource_via_client
+          @matchers = []
+          @ignore_matchers = []
+          @describes = []
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/helper/finder.rb
+++ b/lib/awspec/helper/finder.rb
@@ -28,6 +28,7 @@ require 'awspec/helper/finder/elastictranscoder'
 require 'awspec/helper/finder/cloudtrail'
 require 'awspec/helper/finder/waf'
 require 'awspec/helper/finder/acm'
+require 'awspec/helper/finder/cloudwatch_logs'
 
 require 'awspec/helper/finder/account_attributes'
 
@@ -63,6 +64,7 @@ module Awspec::Helper
     include Awspec::Helper::Finder::Waf
     include Awspec::Helper::Finder::Acm
     include Awspec::Helper::Finder::AccountAttributes
+    include Awspec::Helper::Finder::CloudwatchLogs
 
     CLIENTS = {
       ec2_client: Aws::EC2::Client,
@@ -89,7 +91,8 @@ module Awspec::Helper
       cloudtrail_client: Aws::CloudTrail::Client,
       waf_client: Aws::WAF::Client,
       sts_client: Aws::STS::Client,
-      acm_client: Aws::ACM::Client
+      acm_client: Aws::ACM::Client,
+      cloudwatch_logs_client: Aws::CloudWatchLogs::Client
     }
 
     CLIENTS.each do |method_name, client|

--- a/lib/awspec/helper/finder/cloudwatch_logs.rb
+++ b/lib/awspec/helper/finder/cloudwatch_logs.rb
@@ -13,21 +13,21 @@ module Awspec::Helper
         cloudwatch_logs_client.describe_log_streams({ log_group_name: id }).log_streams.last
       end
 
-      def find_cloudwatch_logs_metric_fileter_by_log_group_name(id, filter_name_prefix)
+      def find_cloudwatch_logs_metric_fileter_by_log_group_name(id, filter_name)
         cloudwatch_logs_client.describe_metric_filters({
                                                          log_group_name: id,
-                                                         filter_name_prefix: filter_name_prefix
+                                                         filter_name_prefix: filter_name
                                                        }).metric_filters.find do |filter|
-          filter.filter_name == filter_name_prefix
+          filter.filter_name == filter_name
         end
       end
 
-      def find_cloudwatch_logs_subscription_fileter_by_log_group_name(id, filter_name_prefix)
+      def find_cloudwatch_logs_subscription_fileter_by_log_group_name(id, filter_name)
         cloudwatch_logs_client.describe_subscription_filters({
                                                                log_group_name: id,
-                                                               filter_name_prefix: filter_name_prefix
+                                                               filter_name_prefix: filter_name
                                                              }).subscription_filters.find do |filter|
-          filter.filter_name == filter_name_prefix
+          filter.filter_name == filter_name
         end
       end
     end

--- a/lib/awspec/helper/finder/cloudwatch_logs.rb
+++ b/lib/awspec/helper/finder/cloudwatch_logs.rb
@@ -1,0 +1,27 @@
+module Awspec::Helper
+  module Finder
+    module CloudwatchLogs
+      def find_cloudwatch_logs_group(id)
+        cloudwatch_logs_client.describe_log_groups({ log_group_name_prefix: id }).log_groups.last
+      end
+
+      def find_cloudwatch_logs_stream(id)
+        cloudwatch_logs_client.describe_log_streams({ log_group_name: id }).log_streams.last
+      end
+
+      def find_cloudwatch_logs_metric_fileter(id, filter_name)
+        cloudwatch_logs_client.describe_metric_filters({
+                                                         log_group_name: id,
+                                                         filter_name_prefix: filter_name
+                                                       }).metric_filters.last
+      end
+
+      def find_cloudwatch_logs_subscription_fileter(id, filter_name)
+        cloudwatch_logs_client.describe_subscription_filters({
+                                                               log_group_name: id,
+                                                               filter_name_prefix: filter_name
+                                                             }).subscription_filters.last
+      end
+    end
+  end
+end

--- a/lib/awspec/helper/finder/cloudwatch_logs.rb
+++ b/lib/awspec/helper/finder/cloudwatch_logs.rb
@@ -2,25 +2,33 @@ module Awspec::Helper
   module Finder
     module CloudwatchLogs
       def find_cloudwatch_logs_group(id)
-        cloudwatch_logs_client.describe_log_groups({ log_group_name_prefix: id }).log_groups.last
+        cloudwatch_logs_client.describe_log_groups({
+                                                     log_group_name_prefix: id
+                                                   }).log_groups.find do |log_group|
+          log_group.log_group_name == id
+        end
       end
 
-      def find_cloudwatch_logs_stream(id)
+      def find_cloudwatch_logs_stream_by_log_group_name(id)
         cloudwatch_logs_client.describe_log_streams({ log_group_name: id }).log_streams.last
       end
 
-      def find_cloudwatch_logs_metric_fileter(id, filter_name)
+      def find_cloudwatch_logs_metric_fileter_by_log_group_name(id, filter_name_prefix)
         cloudwatch_logs_client.describe_metric_filters({
                                                          log_group_name: id,
-                                                         filter_name_prefix: filter_name
-                                                       }).metric_filters.last
+                                                         filter_name_prefix: filter_name_prefix
+                                                       }).metric_filters.find do |filter|
+          filter.filter_name == filter_name_prefix
+        end
       end
 
-      def find_cloudwatch_logs_subscription_fileter(id, filter_name)
+      def find_cloudwatch_logs_subscription_fileter_by_log_group_name(id, filter_name_prefix)
         cloudwatch_logs_client.describe_subscription_filters({
                                                                log_group_name: id,
-                                                               filter_name_prefix: filter_name
-                                                             }).subscription_filters.last
+                                                               filter_name_prefix: filter_name_prefix
+                                                             }).subscription_filters.find do |filter|
+          filter.filter_name == filter_name_prefix
+        end
       end
     end
   end

--- a/lib/awspec/helper/type.rb
+++ b/lib/awspec/helper/type.rb
@@ -15,6 +15,7 @@ module Awspec
         network_acl network_interface rds rds_db_cluster_parameter_group rds_db_parameter_group route53_hosted_zone
         route_table s3_bucket security_group ses_identity subnet vpc cloudfront_distribution
         elastictranscoder_pipeline waf_web_acl customer_gateway vpn_gateway vpn_connection internet_gateway acm
+        cloudwatch_logs
       )
 
       ACCOUNT_ATTRIBUTES = %w(

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -47,3 +47,6 @@ require 'awspec/matcher/have_key_policy'
 
 # WafWebAcl
 require 'awspec/matcher/have_rule'
+
+# CloudWatch Logs
+require 'awspec/matcher/have_subscription_filter'

--- a/lib/awspec/matcher/have_subscription_filter.rb
+++ b/lib/awspec/matcher/have_subscription_filter.rb
@@ -1,0 +1,9 @@
+RSpec::Matchers.define :have_subscription_filter do |filter_name|
+  match do |log_group_name|
+    log_group_name.has_subscription_filter?(filter_name, @pattern)
+  end
+
+  chain :filter_pattern do |pattern|
+    @pattern = pattern
+  end
+end

--- a/lib/awspec/stub/cloudwatch_logs.rb
+++ b/lib/awspec/stub/cloudwatch_logs.rb
@@ -1,0 +1,34 @@
+Aws.config[:cloudwatchlogs] = {
+  stub_responses: {
+    describe_log_groups: {
+      log_groups: [
+        {
+          log_group_name: 'my-cloudwatch-logs-group',
+          retention_in_days: 365
+        }
+      ]
+    },
+    describe_log_streams: {
+      log_streams: [
+        {
+          log_stream_name: 'my-cloudwatch-logs-stream'
+        }
+      ]
+    },
+    describe_metric_filters: {
+      metric_filters: [
+        {
+          filter_name: 'my-cloudwatch-logs-metric-filter'
+        }
+      ]
+    },
+    describe_subscription_filters: {
+      subscription_filters: [
+        {
+          filter_name: 'my-cloudwatch-logs-subscription-filter',
+          filter_pattern: '[host, ident, authuser, date, request, status, bytes]'
+        }
+      ]
+    }
+  }
+}

--- a/lib/awspec/type/cloudwatch_logs.rb
+++ b/lib/awspec/type/cloudwatch_logs.rb
@@ -13,15 +13,15 @@ module Awspec::Type
       return true if ret == stream_name
     end
 
-    def has_metric_filter?(filter_name_prefix)
-      ret = find_cloudwatch_logs_metric_fileter_by_log_group_name(@id, filter_name_prefix).filter_name
-      return true if ret == filter_name_prefix
+    def has_metric_filter?(filter_name)
+      ret = find_cloudwatch_logs_metric_fileter_by_log_group_name(@id, filter_name).filter_name
+      return true if ret == filter_name
     end
 
-    def has_subscription_filter?(filter_name_prefix, pattern = nil)
-      ret = find_cloudwatch_logs_subscription_fileter_by_log_group_name(@id, filter_name_prefix)
+    def has_subscription_filter?(filter_name, pattern = nil)
+      ret = find_cloudwatch_logs_subscription_fileter_by_log_group_name(@id, filter_name)
       return false unless ret.filter_pattern == pattern
-      return true if ret.filter_name == filter_name_prefix
+      return true if ret.filter_name == filter_name
     end
   end
 end

--- a/lib/awspec/type/cloudwatch_logs.rb
+++ b/lib/awspec/type/cloudwatch_logs.rb
@@ -9,19 +9,19 @@ module Awspec::Type
     end
 
     def has_log_stream?(stream_name)
-      ret = find_cloudwatch_logs_stream(@id).log_stream_name
+      ret = find_cloudwatch_logs_stream_by_log_group_name(@id).log_stream_name
       return true if ret == stream_name
     end
 
-    def has_metric_filter?(filter_name)
-      ret = find_cloudwatch_logs_metric_fileter(@id, filter_name).filter_name
-      return true if ret == filter_name
+    def has_metric_filter?(filter_name_prefix)
+      ret = find_cloudwatch_logs_metric_fileter_by_log_group_name(@id, filter_name_prefix).filter_name
+      return true if ret == filter_name_prefix
     end
 
-    def has_subscription_filter?(filter_name, pattern = nil)
-      ret = find_cloudwatch_logs_subscription_fileter(@id, filter_name)
+    def has_subscription_filter?(filter_name_prefix, pattern = nil)
+      ret = find_cloudwatch_logs_subscription_fileter_by_log_group_name(@id, filter_name_prefix)
       return false unless ret.filter_pattern == pattern
-      return true if ret.filter_name == filter_name
+      return true if ret.filter_name == filter_name_prefix
     end
   end
 end

--- a/lib/awspec/type/cloudwatch_logs.rb
+++ b/lib/awspec/type/cloudwatch_logs.rb
@@ -1,0 +1,27 @@
+module Awspec::Type
+  class CloudwatchLogs < ResourceBase
+    def resource_via_client
+      @resource_via_client ||= find_cloudwatch_logs_group(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.log_group_name if resource_via_client
+    end
+
+    def has_log_stream?(stream_name)
+      ret = find_cloudwatch_logs_stream(@id).log_stream_name
+      return true if ret == stream_name
+    end
+
+    def has_metric_filter?(filter_name)
+      ret = find_cloudwatch_logs_metric_fileter(@id, filter_name).filter_name
+      return true if ret == filter_name
+    end
+
+    def has_subscription_filter?(filter_name, pattern = nil)
+      ret = find_cloudwatch_logs_subscription_fileter(@id, filter_name)
+      return false unless ret.filter_pattern == pattern
+      return true if ret.filter_name == filter_name
+    end
+  end
+end

--- a/spec/type/cloudwatch_logs_spec.rb
+++ b/spec/type/cloudwatch_logs_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+Awspec::Stub.load 'cloudwatch_logs'
+
+describe cloudwatch_logs('my-cloudwatch-logs-group') do
+  it { should exist }
+  its(:retention_in_days) { should eq 365 }
+  it { should have_log_stream('my-cloudwatch-logs-stream') }
+  it { should have_metric_filter('my-cloudwatch-logs-metric-filter') }
+  it do
+    should have_subscription_filter('my-cloudwatch-logs-subscription-filter')\
+      .filter_pattern('[host, ident, authuser, date, request, status, bytes]')
+  end
+end


### PR DESCRIPTION
Hi, Koyama san

Otsukaresama desu.
I added CloudWatch Logs Resource type.

### exist

```ruby
describe cloudwatch_logs('my-cloudwatch-logs-group') do
  it { should exist }
end
```

### have_log_stream

```ruby
describe cloudwatch_logs('my-cloudwatch-logs-group') do
  it { should have_log_stream('my-cloudwatch-logs-stream') }
end
```

### have_metric_filter

```ruby
describe cloudwatch_logs('my-cloudwatch-logs-group') do
  it { should have_metric_filter('my-cloudwatch-logs-metric-filter') }
end
```

### have_subscription_filter

```ruby
describe cloudwatch_logs('my-cloudwatch-logs-group') do
  it { should have_subscription_filter('my-cloudwatch-logs-subscription-filter') }
end
```
or
```ruby
describe cloudwatch_logs('my-cloudwatch-logs-group') do
  it do
    should have_subscription_filter('my-cloudwatch-logs-subscription-filter')\
      .filter_pattern('[host, ident, authuser, date, request, status, bytes]')
  end
end
```

Please confirm. 

Regards.

Yohei.