### PR TITLE
Subnet route table association

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -2199,6 +2199,8 @@ end
 ```
 
 
+### be_associated_to
+
 ### be_available, be_pending
 
 ```ruby

--- a/lib/awspec/type/subnet.rb
+++ b/lib/awspec/type/subnet.rb
@@ -21,13 +21,9 @@ module Awspec::Type
                                                  }
                                                ]
                                              })
-      return false unless res[:route_tables].length == 1
-      route_table = res[:route_tables][0]
-
-      name_tag = route_table.tags.select { |tag| tag.key == 'Name' }
-      name = name_tag.nil? ? nil : name_tag[0].value
-
-      route_table.route_table_id == route_table_id || name == route_table_id
+      return false unless res[:route_tables].length > 0
+      associated_route_table = res[:route_tables].first
+      associated_route_table.route_table_id == route_table_id || associated_route_table.tag_name == route_table_id
     end
 
     STATES = %w(

--- a/lib/awspec/type/subnet.rb
+++ b/lib/awspec/type/subnet.rb
@@ -11,6 +11,25 @@ module Awspec::Type
       @id ||= resource_via_client.subnet_id if resource_via_client
     end
 
+    def associated_to?(route_table_id)
+      res = ec2_client.describe_route_tables({
+                                               filters:
+                                               [
+                                                 {
+                                                   name: 'association.subnet-id',
+                                                   values: [id]
+                                                 }
+                                               ]
+                                             })
+      return false unless res[:route_tables].length == 1
+      route_table = res[:route_tables][0]
+
+      name_tag = route_table.tags.select { |tag| tag.key == 'Name' }
+      name = name_tag.nil? ? nil : name_tag[0].value
+
+      route_table.route_table_id == route_table_id || name == route_table_id
+    end
+
     STATES = %w(
       available pending
     )

--- a/lib/awspec/type/subnet.rb
+++ b/lib/awspec/type/subnet.rb
@@ -21,7 +21,7 @@ module Awspec::Type
                                                  }
                                                ]
                                              })
-      return false unless res[:route_tables].length > 0
+      return false if res[:route_tables].empty?
       associated_route_table = res[:route_tables].first
       associated_route_table.route_table_id == route_table_id || associated_route_table.tag_name == route_table_id
     end


### PR DESCRIPTION
Given a subnet you can assert that it is associated with a particular
route table:

```ruby
describe subnet('PublicSubnetAZ') do
  it { should be_associated_to('PublicRouteTable') }
end
```

https://github.com/aws/aws-sdk-ruby/issues/851