### PR TITLE
Add to check  security_groups

### DIFF
--- a/doc/_resource_types/ec2.md
+++ b/doc/_resource_types/ec2.md
@@ -91,6 +91,15 @@ describe ec2('my-ec2') do
 end
 ```
 
+### have_security_groups
+
+```ruby
+describe ec2('my-ec2') do
+  it { should have_security_groups(['my-security-group-name-1', 'my-security-group-name-2']) }
+  it { should have_security_groups(['sg-1a2b3cd4', 'sg-5e6f7gh8']) }
+end
+```
+
 ### have_tag
 
 ```ruby

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -445,6 +445,16 @@ end
 ```
 
 
+### have_security_groups
+
+```ruby
+describe ec2('my-ec2') do
+  it { should have_security_groups(['my-security-group-name-1', 'my-security-group-name-2']) }
+  it { should have_security_groups(['sg-1a2b3cd4', 'sg-5e6f7gh8']) }
+end
+```
+
+
 ### have_tag
 
 ```ruby

--- a/lib/awspec/helper/finder/security_group.rb
+++ b/lib/awspec/helper/finder/security_group.rb
@@ -12,19 +12,19 @@ module Awspec::Helper
       end
 
       def select_security_group_by_vpc_id(vpc_id)
-        describe_security_groups({filters: [{ name: 'vpc-id', values: [vpc_id] }]})
+        describe_security_groups({ filters: [{ name: 'vpc-id', values: [vpc_id] }] })
       end
 
       def select_security_group_by_group_id(ids)
-        describe_security_groups({filters: [{ name: 'group-id', values: ids }]})
+        describe_security_groups({ filters: [{ name: 'group-id', values: ids }] })
       end
 
       def select_security_group_by_group_name(names)
-        describe_security_groups({filters: [{ name: 'group-name', values: names }]})
+        describe_security_groups({ filters: [{ name: 'group-name', values: names }] })
       end
 
       def select_security_group_by_tag_name(names)
-        describe_security_groups({filters: [{ name: 'tag:Name', values: names }]})
+        describe_security_groups({ filters: [{ name: 'tag:Name', values: names }] })
       end
 
       def describe_security_groups(param)

--- a/lib/awspec/helper/finder/security_group.rb
+++ b/lib/awspec/helper/finder/security_group.rb
@@ -2,27 +2,33 @@ module Awspec::Helper
   module Finder
     module SecurityGroup
       def find_security_group(sg_id)
-        res = ec2_client.describe_security_groups({
-                                                    filters: [{ name: 'group-id', values: [sg_id] }]
-                                                  })
-        resource = res.security_groups.single_resource(sg_id)
+        resource = select_security_group_by_group_id([sg_id]).single_resource(sg_id)
         return resource if resource
-        res = ec2_client.describe_security_groups({
-                                                    filters: [{ name: 'group-name', values: [sg_id] }]
-                                                  })
-        resource = res.security_groups.single_resource(sg_id)
+
+        resource = select_security_group_by_group_name([sg_id]).single_resource(sg_id)
         return resource if resource
-        res = ec2_client.describe_security_groups({
-                                                    filters: [{ name: 'tag:Name', values: [sg_id] }]
-                                                  })
-        res.security_groups.single_resource(sg_id)
+
+        select_security_group_by_tag_name([sg_id]).single_resource(sg_id)
       end
 
       def select_security_group_by_vpc_id(vpc_id)
-        res = ec2_client.describe_security_groups({
-                                                    filters: [{ name: 'vpc-id', values: [vpc_id] }]
-                                                  })
-        res.security_groups
+        describe_security_groups({filters: [{ name: 'vpc-id', values: [vpc_id] }]})
+      end
+
+      def select_security_group_by_group_id(ids)
+        describe_security_groups({filters: [{ name: 'group-id', values: ids }]})
+      end
+
+      def select_security_group_by_group_name(names)
+        describe_security_groups({filters: [{ name: 'group-name', values: names }]})
+      end
+
+      def select_security_group_by_tag_name(names)
+        describe_security_groups({filters: [{ name: 'tag:Name', values: names }]})
+      end
+
+      def describe_security_groups(param)
+        ec2_client.describe_security_groups(param).security_groups
       end
     end
   end

