### PR TITLE
[ELB] `has_ec2()` should use comparison operator `==` (not assingment `=`)

### DIFF
--- a/lib/awspec/type/elb.rb
+++ b/lib/awspec/type/elb.rb
@@ -23,7 +23,7 @@ module Awspec::Type
       ec2 = find_ec2(id)
       return nil unless ec2
       resource_via_client.instances.find do |instance|
-        instance.instance_id = ec2.instance_id
+        instance.instance_id == ec2.instance_id
       end
     end
 


### PR DESCRIPTION
Hi @k1LoW 

Maybe typo 😄 

## Environment in which trouble occurs

1. There are two ec2 instance (e.g. `ec2-1` `ec2-2`).
1. `ec2-1` is attached to ELB
1. run the following code:

    ```ruby
    describe elb('ELB') do
      it { should have_ec2('ec2-2') } # => pass 😱
    end
    ```

1. because

    ```ruby
    ec2 = find_ec2(id)  # => `ec2-2`
    return nil unless ec2

    # resource_via_client.instances => [`ec2-1`]
    resource_via_client.instances.find do |instance|
      instance.instance_id = ec2.instance_id # =>  `ec2-1` = `ec2-2` to be true.
    end # => `ec2-1`
    ```