### PR TITLE
Add alb_target_group resource type

### DIFF
--- a/doc/_resource_types/alb_target_group.md
+++ b/doc/_resource_types/alb_target_group.md
@@ -1,0 +1,35 @@
+# exist
+
+```ruby
+describe alb_target_group('my-alb-target-group') do
+  it { should exist }
+  its(:health_check_path) { should eq '/' }
+  its(:health_check_port) { should eq 'traffic-port' }
+  its(:health_check_protocol) { should eq 'HTTP' }
+end
+```
+
+### have_ec2
+
+```ruby
+describe alb_target_group('my-alb-target-group') do
+  it { should have_ec2('my-ec2') }
+end
+```
+
+### belong_to_alb
+
+```ruby
+describe alb_target_group('my-alb-target-group') do
+  it { should belong_to_alb('my-alb') }
+end
+```
+
+### belong_to_vpc
+
+```ruby
+describe alb_target_group('my-alb-target-group') do
+  it { should belong_to_vpc('my-vpc') }
+end
+```
+

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -3,6 +3,7 @@
 [acm](#acm)
 | [alb](#alb)
 | [alb_listener](#alb_listener)
+| [alb_target_group](#alb_target_group)
 | [ami](#ami)
 | [autoscaling_group](#autoscaling_group)
 | [cloudfront_distribution](#cloudfront_distribution)
@@ -117,6 +118,40 @@ AlbListener resource type.
 ### exist
 
 ### its(:listener_arn), its(:load_balancer_arn), its(:port), its(:protocol), its(:certificates), its(:ssl_policy)
+## <a name="alb_target_group">alb_target_group</a>
+
+AlbTargetGroup resource type.
+
+### exist
+
+### have_ec2
+
+```ruby
+describe alb_target_group('my-alb-target-group') do
+  it { should have_ec2('my-ec2') }
+end
+```
+
+
+### belong_to_alb
+
+```ruby
+describe alb_target_group('my-alb-target-group') do
+  it { should belong_to_alb('my-alb') }
+end
+```
+
+
+### belong_to_vpc
+
+```ruby
+describe alb_target_group('my-alb-target-group') do
+  it { should belong_to_vpc('my-vpc') }
+end
+```
+
+
+### its(:target_group_arn), its(:target_group_name), its(:protocol), its(:port), its(:vpc_id), its(:health_check_protocol), its(:health_check_port), its(:health_check_interval_seconds), its(:health_check_timeout_seconds), its(:healthy_threshold_count), its(:unhealthy_threshold_count), its(:health_check_path), its(:load_balancer_arns)
 ## <a name="ami">ami</a>
 
 AMI resource type.

--- a/lib/awspec/generator/doc/type/alb_target_group.rb
+++ b/lib/awspec/generator/doc/type/alb_target_group.rb
@@ -1,0 +1,17 @@
+module Awspec::Generator
+  module Doc
+    module Type
+      class AlbTargetGroup < Base
+        def initialize
+          super
+          @type_name = 'AlbTargetGroup'
+          @type = Awspec::Type::AlbTargetGroup.new('my-alb-target-group')
+          @ret = @type.resource_via_client
+          @matchers = %w(belong_to_alb belong_to_vpc)
+          @ignore_matchers = []
+          @describes = []
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/helper/finder/alb.rb
+++ b/lib/awspec/helper/finder/alb.rb
@@ -21,6 +21,13 @@ module Awspec::Helper
       rescue
         return nil
       end
+
+      def find_alb_target_group(id)
+        res = elbv2_client.describe_target_groups({ names: [id] })
+        res.target_groups.single_resource(id)
+      rescue
+        return nil
+      end
     end
   end
 end

--- a/lib/awspec/helper/type.rb
+++ b/lib/awspec/helper/type.rb
@@ -15,7 +15,7 @@ module Awspec
         network_acl network_interface rds rds_db_cluster_parameter_group rds_db_parameter_group route53_hosted_zone
         route_table s3_bucket security_group ses_identity subnet vpc cloudfront_distribution
         elastictranscoder_pipeline waf_web_acl customer_gateway vpn_gateway vpn_connection internet_gateway acm
-        cloudwatch_logs dynamodb_table eip sqs alb_listener
+        cloudwatch_logs dynamodb_table eip sqs alb_listener alb_target_group
       )
 
       ACCOUNT_ATTRIBUTES = %w(

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -57,3 +57,6 @@ require 'awspec/matcher/have_key_schema'
 
 # EIP
 require 'awspec/matcher/belong_to_domain'
+
+# Alb Target Group
+require 'awspec/matcher/belong_to_alb'

--- a/lib/awspec/matcher/belong_to_alb.rb
+++ b/lib/awspec/matcher/belong_to_alb.rb
@@ -1,0 +1,8 @@
+RSpec::Matchers.define :belong_to_alb do |alb_arn|
+  match do |type|
+    return true if type.load_balancer_arns.include?(alb_arn)
+    ret = type.find_alb(alb_arn)
+    return false unless ret
+    type.load_balancer_arns.include?(ret.load_balancer_arn)
+  end
+end

--- a/lib/awspec/stub/alb_target_group.rb
+++ b/lib/awspec/stub/alb_target_group.rb
@@ -1,0 +1,325 @@
+# rubocop:disable Metrics/LineLength
+Aws.config[:elasticloadbalancingv2] = {
+  stub_responses: {
+    describe_load_balancers: {
+      load_balancers: [
+        {
+          load_balancer_arn:
+            'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:loadbalancer/app/my-alb/1aa1bb1cc1ddee11',
+          dns_name:
+            'internal-my-elb-1551266724.ap-northeast-1.elb.amazonaws.com',
+          canonical_hosted_zone_id: 'A12BCDEDCBA34BC',
+          created_time: Time.new(2017, 4, 4, 9, 00, 00, '+00:00'),
+          load_balancer_name: 'my-alb',
+          scheme: 'internal',
+          vpc_id: 'vpc-ab123cde',
+          state:
+            {
+              code: 'active',
+              reason: nil
+            },
+          type: 'application',
+          availability_zones:
+            [
+              {
+                zone_name: 'ap-northeast-1a',
+                subnet_id: 'subnet-1234a567'
+              },
+              {
+                zone_name: 'ap-northeast-1c',
+                subnet_id: 'subnet-abcd7890'
+              }
+            ],
+          security_groups: ['sg-1a2b3cd4'],
+          ip_address_type: 'ipv4'
+        }
+      ],
+      next_marker: nil
+    },
+    describe_listeners: {
+      listeners: [
+        {
+          default_actions: [
+            {
+              target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:targetgroup/my-targets/73e2d6bc24d8a067',
+              type: 'forward'
+            }
+          ],
+          listener_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:listener/app/my-alb/1aa1bb1cc1ddee11/f2f7dc8efc522ab2',
+          load_balancer_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:loadbalancer/app/my-alb/1aa1bb1cc1ddee11',
+          port: 80,
+          protocol: 'HTTP'
+        }
+      ]
+    },
+    describe_target_groups: {
+      target_groups: [
+        {
+          health_check_interval_seconds: 30,
+          health_check_path: '/',
+          health_check_port: 'traffic-port',
+          health_check_protocol: 'HTTP',
+          health_check_timeout_seconds: 5,
+          healthy_threshold_count: 5,
+          load_balancer_arns: [
+            'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:loadbalancer/app/my-alb/1aa1bb1cc1ddee11'
+          ],
+          matcher: {
+            http_code: '200'
+          },
+          port: 80,
+          protocol: 'HTTP',
+          target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067',
+          target_group_name: 'my-alb-target-group',
+          unhealthy_threshold_count: 2,
+          vpc_id: 'vpc-ab123cde'
+        }
+      ]
+    },
+    describe_target_health: {
+      target_health_descriptions: [
+        {
+          target: {
+            id: 'i-0f76fade',
+            port: 80
+          },
+          target_health: {
+            description: 'Given target group is not configured to receive traffic from ELB',
+            reason: 'Target.NotInUse',
+            state: 'unused'
+          }
+        },
+        {
+          health_check_port: '80',
+          target: {
+            id: 'i-ec12345a',
+            port: 80
+          },
+          target_health: {
+            state: 'healthy'
+          }
+        }
+      ]
+    }
+  }
+}
+
+Aws.config[:ec2] = {
+  stub_responses: {
+    describe_instances: {
+      reservations: [
+        {
+          instances: [
+            {
+              instance_id: 'i-ec12345a',
+              image_id: 'ami-abc12def',
+              vpc_id: 'vpc-ab123cde',
+              subnet_id: 'subnet-1234a567',
+              public_ip_address: '123.0.456.789',
+              private_ip_address: '10.0.1.1',
+              instance_type: 't2.small',
+              state: {
+                name: 'running'
+              },
+              security_groups: [
+                {
+                  group_id: 'sg-1a2b3cd4',
+                  group_name: 'my-security-group-name'
+                }
+              ],
+              iam_instance_profile: {
+                arn: 'arn:aws:iam::123456789012:instance-profile/Ec2IamProfileName',
+                id: 'ABCDEFGHIJKLMNOPQRSTU'
+              },
+              block_device_mappings: [
+                {
+                  device_name: '/dev/sda',
+                  ebs: {
+                    volume_id: 'vol-123a123b'
+                  }
+                }
+              ],
+              network_interfaces: [
+                {
+                  network_interface_id: 'eni-12ab3cde',
+                  subnet_id: 'subnet-1234a567',
+                  vpc_id: 'vpc-ab123cde',
+                  attachment: {
+                    device_index: 1
+                  }
+                }
+              ],
+              tags: [
+                {
+                  key: 'Name',
+                  value: 'my-ec2'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    describe_security_groups: {
+      security_groups: [
+        {
+          vpc_id: 'vpc-ab123cde',
+          owner_id: '112233445566',
+          group_id: 'sg-1a2b3cd4',
+          group_name: 'my-security-group-name',
+          tags: [
+            {
+              key: 'env',
+              value: 'dev'
+            }
+          ],
+          ip_permissions: [
+            {
+              from_port: 80,
+              to_port: 80,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '123.456.789.012/32'
+                },
+                {
+                  cidr_ip: '456.789.123.456/32'
+                }
+              ],
+              user_id_group_pairs: []
+            },
+            {
+              from_port: 22,
+              to_port: 22,
+              ip_protocol: 'tcp',
+              ip_ranges: [],
+              user_id_group_pairs: [
+                {
+                  group_id: 'sg-5a6b7cd8',
+                  group_name: 'group-name-sg'
+                }
+              ]
+            },
+            {
+              from_port: 60_000,
+              to_port: 60_000,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '100.456.789.012/32'
+                }
+              ],
+              user_id_group_pairs: []
+            },
+            {
+              from_port: 70_000,
+              to_port: 70_000,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '100.456.789.012/32'
+                }
+              ],
+              user_id_group_pairs: []
+            },
+            {
+              from_port: 70_000,
+              to_port: 70_000,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '101.456.789.012/32'
+                }
+              ],
+              user_id_group_pairs: []
+            },
+            {
+              from_port: 50_000,
+              to_port: 50_009,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '123.456.789.012/32'
+                }
+              ],
+              user_id_group_pairs: []
+            },
+            {
+              from_port: nil,
+              to_port: nil,
+              ip_protocol: '-1',
+              ip_ranges: [],
+              user_id_group_pairs: [
+                {
+                  user_id: '1234567890',
+                  group_name: nil,
+                  group_id: 'sg-3a4b5cd6',
+                  vpc_id: nil,
+                  vpc_peering_connection_id: nil,
+                  peering_status: nil
+                }
+              ]
+            }
+          ],
+          ip_permissions_egress: [
+            {
+              from_port: 50_000,
+              to_port: 50_000,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '100.456.789.012/32'
+                }
+              ]
+            },
+            {
+              from_port: 8080,
+              to_port: 8080,
+              ip_protocol: 'tcp',
+              ip_ranges: [],
+              user_id_group_pairs: [
+                {
+                  user_id: '5678901234',
+                  group_name: 'group-in-other-aws-account-with-vpc-peering',
+                  group_id: 'sg-9a8b7c6d',
+                  vpc_id: 'vpc-5b6a7c8f',
+                  vpc_peering_connection_id: 'pcx-f9e8d7c6',
+                  peering_status: 'active'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    describe_subnets: {
+      subnets: [
+        {
+          state: 'available',
+          vpc_id: 'vpc-ab123cde',
+          subnet_id: 'subnet-1234a567',
+          cidr_block: '10.0.1.0/24',
+          tags: [
+            {
+              key: 'Name',
+              value: 'my-subnet'
+            }
+          ]
+        }
+      ]
+    },
+    describe_vpcs: {
+      vpcs: [
+        {
+          vpc_id: 'vpc-ab123cde',
+          tags: [
+            {
+              key: 'Name',
+              value: 'my-vpc'
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/lib/awspec/type/alb_target_group.rb
+++ b/lib/awspec/type/alb_target_group.rb
@@ -1,0 +1,22 @@
+module Awspec::Type
+  class AlbTargetGroup < ResourceBase
+    def resource_via_client
+      @resource_via_client ||= find_alb_target_group(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.target_group_name if resource_via_client
+    end
+
+    def has_ec2?(id)
+      ec2 = find_ec2(id)
+      return nil unless ec2
+      descriptions = elbv2_client.describe_target_health(
+        target_group_arn: resource_via_client.target_group_arn
+      ).target_health_descriptions
+      descriptions.find do |description|
+        description.target.id == ec2.instance_id
+      end
+    end
+  end
+end

--- a/spec/type/alb_target_group_spec.rb
+++ b/spec/type/alb_target_group_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+Awspec::Stub.load 'alb_target_group'
+
+describe alb_target_group('my-alb-target-group') do
+  it { should exist }
+  its(:health_check_path) { should eq '/' }
+  its(:health_check_port) { should eq 'traffic-port' }
+  its(:health_check_protocol) { should eq 'HTTP' }
+  it { should belong_to_vpc('my-vpc') }
+  it { should belong_to_alb('my-alb') }
+  it { should have_ec2('my-ec2') }
+end


### PR DESCRIPTION
```ruby
describe alb_target_group('my-alb-target-group') do
  it { should exist }
  its(:health_check_path) { should eq '/' }
  its(:health_check_port) { should eq 'traffic-port' }
  its(:health_check_protocol) { should eq 'HTTP' }
  it { should belong_to_vpc('my-vpc') }
  it { should belong_to_alb('my-alb') }
  it { should have_ec2('my-ec2') }
end
```