--- a/lib/awspec/stub/ec2_has_multi_security_groups.rb
+++ b/lib/awspec/stub/ec2_has_multi_security_groups.rb
@@ -1,0 +1,21 @@
+require_relative "../stub/ec2"
+
+stub_responses = Aws.config[:ec2][:stub_responses]
+
+stub_responses[:describe_instances][:reservations][0][:instances][0][:security_groups] <<
+  {
+    group_id: 'sg-5e6f7gh8',
+    group_name: 'my-security-group-name-2'
+  }
+
+stub_responses[:describe_security_groups][:security_groups] <<
+  {
+    group_id: 'sg-5e6f7gh8',
+    group_name: 'my-security-group-name-2',
+    tags: [
+      {
+        key: 'Name',
+        value: 'my-security-group-tag-name-2'
+      }
+    ]
+  }

--- a/lib/awspec/stub/ec2_has_multi_security_groups.rb
+++ b/lib/awspec/stub/ec2_has_multi_security_groups.rb
@@ -1,4 +1,4 @@
-require_relative "../stub/ec2"
+require_relative '../stub/ec2'
 
 stub_responses = Aws.config[:ec2][:stub_responses]
 

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -43,13 +43,12 @@ module Awspec::Type
     end
 
     def has_security_groups?(sg_ids)
-      return true if (match_group_ids?(sg_ids) || match_group_names?(sg_ids))
+      return true if match_group_ids?(sg_ids) || match_group_names?(sg_ids)
 
       group_ids = resource_security_groups.map { |sg| sg.group_id }
       tags = select_security_group_by_group_id(group_ids).map { |sg| sg.tags }.flatten
-      group_names =  tags.select { |tag| tag.key == 'Name' }.map { |tag| tag.value }
-      ret = group_names == sg_ids
-      return ret
+      group_names = tags.select { |tag| tag.key == 'Name' }.map { |tag| tag.value }
+      group_names == sg_ids
     end
 
     def has_security_group?(sg_id)

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -42,6 +42,20 @@ module Awspec::Type
       return ret.addresses.count > 0 unless ip_address
     end
 
+    def has_security_groups?(sg_ids)
+      sgs = resource_via_client.security_groups
+      group_ids = sgs.map { |sg| sg.group_id }
+      group_names = sgs.map { |sg| sg.group_name }
+
+      ret = group_ids == sg_ids || group_names == sg_ids
+      return true if ret
+
+      tags = ec2_client.describe_security_groups({filters: [{name: 'group-id', values: group_ids}]}).security_groups.map { |sg| sg.tags }.flatten
+      group_names =  tags.select { |tag| tag.key == 'Name' }.map { |tag| tag.value }
+      ret = group_names == sg_ids
+      return ret
+    end
+
     def has_security_group?(sg_id)
       sgs = resource_via_client.security_groups
       ret = sgs.find do |sg|

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -45,9 +45,8 @@ module Awspec::Type
     def has_security_groups?(sg_ids)
       sgs = resource_via_client.security_groups
       group_ids = sgs.map { |sg| sg.group_id }
-      group_names = sgs.map { |sg| sg.group_name }
 
-      ret = group_ids == sg_ids || group_names == sg_ids
+      ret = match_group_ids?(sg_ids) || match_group_names?(sg_ids)
       return true if ret
 
       tags = ec2_client.describe_security_groups({filters: [{name: 'group-id', values: group_ids}]}).security_groups.map { |sg| sg.tags }.flatten
@@ -131,6 +130,20 @@ module Awspec::Type
         sg.group_id == sg_id || sg.group_name == sg_id
       end
       return true if ret
+    end
+
+    private
+
+    def match_group_ids?(sg_ids)
+      sg_ids.sort == resource_security_groups.map { |sg| sg.group_id }.sort
+    end
+
+    def match_group_names?(sg_names)
+      sg_names.sort == resource_security_groups.map { |sg| sg.group_name }.sort
+    end
+
+    def resource_security_groups
+      resource_via_client.security_groups
     end
   end
 end

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -46,7 +46,7 @@ module Awspec::Type
       return true if (match_group_ids?(sg_ids) || match_group_names?(sg_ids))
 
       group_ids = resource_security_groups.map { |sg| sg.group_id }
