### PR TITLE
Add `be_*` `have_security_group` support for alb

### DIFF
--- a/doc/_resource_types/alb.md
+++ b/doc/_resource_types/alb.md
@@ -1,1 +1,25 @@
-# exist
+### exist
+
+```ruby
+describe alb('my-alb') do
+  it { should exist }
+end
+```
+
+### be_active, be_provisioning, be_failed
+
+```ruby
+describe alb('my-alb') do
+  it { should be_active }
+end
+```
+
+### have_security_group
+
+```ruby
+describe alb('my-alb') do
+  it { should have_security_group('sg-1a2b3cd4') }
+end
+```
+
+

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -73,7 +73,33 @@ ALB resource type.
 
 ### exist
 
-### its(:load_balancer_arn), its(:dns_name), its(:canonical_hosted_zone_id), its(:created_time), its(:load_balancer_name), its(:scheme), its(:vpc_id), its(:state), its(:type), its(:availability_zones), its(:security_groups), its(:ip_address_type)
+```ruby
+describe alb('my-alb') do
+  it { should exist }
+end
+```
+
+
+### be_active, be_provisioning, be_failed
+
+```ruby
+describe alb('my-alb') do
+  it { should be_active }
+end
+```
+
+
+### have_security_group
+
+```ruby
+describe alb('my-alb') do
+  it { should have_security_group('sg-1a2b3cd4') }
+end
+```
+
+
+
+### its(:load_balancer_arn), its(:dns_name), its(:canonical_hosted_zone_id), its(:created_time), its(:load_balancer_name), its(:scheme), its(:vpc_id), its(:type), its(:security_groups), its(:ip_address_type)
 ## <a name="ami">ami</a>
 
 AMI resource type.

--- a/lib/awspec/generator/doc/type/alb.rb
+++ b/lib/awspec/generator/doc/type/alb.rb
@@ -7,8 +7,10 @@ module Awspec::Generator
           @type_name = 'ALB'
           @type = Awspec::Type::Alb.new('my-alb')
           @ret = @type.resource_via_client
-          @matchers = []
-          @ignore_matchers = []
+          @matchers = [
+            Awspec::Type::Alb::STATES.map { |state| 'be_' + state }.join(', ')
+          ]
+          @ignore_matchers = Awspec::Type::Alb::STATES.map { |state| 'be_' + state }
           @describes = []
         end
       end

