### PR TITLE
Support for VPC filter in the route tables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
 
 before_install:
   - gem update --system
-  
+  - gem install rspec
+
 script:
   - bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
 
 before_install:
   - gem update --system
-  - gem install rspec
 
 script:
   - bundle exec rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in awspec.gemspec
 gemspec
-
-group :test do
-  gem 'rspec'
-  gem 'rake'
-end

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in awspec.gemspec
 gemspec
+
+group :test do
+  gem 'rspec'
+  gem 'rake'
+end

--- a/lib/awspec/helper/finder/vpc.rb
+++ b/lib/awspec/helper/finder/vpc.rb
@@ -13,14 +13,18 @@ module Awspec::Helper
         res.vpcs.single_resource(id)
       end
 
-      def find_route_table(route_table_id)
+      def vpc_id_filter(vpc_id)
+        vpc_id.nil? ? []:[{ name: 'vpc-id', values: [vpc_id] }]
+      end
+
+      def find_route_table(route_table_id, vpc_id=nil)
         res = ec2_client.describe_route_tables({
-                                                 filters: [{ name: 'route-table-id', values: [route_table_id] }]
+                                                 filters: vpc_id_filter(vpc_id) + [{ name: 'route-table-id', values: [route_table_id] }]
                                                })
         resource = res.route_tables.single_resource(route_table_id)
         return resource if resource
         res = ec2_client.describe_route_tables({
-                                                 filters: [{ name: 'tag:Name', values: [route_table_id] }]
+                                                 filters: vpc_id_filter(vpc_id) + [{ name: 'tag:Name', values: [route_table_id] }]
                                                })
         res.route_tables.single_resource(route_table_id)
       end
@@ -39,14 +43,14 @@ module Awspec::Helper
 
       def select_route_table_by_vpc_id(vpc_id)
         res = ec2_client.describe_route_tables({
-                                                 filters: [{ name: 'vpc-id', values: [vpc_id] }]
+                                                 filters: vpc_id_filter(vpc_id)
                                                })
         res.route_tables
       end
 
       def select_network_acl_by_vpc_id(vpc_id)
         res = ec2_client.describe_network_acls({
-                                                 filters: [{ name: 'vpc-id', values: [vpc_id] }]
+                                                 filters: vpc_id_filter(vpc_id)
                                                })
         res.network_acls
       end

--- a/lib/awspec/helper/finder/vpc.rb
+++ b/lib/awspec/helper/finder/vpc.rb
@@ -14,29 +14,33 @@ module Awspec::Helper
       end
 
       def vpc_id_filter(vpc_id)
-        vpc_id.nil? ? []:[{ name: 'vpc-id', values: [vpc_id] }]
+        vpc_id.nil? ? [] : [{ name: 'vpc-id', values: [vpc_id] }]
       end
 
-      def find_route_table(route_table_id, vpc_id=nil)
+      def find_route_table(route_table_id, vpc_id = nil)
         res = ec2_client.describe_route_tables({
-                                                 filters: vpc_id_filter(vpc_id) + [{ name: 'route-table-id', values: [route_table_id] }]
+                                                 filters: vpc_id_filter(vpc_id) +
+                                                  [{ name: 'route-table-id', values: [route_table_id] }]
                                                })
         resource = res.route_tables.single_resource(route_table_id)
         return resource if resource
         res = ec2_client.describe_route_tables({
-                                                 filters: vpc_id_filter(vpc_id) + [{ name: 'tag:Name', values: [route_table_id] }]
+                                                 filters: vpc_id_filter(vpc_id) +
+                                                  [{ name: 'tag:Name', values: [route_table_id] }]
                                                })
         res.route_tables.single_resource(route_table_id)
       end
 
