### PR TITLE
fix elasticsearch generator

### DIFF
--- a/lib/awspec/generator.rb
+++ b/lib/awspec/generator.rb
@@ -26,6 +26,7 @@ require 'awspec/generator/spec/acm'
 require 'awspec/generator/spec/cloudwatch_logs'
 require 'awspec/generator/spec/alb'
 require 'awspec/generator/spec/internet_gateway'
+require 'awspec/generator/spec/elasticsearch'
 
 # Doc
 require 'awspec/generator/doc/type'

--- a/lib/awspec/generator/spec/elasticsearch.rb
+++ b/lib/awspec/generator/spec/elasticsearch.rb
@@ -1,35 +1,38 @@
 module Awspec::Generator
   module Spec
-    class ElasticSearch
+    class Elasticsearch
       include Awspec::Helper::Finder
       def generate_all
         domains = select_all_elasticsearch_domains
-        raise 'Not Found Domain' if events.empty?
-        ERB.new(domain_spec_template, nil, '-').result(binding).chomp
+        raise 'Not Found Domain' if domains.empty?
+        ERB.new(domain_spec_template, nil, '-').result(binding).gsub(/^\n/, '')
       end
 
       def domain_spec_template
         template = <<-'EOF'
-<% domain.each do |domain| %>
-describe elasticsearch('<%= domain.domain_name %>') do
+<% domains.each do |domain| %>
+describe elasticsearch('<%= domain.domain_status.domain_name %>') do
   it { should exist }
-  <% if domain.ebs_options.created %>
+<% if domain.domain_status.created %>
   it { should be_created }
-  <% end %>
-  <% if domain.ebs_options.deleted %>
+<% end %>
+<% if domain.domain_status.deleted %>
   it { should be_deleted }
-  <% end %>
-  its(:elasticsearch_version) { should eq <%= domain.elasticsearch_version %> }
-  its('elasticsearch_cluster_config.instance_type') { should eq <%= domain.elasticsearch_cluster_config.instance_type %> }
-  its('ebs_options.ebs_enabled') { should eq <%= domain.ebs_options.ebs_enabled %> }
-  <% if domain.ebs_options.ebs_enabled %>
-  its('ebs_options.volume_type') { should eq <%= domain.ebs_options.ebs_volume_type %> }
-  its('ebs_options.volume_size') { should eq <%= domain.ebs_options.ebs_volume_size %> }
-  <% end %>
+<% end %>
+  its(:elasticsearch_version) { should eq '<%= domain.domain_status.elasticsearch_version %>' }
+  its('elasticsearch_cluster_config.instance_type') { should eq '<%= domain.domain_status.elasticsearch_cluster_config.instance_type %>' }
+  its('ebs_options.ebs_enabled') { should eq <%= domain.domain_status.ebs_options.ebs_enabled %> }
+<% if domain.domain_status.ebs_options.ebs_enabled -%>
+  its('ebs_options.volume_type') { should eq '<%= domain.domain_status.ebs_options.volume_type %>' }
+  its('ebs_options.volume_size') { should eq <%= domain.domain_status.ebs_options.volume_size %> }
+<% end %>
   it do
     should have_access_policies <<-policy
-<%= JSON.pretty_generate(JSON.load(domain.access_policies)) %>
+<%= JSON.pretty_generate(JSON.load(domain.domain_status.access_policies)) %>
   policy
+  end
+end
+<% end %>
 EOF
         template
       end

--- a/lib/awspec/helper/finder/elasticsearch.rb
+++ b/lib/awspec/helper/finder/elasticsearch.rb
@@ -9,9 +9,9 @@ module Awspec::Helper
       end
 
       def select_all_elasticsearch_domains
-        domain_names = elastisearch_client.list_domain_names
-        domain_names.map do |domain_name|
-          elasticsearch_client.describe_elasticsearch_domain(domain_name)
+        domain_names = elasticsearch_client.list_domain_names.domain_names
+        domain_names.map do |domain|
+          elasticsearch_client.describe_elasticsearch_domain(domain_name: domain.domain_name)
         end
       end
     end


### PR DESCRIPTION
Hi, @k1LoW 

When I executed `awspec generate elasticsearch`,  I got following error.

```sh
bash-3.2$ AWS_PROFILE=xxxxx AWS_REGION=ap-northeast-1 bundle exec awspec generate elasticsearch
/path/to/awspec/vendor/bundle/ruby/2.3.0/gems/awspec-0.75.1/lib/awspec/command/generate.rb:53:in `eval': uninitialized constant Awspec::Generator::Spec::Elasticsearch (NameError)
```

I fixed Class Name(ElasticSearch => Elasticsearch) because Camelized `Elasticsearch` was `Elasticsearch` as follows.

```sh
bash-3.2$ bundle exec pry
[1] pry(main)> require 'active_support/inflector'
=> true
[2] pry(main)> 'Elasticsearch'.camelize
=> "Elasticsearch"
```

And I fixed some parts of lib/awspec/generator/spec/elasticsearch.rb
Please confirm.

Regards.

Yohei