### PR TITLE
Add some matcher for autoscaling_group and launch_configuration resource

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -159,6 +159,8 @@ end
 ```
 
 
+### have_suspended_process
+
 ### have_tag
 
 ```ruby
@@ -167,7 +169,7 @@ describe autoscaling_group('my-auto-scaling-group') do
 end
 ```
 
-### its(:auto_scaling_group_name), its(:auto_scaling_group_arn), its(:launch_configuration_name), its(:min_size), its(:max_size), its(:desired_capacity), its(:default_cooldown), its(:availability_zones), its(:load_balancer_names), its(:target_group_arns), its(:health_check_type), its(:health_check_grace_period), its(:created_time), its(:suspended_processes), its(:placement_group), its(:vpc_zone_identifier), its(:enabled_metrics), its(:status), its(:termination_policies), its(:new_instances_protected_from_scale_in)
+### its(:auto_scaling_group_name), its(:auto_scaling_group_arn), its(:launch_configuration_name), its(:min_size), its(:max_size), its(:desired_capacity), its(:default_cooldown), its(:availability_zones), its(:load_balancer_names), its(:target_group_arns), its(:health_check_type), its(:health_check_grace_period), its(:created_time), its(:placement_group), its(:vpc_zone_identifier), its(:enabled_metrics), its(:status), its(:termination_policies), its(:new_instances_protected_from_scale_in)
 ## <a name="cloudfront_distribution">cloudfront_distribution</a>
 
 CloudfrontDistribution resource type.
@@ -1548,6 +1550,8 @@ end
 ```
 
 
+### have_block_device_mapping
+
 ### have_security_group
 
 ```ruby
@@ -1556,7 +1560,7 @@ describe launch_configuration('my-lc') do
 end
 ```
 
-### its(:launch_configuration_name), its(:launch_configuration_arn), its(:image_id), its(:key_name), its(:security_groups), its(:classic_link_vpc_id), its(:classic_link_vpc_security_groups), its(:user_data), its(:instance_type), its(:kernel_id), its(:ramdisk_id), its(:block_device_mappings), its(:spot_price), its(:iam_instance_profile), its(:created_time), its(:ebs_optimized), its(:associate_public_ip_address), its(:placement_tenancy)
+### its(:launch_configuration_name), its(:launch_configuration_arn), its(:image_id), its(:key_name), its(:security_groups), its(:classic_link_vpc_id), its(:classic_link_vpc_security_groups), its(:user_data), its(:instance_type), its(:kernel_id), its(:ramdisk_id), its(:spot_price), its(:iam_instance_profile), its(:created_time), its(:ebs_optimized), its(:associate_public_ip_address), its(:placement_tenancy)
 ## <a name="nat_gateway">nat_gateway</a>
 
 NatGateway resource type.

--- a/lib/awspec/stub/autoscaling_group.rb
+++ b/lib/awspec/stub/autoscaling_group.rb
@@ -35,6 +35,11 @@ Aws.config[:autoscaling] = {
               key: 'name',
               value: 'my-autoscaling-group'
             }
+          ],
+          suspended_processes: [
+            {
+              process_name: 'HealthCheck'
+            }
           ]
         }
       ]

--- a/lib/awspec/stub/launch_configuration.rb
+++ b/lib/awspec/stub/launch_configuration.rb
@@ -15,7 +15,12 @@ Aws.config[:autoscaling] = {
         instance_type: 'c3.large',
         kernel_id: '',
         ramdisk_id: '',
-        block_device_mappings: [],
+        block_device_mappings: [
+          {
+            virtual_name: 'ephemeral0',
+            device_name: '/dev/sdf'
+          }
+        ],
         instance_monitoring: {
           enabled: true
         },

--- a/lib/awspec/type/autoscaling_group.rb
+++ b/lib/awspec/type/autoscaling_group.rb
@@ -24,5 +24,11 @@ module Awspec::Type
         instance.instance_id = ec2.instance_id
       end
     end
+
+    def has_suspended_process?(id)
+      resource_via_client.suspended_processes.find do |process|
+        process.process_name == id
+      end
+    end
   end
 end

--- a/lib/awspec/type/launch_configuration.rb
+++ b/lib/awspec/type/launch_configuration.rb
@@ -19,5 +19,12 @@ module Awspec::Type
         sg == sg2.group_id
       end
     end
+
+    def has_block_device_mapping?(id)
+      resource_via_client.block_device_mappings.find do |device|
+        return true if device.device_name == id
+        return true if device.virtual_name == id
+      end
+    end
   end
 end

--- a/spec/type/autoscaling_group_spec.rb
+++ b/spec/type/autoscaling_group_spec.rb
@@ -12,6 +12,7 @@ describe autoscaling_group('my-auto-scaling-group') do
   it { should have_ec2('my-ec2') }
   it { should have_elb('my-elb') }
   it { should have_tag('name').value('my-autoscaling-group') }
+  it { should have_suspended_process('HealthCheck') }
 end
 
 # deprecated

--- a/spec/type/launch_configuration_spec.rb
+++ b/spec/type/launch_configuration_spec.rb
@@ -5,4 +5,6 @@ describe launch_configuration('my-lc') do
   it { should exist }
   it { should have_security_group('my-security-group-name') }
   its(:associate_public_ip_address) { should eq true }
+  it { should have_block_device_mapping('/dev/sdf') }
+  it { should have_block_device_mapping('ephemeral0') }
 end


### PR DESCRIPTION
Hi, @k1LoW

I added some matcher for autoscaling_group and launch_configuration resource.

### have_suspended_process

```ruby
describe autoscaling_group('my-auto-scaling-group') do
...
  it { should have_suspended_process('HealthCheck') }
end
```

### have_block_device_mapping

```ruby
describe launch_configuration('my-lc') do
  ...
  it { should have_block_device_mapping('/dev/sdf') }
  it { should have_block_device_mapping('ephemeral0') }
end
```

Please confirm. 🙏
Regards.

Yohei