-      def find_network_acl(id, vpc_id=nil)
+      def find_network_acl(id, vpc_id = nil)
         res = ec2_client.describe_network_acls({
-                                                 filters: vpc_id_filter(vpc_id) +[{ name: 'network-acl-id', values: [id] }]
+                                                 filters: vpc_id_filter(vpc_id) +
+                                                  [{ name: 'network-acl-id', values: [id] }]
                                                })
         resource = res.network_acls.single_resource(id)
         return resource if resource
         res = ec2_client.describe_network_acls({
-                                                 filters: vpc_id_filter(vpc_id) +[{ name: 'tag:Name', values: [id] }]
+                                                 filters: vpc_id_filter(vpc_id) +
+                                                  [{ name: 'tag:Name', values: [id] }]
                                                })
         res.network_acls.single_resource(id)
       end

--- a/lib/awspec/helper/finder/vpc.rb
+++ b/lib/awspec/helper/finder/vpc.rb
@@ -29,14 +29,14 @@ module Awspec::Helper
         res.route_tables.single_resource(route_table_id)
       end
 
-      def find_network_acl(id)
+      def find_network_acl(id, vpc_id=nil)
         res = ec2_client.describe_network_acls({
-                                                 filters: [{ name: 'network-acl-id', values: [id] }]
+                                                 filters: vpc_id_filter(vpc_id) +[{ name: 'network-acl-id', values: [id] }]
                                                })
         resource = res.network_acls.single_resource(id)
         return resource if resource
         res = ec2_client.describe_network_acls({
-                                                 filters: [{ name: 'tag:Name', values: [id] }]
+                                                 filters: vpc_id_filter(vpc_id) +[{ name: 'tag:Name', values: [id] }]
                                                })
         res.network_acls.single_resource(id)
       end

--- a/lib/awspec/helper/type.rb
+++ b/lib/awspec/helper/type.rb
@@ -22,14 +22,20 @@ module Awspec
         ec2_account_attributes rds_account_attributes lambda_account_settings ses_send_quota
       )
 
+      def class_from_string(str)
+        str.split('::').inject(Object) do |mod, class_name|
+          mod.const_get(class_name)
+        end
+      end
+
       TYPES.each do |type|
         require "awspec/type/#{type}"
         define_method type do |*args|
           unless Object.const_get("Awspec::Type::#{type.camelize}").superclass.to_s == 'Awspec::Type::ResourceBase'
             raise "Awspec::Type::#{type.camelize} should extend Awspec::Type::ResourceBase"
           end
-          name = args.first
-          eval "Awspec::Type::#{type.camelize}.new(name)"
+          name, params = args.first(2)
+          class_from_string("Awspec::Type::#{type.camelize}").new(name, params)
         end
       end
 
@@ -40,7 +46,7 @@ module Awspec
                  == 'Awspec::Type::AccountAttributeBase'
             raise "Awspec::Type::#{type.camelize} should extend Awspec::Type::AccountAttributeBase"
           end
-          eval "Awspec::Type::#{type.camelize}.new"
+          class_from_string("Awspec::Type::#{type.camelize}").new()
         end
       end
 

--- a/lib/awspec/helper/type.rb
+++ b/lib/awspec/helper/type.rb
@@ -46,7 +46,7 @@ module Awspec
                  == 'Awspec::Type::AccountAttributeBase'
             raise "Awspec::Type::#{type.camelize} should extend Awspec::Type::AccountAttributeBase"
           end
-          class_from_string("Awspec::Type::#{type.camelize}").new()
+          class_from_string("Awspec::Type::#{type.camelize}").new
         end
       end
 

--- a/lib/awspec/type/customer_gateway.rb
+++ b/lib/awspec/type/customer_gateway.rb
@@ -2,7 +2,7 @@ module Awspec::Type
   class CustomerGateway < ResourceBase
     tags_allowed
 
-    def initialize(name)
+    def initialize(name, params = nil)
       super
       @display_name = name
     end

