### PR TITLE
Add Elastic IP resource type and Generator

### DIFF
--- a/doc/_resource_types/eip.md
+++ b/doc/_resource_types/eip.md
@@ -1,0 +1,23 @@
+### exist
+
+```ruby
+describe eip('123.0.456.789') do
+  it { should exist }
+end
+```
+
+### be_associated_to
+
+```ruby
+describe eip('123.0.456.789') do
+  it { should be_associated_to('i-ec12345a') }
+end
+```
+
+### belong_to_domain
+
+```ruby
+describe eip('123.0.456.789') do
+  it { should belong_to_domain('vpc') }
+end
+```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -20,6 +20,7 @@
 | [ecs_service](#ecs_service)
 | [ecs_task_definition](#ecs_task_definition)
 | [efs](#efs)
+| [eip](#eip)
 | [elasticache](#elasticache)
 | [elasticache_cache_parameter_group](#elasticache_cache_parameter_group)
 | [elasticsearch](#elasticsearch)
@@ -865,6 +866,37 @@ end
 ```
 
 ### its(:owner_id), its(:creation_token), its(:file_system_id), its(:creation_time), its(:life_cycle_state), its(:name), its(:number_of_mount_targets), its(:performance_mode)
+## <a name="elastic_ip">elastic_ip</a>
+
+Elastic IP resource type.
+
+### exist
+
+```ruby
+describe eip('123.0.456.789') do
+  it { should exist }
+end
+```
+
+
+### be_associated_to
+
+```ruby
+describe eip('123.0.456.789') do
+  it { should be_associated_to('i-ec12345a') }
+end
+```
+
+
+### belong_to_domain
+
+```ruby
+describe eip('123.0.456.789') do
+  it { should belong_to_domain('vpc') }
+end
+```
+
+
 ## <a name="elasticache">elasticache</a>
 
 Elasticache resource type.

--- a/lib/awspec/command/generate.rb
+++ b/lib/awspec/command/generate.rb
@@ -39,7 +39,7 @@ module Awspec
     types_for_generate_all = %w(
       cloudwatch_alarm cloudwatch_event directconnect ebs efs
       elasticsearch iam_group iam_policy iam_role iam_user kms lambda
-      acm cloudwatch_logs
+      acm cloudwatch_logs eip
     )
 
     types_for_generate_all.each do |type|

--- a/lib/awspec/generator.rb
+++ b/lib/awspec/generator.rb
@@ -27,6 +27,7 @@ require 'awspec/generator/spec/cloudwatch_logs'
 require 'awspec/generator/spec/alb'
 require 'awspec/generator/spec/internet_gateway'
 require 'awspec/generator/spec/elasticsearch'
+require 'awspec/generator/spec/eip'
 
 # Doc
 require 'awspec/generator/doc/type'

--- a/lib/awspec/generator/doc/type/eip.rb
+++ b/lib/awspec/generator/doc/type/eip.rb
@@ -1,0 +1,17 @@
+module Awspec::Generator
+  module Doc
+    module Type
+      class Eip < Base
+        def initialize
+          super
+          @type_name = 'Elastic IP'
+          @type = Awspec::Type::Eip.new('123.0.456.789')
+          @ret = @type.resource_via_client
+          @matchers = ['belong_to_domain']
+          @ignore_matchers = []
+          @describes = []
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/generator/spec/eip.rb
+++ b/lib/awspec/generator/spec/eip.rb
@@ -1,0 +1,30 @@
+module Awspec::Generator
+  module Spec
+    class Eip
+      include Awspec::Helper::Finder
+      def select_all_addresses
+        res = ec2_client.describe_addresses
+        res.addresses
+      end
+
+      def generate_all
+        eips = select_all_addresses
+        raise 'Not Found Elastic IP addresses.' if eips.empty?
+        ERB.new(eip_spec_template, nil, '-').result(binding).chomp
+      end
+
+      def eip_spec_template
+        template = <<-'EOF'
+<% eips.each do |eip| %>
+describe eip('<%= eip.public_ip %>') do
+  it { should exist }
+  it { should be_associated_to('<%= eip.instance_id %>') }
+  it { should belong_to_domain('<%= eip.domain %>') }
+end
+<% end %>
+EOF
+        template
+      end
+    end
+  end
+end

--- a/lib/awspec/helper/finder/ec2.rb
+++ b/lib/awspec/helper/finder/ec2.rb
@@ -109,6 +109,11 @@ module Awspec::Helper
         res.addresses
       end
 
+      def select_eip_by_public_ip(id)
+        res = ec2_client.describe_addresses
+        res.addresses.select { |address| address.public_ip == id }
+      end
+
       def select_network_interface_by_instance_id(id)
         res = ec2_client.describe_network_interfaces({
                                                        filters: [{ name: 'attachment.instance-id', values: [id] }]

--- a/lib/awspec/helper/finder/ec2.rb
+++ b/lib/awspec/helper/finder/ec2.rb
@@ -110,8 +110,10 @@ module Awspec::Helper
       end
 
       def select_eip_by_public_ip(id)
-        res = ec2_client.describe_addresses
-        res.addresses.select { |address| address.public_ip == id }
+        res = ec2_client.describe_addresses({
+                                              filters: [{ name: 'public-ip', values: [id] }]
+                                            })
+        res.addresses
       end
 
       def select_network_interface_by_instance_id(id)

--- a/lib/awspec/helper/type.rb
+++ b/lib/awspec/helper/type.rb
@@ -15,7 +15,7 @@ module Awspec
         network_acl network_interface rds rds_db_cluster_parameter_group rds_db_parameter_group route53_hosted_zone
         route_table s3_bucket security_group ses_identity subnet vpc cloudfront_distribution
         elastictranscoder_pipeline waf_web_acl customer_gateway vpn_gateway vpn_connection internet_gateway acm
-        cloudwatch_logs dynamodb_table
+        cloudwatch_logs dynamodb_table eip
       )
 
       ACCOUNT_ATTRIBUTES = %w(

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -54,3 +54,6 @@ require 'awspec/matcher/have_subscription_filter'
 # DynamoDB
 require 'awspec/matcher/have_attribute_definition'
 require 'awspec/matcher/have_key_schema'
+
+# EIP
+require 'awspec/matcher/belong_to_domain'

--- a/lib/awspec/matcher/belong_to_domain.rb
+++ b/lib/awspec/matcher/belong_to_domain.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :belong_to_domain do |domain|
+  match do |type|
+    return true if type.resource_via_client.last[:domain] == domain
+  end
+end

--- a/lib/awspec/stub/eip.rb
+++ b/lib/awspec/stub/eip.rb
@@ -1,0 +1,13 @@
+Aws.config[:ec2] = {
+  stub_responses: {
+    describe_addresses: {
+      addresses: [
+        {
+          domain: 'vpc',
+          public_ip: '123.0.456.789',
+          instance_id: 'i-ec12345a'
+        }
+      ]
+    }
+  }
+}

--- a/lib/awspec/type/eip.rb
+++ b/lib/awspec/type/eip.rb
@@ -1,0 +1,16 @@
+module Awspec::Type
+  class Eip < ResourceBase
+    def resource_via_client
+      @resource_via_client ||= select_eip_by_public_ip(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.last.public_ip if resource_via_client
+    end
+
+    def associated_to?(instance_id)
+      return false unless resource_via_client.last.instance_id == instance_id
+      resource_via_client.last.instance_id == instance_id
+    end
+  end
+end

--- a/spec/type/eip_spec.rb
+++ b/spec/type/eip_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+Awspec::Stub.load 'eip'
+
+describe eip('123.0.456.789') do
+  it { should exist }
+  it { should be_associated_to('i-ec12345a') }
+  it { should belong_to_domain('vpc') }
+end


### PR DESCRIPTION
Hi, @k1LoW 

I added "eip resource type", Because I want to do test "eip".

## exist

```ruby
describe eip('123.0.456.789') do
  it { should exist }
end
```

## be_associated_to

```ruby
describe eip('123.0.456.789') do
  it { should be_associated_to('i-ec12345a') }
end
```

## belong_to_domain

```ruby
describe eip('123.0.456.789') do
  it { should belong_to_domain('vpc') }
end
```

## generate

```sh
$ bundle exec awspec generate eip --profile my-profile --region ap-northeast-1

describe eip('xx.xxx.xxx.xxx') do
  it { should exist }
  it { should be_associated_to('i-xxxxxxxxxxxxxxxxxx') }
  it { should belong_to_domain('vpc') }
end
```

Please confirm. 🙏 
Regards.

Yohei

