### PR TITLE
Remove default value from `secrets_path` option, when `awspec generate`

### DIFF
--- a/lib/awspec/command/generate.rb
+++ b/lib/awspec/command/generate.rb
@@ -5,7 +5,7 @@ module Awspec
   class Generate < Thor
     class_option :profile
     class_option :region
-    class_option :secrets_path, default: 'secrets.yml'
+    class_option :secrets_path
 
     types = %w(
       vpc ec2 rds security_group elb network_acl route_table subnet nat_gateway network_interface alb


### PR DESCRIPTION
link https://github.com/k1LoW/awsecrets/pull/13