--- a/lib/awspec/type/directconnect_virtual_interface.rb
+++ b/lib/awspec/type/directconnect_virtual_interface.rb
@@ -1,6 +1,6 @@
 module Awspec::Type
   class DirectconnectVirtualInterface < ResourceBase
-    def initialize(name)
+    def initialize(name, params = nil)
       super
       @display_name = name
     end

--- a/lib/awspec/type/ebs.rb
+++ b/lib/awspec/type/ebs.rb
@@ -3,7 +3,7 @@ module Awspec::Type
     aws_resource Aws::EC2::Volume
     tags_allowed
 
-    def initialize(name)
+    def initialize(name, params = nil)
       super
       @display_name = name
     end

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -3,7 +3,7 @@ module Awspec::Type
     aws_resource Aws::EC2::Instance
     tags_allowed
 
-    def initialize(name)
+    def initialize(name, params = nil)
       super
       @display_name = name
     end

--- a/lib/awspec/type/ecr_repository.rb
+++ b/lib/awspec/type/ecr_repository.rb
@@ -2,7 +2,7 @@ module Awspec::Type
   class EcrRepository < ResourceBase
     aws_resource Aws::ECR::Types::Repository
 
-    def initialize(repository_name)
+    def initialize(repository_name, params = nil)
       super
       @display_name = repository_name
     end

--- a/lib/awspec/type/ecs_cluster.rb
+++ b/lib/awspec/type/ecs_cluster.rb
@@ -1,6 +1,6 @@
 module Awspec::Type
   class EcsCluster < ResourceBase
-    def initialize(name)
+    def initialize(name, params = nil)
       super
       @display_name = name
     end

--- a/lib/awspec/type/ecs_container_instance.rb
+++ b/lib/awspec/type/ecs_container_instance.rb
@@ -2,7 +2,7 @@ module Awspec::Type
   class EcsContainerInstance < ResourceBase
     attr_accessor :cluster
 
-    def initialize(container_instance)
+    def initialize(container_instance, params = nil)
       super
       @display_name = container_instance.split('/').last
     end

--- a/lib/awspec/type/ecs_service.rb
+++ b/lib/awspec/type/ecs_service.rb
@@ -1,6 +1,6 @@
 module Awspec::Type
   class EcsService < ResourceBase
-    def initialize(service)
+    def initialize(service, params = nil)
       super
       @display_name = service
     end

--- a/lib/awspec/type/ecs_task_definition.rb
+++ b/lib/awspec/type/ecs_task_definition.rb
@@ -1,6 +1,6 @@
 module Awspec::Type
   class EcsTaskDefinition < ResourceBase
-    def initialize(taskdef)
+    def initialize(taskdef, params = nil)
       super
       @display_name = taskdef
     end

--- a/lib/awspec/type/efs.rb
+++ b/lib/awspec/type/efs.rb
@@ -1,6 +1,6 @@
 module Awspec::Type
   class Efs < ResourceBase
-    def initialize(file_system_id)
+    def initialize(file_system_id, params = nil)
       super
       @display_name = file_system_id
     end

--- a/lib/awspec/type/elasticache.rb
+++ b/lib/awspec/type/elasticache.rb
@@ -1,6 +1,6 @@
 module Awspec::Type
   class Elasticache < ResourceBase
-    def initialize(name)
+    def initialize(name, paams = nil)
       super
       @display_name = name
     end

--- a/lib/awspec/type/elasticache_cache_parameter_group.rb
+++ b/lib/awspec/type/elasticache_cache_parameter_group.rb
@@ -1,6 +1,6 @@
 module Awspec::Type
   class ElasticacheCacheParameterGroup < ResourceBase
-    def initialize(name)
+    def initialize(name, params = nil)
       super
       @display_name = name
     end

--- a/lib/awspec/type/network_acl.rb
+++ b/lib/awspec/type/network_acl.rb
@@ -6,7 +6,7 @@ module Awspec::Type
 
     def initialize(display_name = nil, params = nil)
       super(display_name, params)