-      tags = ec2_client.describe_security_groups({filters: [{name: 'group-id', values: group_ids}]}).security_groups.map { |sg| sg.tags }.flatten
+      tags = select_security_group_by_group_id(group_ids).map { |sg| sg.tags }.flatten
       group_names =  tags.select { |tag| tag.key == 'Name' }.map { |tag| tag.value }
       ret = group_names == sg_ids
       return ret

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -43,12 +43,9 @@ module Awspec::Type
     end
 
     def has_security_groups?(sg_ids)
-      sgs = resource_via_client.security_groups
-      group_ids = sgs.map { |sg| sg.group_id }
+      return true if (match_group_ids?(sg_ids) || match_group_names?(sg_ids))
 
-      ret = match_group_ids?(sg_ids) || match_group_names?(sg_ids)
-      return true if ret
-
+      group_ids = resource_security_groups.map { |sg| sg.group_id }
       tags = ec2_client.describe_security_groups({filters: [{name: 'group-id', values: group_ids}]}).security_groups.map { |sg| sg.tags }.flatten
       group_names =  tags.select { |tag| tag.key == 'Name' }.map { |tag| tag.value }
       ret = group_names == sg_ids

--- a/spec/type/ec2_has_multi_security_groups_spec.rb
+++ b/spec/type/ec2_has_multi_security_groups_spec.rb
@@ -1,8 +1,0 @@
-require 'spec_helper'
-Awspec::Stub.load 'ec2_has_multi_security_groups'
-
-describe ec2('i-ec12345a') do
-  it { should have_security_groups(['sg-1a2b3cd4', 'sg-5e6f7gh8']) }
-  it { should have_security_groups(['my-security-group-name', 'my-security-group-name-2']) }
-  it { should have_security_groups(['my-security-group-tag-name', 'my-security-group-tag-name-2']) }
-end

--- a/spec/type/ec2_has_multi_security_groups_spec.rb
+++ b/spec/type/ec2_has_multi_security_groups_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+Awspec::Stub.load 'ec2_has_multi_security_groups'
+
+describe ec2('i-ec12345a') do
+  it { should have_security_groups(['sg-1a2b3cd4', 'sg-5e6f7gh8']) }
+  it { should have_security_groups(['my-security-group-name', 'my-security-group-name-2']) }
+  it { should have_security_groups(['my-security-group-tag-name', 'my-security-group-tag-name-2']) }
+end

--- a/spec/type/ec2_spec.rb
+++ b/spec/type/ec2_spec.rb
@@ -1,47 +1,65 @@
 require 'spec_helper'
-Awspec::Stub.load 'ec2'
 
-describe ec2('i-ec12345a') do
-  it { should exist }
-  it { should be_running }
-  it { should have_event('system-reboot') }
-  it { should have_events }
-  it { should_not be_stopped }
-  its(:instance_id) { should eq 'i-ec12345a' }
-  its(:image_id) { should eq 'ami-abc12def' }
-  its(:public_ip_address) { should eq '123.0.456.789' }
-  its(:private_ip_address) { should eq '10.0.1.1' }
-  it { should be_disabled_api_termination }
-  it { should have_security_group('sg-1a2b3cd4') }
-  it { should have_security_group('my-security-group-name') }
-  it { should have_security_group('my-security-group-tag-name') }
-  it { should belong_to_vpc('vpc-ab123cde') }
-  it { should belong_to_vpc('my-vpc') }
-  it { should belong_to_subnet('subnet-1234a567') }
-  it { should belong_to_subnet('my-subnet') }
-  it { should have_eip }
-  it { should have_eip('123.0.456.789') }
-  it { should have_ebs('vol-123a123b') }
-  it { should have_ebs('my-volume') }
-  it { should have_network_interface('eni-12ab3cde') }
-  it { should have_network_interface('my-eni').as_eth1 }
-  its(:private_ip_address) { should eq '10.0.1.1' }
-  context 'nested attribute call' do
-    its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }
-    its('vpc.id') { should eq 'vpc-ab123cde' }
+describe 'single security group' do
+  before do
+    Awspec::Stub.load 'ec2'
   end