--- a/lib/awspec/stub/alb.rb
+++ b/lib/awspec/stub/alb.rb
@@ -3,8 +3,201 @@ Aws.config[:elasticloadbalancingv2] = {
     describe_load_balancers: {
       load_balancers: [
         {
-          load_balancer_name: 'my-alb',
-          dns_name: 'my-load-balancer-123456789.us-west-1.elb.amazonaws.com'
+          load_balancer_arn:
+            'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:loadbalancer/app/my-elb/1aa1bb1cc1ddee11',
+          dns_name:
+            'internal-my-elb-1551266724.ap-northeast-1.elb.amazonaws.com',
+          canonical_hosted_zone_id: 'A12BCDEDCBA34BC',
+          created_time: Time.new(2017, 4, 4, 9, 00, 00, '+00:00'),
+          load_balancer_name: 'my-elb',
+          scheme: 'internal',
+          vpc_id: 'vpc-ab123cde',
+          state:
+            {
+              code: 'active',
+              reason: nil
+            },
+          type: 'application',
+          availability_zones:
+            [
+              {
+                zone_name: 'ap-northeast-1a',
+                subnet_id: 'subnet-1234a567'
+              },
+              {
+                zone_name: 'ap-northeast-1c',
+                subnet_id: 'subnet-abcd7890'
+              }
+            ],
+          security_groups: ['sg-1a2b3cd4'],
+          ip_address_type: 'ipv4'
+        }
+      ],
+      next_marker: nil
+    }
+  }
+}
+
+Aws.config[:ec2] = {
+  stub_responses: {
+    describe_security_groups: {
+      security_groups: [
+        {
+          vpc_id: 'vpc-ab123cde',
+          owner_id: '112233445566',
+          group_id: 'sg-1a2b3cd4',
+          group_name: 'my-security-group-name',
+          tags: [
+            {
+              key: 'env',
+              value: 'dev'
+            }
+          ],
+          ip_permissions: [
+            {
+              from_port: 80,
+              to_port: 80,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '123.456.789.012/32'
+                },
+                {
+                  cidr_ip: '456.789.123.456/32'
+                }
+              ],
+              user_id_group_pairs: []
+            },
+            {
+              from_port: 22,
+              to_port: 22,
+              ip_protocol: 'tcp',
+              ip_ranges: [],
+              user_id_group_pairs: [
+                {
+                  group_id: 'sg-5a6b7cd8',
+                  group_name: 'group-name-sg'
+                }
+              ]
+            },
+            {
+              from_port: 60_000,
+              to_port: 60_000,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '100.456.789.012/32'
+                }
+              ],
+              user_id_group_pairs: []
+            },
+            {
+              from_port: 70_000,
+              to_port: 70_000,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '100.456.789.012/32'
+                }
+              ],
+              user_id_group_pairs: []
+            },
+            {
+              from_port: 70_000,
+              to_port: 70_000,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '101.456.789.012/32'
+                }
+              ],
+              user_id_group_pairs: []
+            },
+            {
+              from_port: 50_000,
+              to_port: 50_009,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '123.456.789.012/32'
+                }
+              ],
+              user_id_group_pairs: []
+            },
+            {
+              from_port: nil,
+              to_port: nil,
+              ip_protocol: '-1',
+              ip_ranges: [],
+              user_id_group_pairs: [
+                {
+                  user_id: '1234567890',
+                  group_name: nil,
+                  group_id: 'sg-3a4b5cd6',
+                  vpc_id: nil,
+                  vpc_peering_connection_id: nil,
+                  peering_status: nil
+                }
+              ]
+            }
+          ],
+          ip_permissions_egress: [
+            {
+              from_port: 50_000,
+              to_port: 50_000,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '100.456.789.012/32'
+                }
+              ]
+            },
+            {
+              from_port: 8080,
+              to_port: 8080,
+              ip_protocol: 'tcp',
+              ip_ranges: [],
+              user_id_group_pairs: [
+                {
+                  user_id: '5678901234',
+                  group_name: 'group-in-other-aws-account-with-vpc-peering',
+                  group_id: 'sg-9a8b7c6d',
+                  vpc_id: 'vpc-5b6a7c8f',
+                  vpc_peering_connection_id: 'pcx-f9e8d7c6',
+                  peering_status: 'active'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    describe_subnets: {
+      subnets: [
+        {
+          state: 'available',
+          vpc_id: 'vpc-ab123cde',
+          subnet_id: 'subnet-1234a567',
+          cidr_block: '10.0.1.0/24',
+          tags: [
+            {
+              key: 'Name',
+              value: 'my-subnet'
+            }
+          ]
+        }
+      ]
+    },
+    describe_vpcs: {
+      vpcs: [
+        {
+          vpc_id: 'vpc-ab123cde',
+          tags: [
+            {
+              key: 'Name',
+              value: 'my-vpc'
+            }
+          ]
         }
       ]
     }

--- a/lib/awspec/type/alb.rb
+++ b/lib/awspec/type/alb.rb
@@ -7,5 +7,26 @@ module Awspec::Type
     def id
       @id = resource_via_client.load_balancer_name if resource_via_client
     end
+
+    STATES = %w(
+      active provisioning failed
+    )
+
+    STATES.each do |state|
+      define_method state + '?' do
+        resource_via_client.state.code == state
+      end
+    end
+
+    def has_security_group?(sg_id)
+      sgs = resource_via_client.security_groups
+      ret = sgs.find do |sg|
+        sg == sg_id
+      end
+      return true if ret
+      sg2 = find_security_group(sg_id)
+      return true if sg2.tag_name == sg_id || sg2.group_name == sg_id
+      false
+    end
   end
 end

--- a/spec/type/alb_spec.rb
+++ b/spec/type/alb_spec.rb
@@ -3,8 +3,7 @@ Awspec::Stub.load 'alb'
 
 describe alb('my-alb') do
   it { should exist }
-end
-
-describe alb('my-alb') do
-  its(:dns_name) { should eq 'my-load-balancer-123456789.us-west-1.elb.amazonaws.com' }
+  it { should be_active }
+  its(:dns_name) { should eq 'internal-my-elb-1551266724.ap-northeast-1.elb.amazonaws.com' }
+  it { should have_security_group('sg-1a2b3cd4') }
 end


### PR DESCRIPTION
```ruby
describe alb('my-alb') do
  it { should exist }
  it { should be_active }
  its(:dns_name) { should eq 'internal-my-elb-1551266724.ap-northeast-1.elb.amazonaws.com' }
  it { should have_security_group('sg-1a2b3cd4') }
end
```