### PR TITLE
fix 'be_attached_to' condition in internet_gateway resource type

### DIFF
--- a/lib/awspec/stub/internet_gateway.rb
+++ b/lib/awspec/stub/internet_gateway.rb
@@ -6,7 +6,7 @@ Aws.config[:ec2] = {
         attachments: [
           {
             vpc_id: 'vpc-ab123cde',
-            state: 'attached'
+            state: 'available'
           }
         ],
         tags: [

--- a/lib/awspec/type/internet_gateway.rb
+++ b/lib/awspec/type/internet_gateway.rb
@@ -13,7 +13,7 @@ module Awspec::Type
 
     def attached_to?(vpc)
       resource_via_client.attachments.find do |a|
-        a.vpc_id == find_vpc(vpc).vpc_id && a.state == 'attached'
+        a.vpc_id == find_vpc(vpc).vpc_id && a.state == 'available'
       end
     end
   end


### PR DESCRIPTION
@k1LoW 

Hi, Koyama san.

I fixed the 'be_attached' condition in internet_gateway resource type.(#252) 
Please confirm. 🙏 

Regards.

Yohei