### PR TITLE
find subnet by cidr

### DIFF
--- a/lib/awspec/helper/finder/subnet.rb
+++ b/lib/awspec/helper/finder/subnet.rb
@@ -1,16 +1,23 @@
 module Awspec::Helper
   module Finder
     module Subnet
-      def find_subnet(subnet_id)
+      def filter_type_matcher(search_key)
+        deafult = 'tag:Name'
+        case search_key
+        when /subnet-[a-zA-Z0-9]{8}/
+          return 'subnet-id'
+        when %r{[1-9][0-9]{1,2}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}//[0-9]{1,3}}
+          return 'cidrBlock'
+        else
+          return deafult
+        end
+      end
+
+      def find_subnet(search_key)
         res = ec2_client.describe_subnets({
-                                            filters: [{ name: 'subnet-id', values: [subnet_id] }]
+                                            filters: [{ name: filter_type_matcher(search_key), values: [search_key] }]
                                           })
-        resource = res.subnets.single_resource(subnet_id)
-        return resource if resource
-        res = ec2_client.describe_subnets({
-                                            filters: [{ name: 'tag:Name', values: [subnet_id] }]
-                                          })
-        res.subnets.single_resource(subnet_id)
+        res.subnets.single_resource(search_key)
       end
 
       def select_subnet_by_vpc_id(vpc_id)

--- a/spec/type/subnet_spec.rb
+++ b/spec/type/subnet_spec.rb
@@ -13,3 +13,11 @@ describe subnet('my-subnet') do
   end
   it { should have_tag('Name').value('my-subnet') }
 end
+
+describe subnet('subnet-1234a567') do
+  it { should exist }
+end
+
+describe subnet('10.0.1.0/24') do
+  it { should exist }
+end


### PR DESCRIPTION
Change helper to find subnet by cidr
I want to do test like this 

```
describe subnet('10.0.1.0/24') do
  it { should exist }
end
```

and refactor `find_subnet` function. To reduce the number of AWS API executions.