-      @vpc_id = @params.fetch(:vpc_id, nil)
+      @vpc_id = params.nil? ? nil : @params.fetch(:vpc_id, nil)
     end
 
     def resource_via_client

--- a/lib/awspec/type/network_acl.rb
+++ b/lib/awspec/type/network_acl.rb
@@ -2,15 +2,9 @@ module Awspec::Type
   class NetworkAcl < ResourceBase
     aws_resource Aws::EC2::NetworkAcl
     tags_allowed
-    attr_reader :vpc_id
-
-    def initialize(display_name = nil, params = nil)
-      super(display_name, params)
-      @vpc_id = params.nil? ? nil : @params.fetch(:vpc_id, nil)
-    end
 
     def resource_via_client
-      @resource_via_client ||= find_network_acl(@display_name, @vpc_id)
+      @resource_via_client ||= find_network_acl(@display_name, @params['vpc_id'])
     end
 
     def id

--- a/lib/awspec/type/network_acl.rb
+++ b/lib/awspec/type/network_acl.rb
@@ -2,9 +2,15 @@ module Awspec::Type
   class NetworkAcl < ResourceBase
     aws_resource Aws::EC2::NetworkAcl
     tags_allowed
+    attr_reader :vpc_id
+
+    def initialize(display_name = nil, params = nil)
+      super(display_name, params)
+      @vpc_id = @params.fetch(:vpc_id, nil)
+    end
 
     def resource_via_client
-      @resource_via_client ||= find_network_acl(@display_name)
+      @resource_via_client ||= find_network_acl(@display_name, @vpc_id)
     end
 
     def id

--- a/lib/awspec/type/resource_base.rb
+++ b/lib/awspec/type/resource_base.rb
@@ -1,9 +1,10 @@
 module Awspec::Type
   class ResourceBase < Base
-    attr_reader :id, :resource_via_client
+    attr_reader :id, :resource_via_client, :params
 
-    def initialize(display_name = nil)
+    def initialize(display_name = nil, params = nil)
       @display_name = display_name
+      @params = params
       @id = nil
     end
 

--- a/lib/awspec/type/resource_base.rb
+++ b/lib/awspec/type/resource_base.rb
@@ -2,9 +2,9 @@ module Awspec::Type
   class ResourceBase < Base
     attr_reader :id, :resource_via_client, :params
 
-    def initialize(display_name = nil, params = nil)
+    def initialize(display_name = nil, params = {})
       @display_name = display_name
-      @params = params
+      @params = params.nil? ? {} : params
       @id = nil
     end
 

--- a/lib/awspec/type/route_table.rb
+++ b/lib/awspec/type/route_table.rb
@@ -2,9 +2,15 @@ module Awspec::Type
   class RouteTable < ResourceBase
     aws_resource Aws::EC2::RouteTable
     tags_allowed
+    attr_reader :vpc_id
+
+    def initialize(display_name = nil, params = nil)
+      super(display_name, params)
+      @vpc_id = @params.fetch(:vpc_id, nil)
+    end
 
     def resource_via_client
-      @resource_via_client ||= find_route_table(@display_name)
+      @resource_via_client ||= find_route_table(@display_name, @vpc_id)
     end
 
     def id

--- a/lib/awspec/type/route_table.rb
+++ b/lib/awspec/type/route_table.rb
@@ -2,15 +2,9 @@ module Awspec::Type
   class RouteTable < ResourceBase
     aws_resource Aws::EC2::RouteTable
     tags_allowed
-    attr_reader :vpc_id
-
-    def initialize(display_name = nil, params = nil)
-      super(display_name, params)
-      @vpc_id = params.nil? ? nil : @params.fetch(:vpc_id, nil)
-    end
 
     def resource_via_client
-      @resource_via_client ||= find_route_table(@display_name, @vpc_id)
+      @resource_via_client ||= find_route_table(@display_name, @params['vpc_id'])
     end
 
     def id