-  it { should have_tag('Name').value('my-ec2') }
-  it { should have_iam_instance_profile('Ec2IamProfileName') }
+
+  describe ec2('i-ec12345a') do
+    it { should exist }
+    it { should be_running }
+    it { should have_event('system-reboot') }
+    it { should have_events }
+    it { should_not be_stopped }
+    its(:instance_id) { should eq 'i-ec12345a' }
+    its(:image_id) { should eq 'ami-abc12def' }
+    its(:public_ip_address) { should eq '123.0.456.789' }
+    its(:private_ip_address) { should eq '10.0.1.1' }
+    it { should be_disabled_api_termination }
+    it { should have_security_group('sg-1a2b3cd4') }
+    it { should have_security_group('my-security-group-name') }
+    it { should have_security_group('my-security-group-tag-name') }
+    it { should belong_to_vpc('vpc-ab123cde') }
+    it { should belong_to_vpc('my-vpc') }
+    it { should belong_to_subnet('subnet-1234a567') }
+    it { should belong_to_subnet('my-subnet') }
+    it { should have_eip }
+    it { should have_eip('123.0.456.789') }
+    it { should have_ebs('vol-123a123b') }
+    it { should have_ebs('my-volume') }
+    it { should have_network_interface('eni-12ab3cde') }
+    it { should have_network_interface('my-eni').as_eth1 }
+    its(:private_ip_address) { should eq '10.0.1.1' }
+    context 'nested attribute call' do
+      its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }
+      its('vpc.id') { should eq 'vpc-ab123cde' }
+    end
+    it { should have_tag('Name').value('my-ec2') }
+    it { should have_iam_instance_profile('Ec2IamProfileName') }
+  end
+
+  describe ec2('my-ec2') do
+    it { should exist }
+    it { should be_running }
+    it { should have_tag('Name').value('my-ec2') }
+  end
+
+  describe ec2('my-ec2-classic') do
+    it { should have_classiclink('my-vpc') }
+    it { should have_classiclink_security_group('sg-2a3b4cd5') }
+    it { should have_classiclink_security_group('my-vpc-security-group-name') }
+  end
 end
 
-describe ec2('my-ec2') do
-  it { should exist }
-  it { should be_running }
-  it { should have_tag('Name').value('my-ec2') }
-end
 
-describe ec2('my-ec2-classic') do
-  it { should have_classiclink('my-vpc') }
-  it { should have_classiclink_security_group('sg-2a3b4cd5') }
-  it { should have_classiclink_security_group('my-vpc-security-group-name') }
+describe 'multi security group' do
+  before do
+    Awspec::Stub.load 'ec2_has_multi_security_groups'
+  end
+
+  describe ec2('i-ec12345a') do
+    it { should have_security_groups(['sg-1a2b3cd4', 'sg-5e6f7gh8']) }
+    it { should have_security_groups(['my-security-group-name', 'my-security-group-name-2']) }
+    it { should have_security_groups(['my-security-group-tag-name', 'my-security-group-tag-name-2']) }
+  end
 end

--- a/spec/type/ec2_spec.rb
+++ b/spec/type/ec2_spec.rb
@@ -51,7 +51,6 @@ describe 'single security group' do
   end
 end
 
-
 describe 'multi security group' do
   before do
     Awspec::Stub.load 'ec2_has_multi_security_groups'


### PR DESCRIPTION
Add to check instance's security group wiht array.

So, when instance 'my-ec2' has following security groups:

- my-security-group-name-1
- my-security-group-name-2

This spec is pass.

```
describe ec2('my-ec2') do
  it { should have_security_groups(['my-security-group-name-1', 'my-security-group-name-2']) }
end
```

But, this spec is fail.

```
describe ec2('my-ec2') do
  it { should have_security_groups(['my-security-group-name-1']) }
end
```