### PR TITLE
Fix: Find subnet by cidr

### DIFF
--- a/lib/awspec/helper/finder/subnet.rb
+++ b/lib/awspec/helper/finder/subnet.rb
@@ -1,23 +1,21 @@
 module Awspec::Helper
   module Finder
     module Subnet
-      def filter_type_matcher(search_key)
-        deafult = 'tag:Name'
-        case search_key
-        when /subnet-[a-zA-Z0-9]{8}/
-          return 'subnet-id'
-        when %r{[1-9][0-9]{1,2}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}//[0-9]{1,3}}
-          return 'cidrBlock'
-        else
-          return deafult
-        end
-      end
-
-      def find_subnet(search_key)
+      def find_subnet(subnet_id)
         res = ec2_client.describe_subnets({
-                                            filters: [{ name: filter_type_matcher(search_key), values: [search_key] }]
+                                            filters: [{ name: 'subnet-id', values: [subnet_id] }]
                                           })
-        res.subnets.single_resource(search_key)
+        resource = res.subnets.single_resource(subnet_id)
+        return resource if resource
+        res = ec2_client.describe_subnets({
+                                            filters: [{ name: 'tag:Name', values: [subnet_id] }]
+                                          })
+        resource = res.subnets.single_resource(subnet_id)
+        return resource if resource
+        res = ec2_client.describe_subnets({
+                                            filters: [{ name: 'cidrBlock', values: [subnet_id] }]
+                                          })
+        res.subnets.single_resource(subnet_id)
       end
 
       def select_subnet_by_vpc_id(vpc_id)

--- a/spec/type/subnet_spec.rb
+++ b/spec/type/subnet_spec.rb
@@ -13,11 +13,3 @@ describe subnet('my-subnet') do
   end
   it { should have_tag('Name').value('my-subnet') }
 end
-
-describe subnet('subnet-1234a567') do
-  it { should exist }
-end
-
-describe subnet('10.0.1.0/24') do
-  it { should exist }
-end


### PR DESCRIPTION
Fix #280 bug

Hi @k1LoW 

Sorry... 
CIDR regex is incorrect in `filter_type_matcher` method that I added at #280. 
I made a mistake. Because  `rake spec` test have passed. (When I fixed rubocop test, this bug was injected)
But, `Aws::ClientStubs` is always return correct value ignore `filters` in `ec2_client.describe_subnets`. I did not understand it.

`rake spec` can't test `filter_type_matcher` method.  Therefore I'm delete it and revert previous code format.

I’m apologize for this bug. Please re-review this PR. 