--- a/lib/awspec/type/route_table.rb
+++ b/lib/awspec/type/route_table.rb
@@ -6,7 +6,7 @@ module Awspec::Type
 
     def initialize(display_name = nil, params = nil)
       super(display_name, params)
-      @vpc_id = @params.fetch(:vpc_id, nil)
+      @vpc_id = params.nil? ? nil : @params.fetch(:vpc_id, nil)
     end
 
     def resource_via_client

--- a/lib/awspec/type/vpc.rb
+++ b/lib/awspec/type/vpc.rb
@@ -28,9 +28,9 @@ module Awspec::Type
     end
 
     def has_network_acl?(table_id)
-      n = find_network_acl(table_id)
+      n = find_network_acl(table_id, id)
       return false unless n
-      n.vpc_id == id
+      true
     end
   end
 end

--- a/lib/awspec/type/vpc.rb
+++ b/lib/awspec/type/vpc.rb
@@ -22,9 +22,9 @@ module Awspec::Type
     end
 
     def has_route_table?(table_id)
-      route_table = find_route_table(table_id)
+      route_table = find_route_table(table_id, id)
       return false unless route_table
-      route_table.vpc_id == id
+      true
     end
 
     def has_network_acl?(table_id)

--- a/lib/awspec/type/vpn_connection.rb
+++ b/lib/awspec/type/vpn_connection.rb
@@ -2,7 +2,7 @@ module Awspec::Type
   class VpnConnection < ResourceBase
     tags_allowed
 
-    def initialize(name)
+    def initialize(name, params = nil)
       super
       @display_name = name
     end

--- a/lib/awspec/type/vpn_gateway.rb
+++ b/lib/awspec/type/vpn_gateway.rb
@@ -2,7 +2,7 @@ module Awspec::Type
   class VpnGateway < ResourceBase
     tags_allowed
 
-    def initialize(name)
+    def initialize(name, params = nil)
       super
       @display_name = name
     end

--- a/spec/type/network_acl_spec.rb
+++ b/spec/type/network_acl_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 Awspec::Stub.load 'network_acl'
 
-describe network_acl('my-network-acl', 'my-vpc') do
+describe network_acl('my-network-acl', vpc_id: 'my-vpc') do
   it { should exist }
   it { should belong_to_vpc('my-vpc') }
   it { should have_subnet('my-subnet') }

--- a/spec/type/network_acl_spec.rb
+++ b/spec/type/network_acl_spec.rb
@@ -1,6 +1,23 @@
 require 'spec_helper'
 Awspec::Stub.load 'network_acl'
 
+describe network_acl('my-network-acl', 'my-vpc') do
+  it { should exist }
+  it { should belong_to_vpc('my-vpc') }
+  it { should have_subnet('my-subnet') }
+  its(:inbound) { should be_allowed(80).protocol('tcp').source('123.0.456.789/32') }
+  its(:inbound) { should be_denied.rule_number('*').source('0.0.0.0/0') }
+  its(:outbound) { should be_allowed.protocol('ALL').source('0.0.0.0/0') }
+  its(:inbound_entries_count) { should eq 3 }
+  its(:outbound_entries_count) { should eq 2 }
+  context 'nested attribute call' do
+    its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }
+    its('resource.vpc.id') { should eq 'vpc-ab123cde' }
+    its('vpc.id') { should eq 'vpc-ab123cde' }
+  end
+  it { should have_tag('Name').value('my-network-acl') }
+end
+
 describe network_acl('my-network-acl') do
   it { should exist }
   it { should belong_to_vpc('my-vpc') }


### PR DESCRIPTION
This commit changes the base resource adding the ability to pass extra
parameteres to them in the constructor. These parameters could be used
to filter the resource adding more context or for any other purpose.

The scenario that I'm trying to address here is the same than the issue
number #223. In the deploy that I'm working now, I have multiple route
tables with the same belonging to different VPCs.