### PR TITLE
Fix issue of security group check in alb

### DIFF
--- a/lib/awspec/type/alb.rb
+++ b/lib/awspec/type/alb.rb
@@ -25,7 +25,7 @@ module Awspec::Type
       end
       return true if ret
       sg2 = find_security_group(sg_id)
-      return true if sg2.tag_name == sg_id || sg2.group_name == sg_id
+      return true if sgs.include? sg2.group_id
       false
     end
   end


### PR DESCRIPTION
When passed security group by not group_id (tag.Name or group name), always return true even if it's not to associate the alb.
Because `sg2` and `sg_id` in `sg2 = find_security_group(sg_id)` are same resoueces,
So `sg2.tag_name == sg_id || sg2.group_name == sg_id` return true anytime.

(Sorry, I can't write spec... 😢 )