### PR TITLE
Add `have_rule` matcher to alb_listener

### DIFF
--- a/doc/_resource_types/alb_listener.md
+++ b/doc/_resource_types/alb_listener.md
@@ -1,9 +1,28 @@
-# exist
+### exist
 
 ```ruby
 describe alb_listener('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:listener/app/my-alb/1aa1bb1cc1ddee11/f2f7dc8efc522ab2') do
   it { should exist }
   its(:port) { should eq 80 }
   its(:protocol) { should eq 'HTTP' }
+end
+```
+
+### have_rule
+
+```ruby
+describe alb_listener('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:listener/app/my-alb/1aa1bb1cc1ddee11/f2f7dc8efc522ab2') do
+  it { should have_rule('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:listener-rule/app/my-alb/1aa1bb1cc1ddee11/f2f7dc8efc522ab2/9683b2d02a6cabee') }
+  it do
+    should have_rule.priority('10')
+      .conditions(field: 'path-pattern', values: ['/img/*'])
+      .actions(target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067', type: 'forward')
+  end
+  it do
+    should have_rule.priority('10')
+      .if(field: 'path-pattern', values: ['/img/*'])
+      .then(target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067', type: 'forward')
+  end
+  it { should have_rule.actions(target_group_name: 'my-alb-target-group', type: 'forward') }
 end
 ```

--- a/doc/_resource_types/alb_listener.md
+++ b/doc/_resource_types/alb_listener.md
@@ -23,6 +23,7 @@ describe alb_listener('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:li
       .if(field: 'path-pattern', values: ['/img/*'])
       .then(target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067', type: 'forward')
   end
+  it { should have_rule.conditions([{ field: 'path-pattern', values: ['/admin/*'] }, { field: 'host-header', values: ['admin.example.com'] }]) }
   it { should have_rule.actions(target_group_name: 'my-alb-target-group', type: 'forward') }
 end
 ```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -126,6 +126,34 @@ AlbListener resource type.
 
 ### exist
 
+```ruby
+describe alb_listener('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:listener/app/my-alb/1aa1bb1cc1ddee11/f2f7dc8efc522ab2') do
+  it { should exist }
+  its(:port) { should eq 80 }
+  its(:protocol) { should eq 'HTTP' }
+end
+```
+
+
+### have_rule
+
+```ruby
+describe alb_listener('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:listener/app/my-alb/1aa1bb1cc1ddee11/f2f7dc8efc522ab2') do
+  it { should have_rule('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:listener-rule/app/my-alb/1aa1bb1cc1ddee11/f2f7dc8efc522ab2/9683b2d02a6cabee') }
+  it do
+    should have_rule.priority('10')
+      .conditions(field: 'path-pattern', values: ['/img/*'])
+      .actions(target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067', type: 'forward')
+  end
+  it do
+    should have_rule.priority('10')
+      .if(field: 'path-pattern', values: ['/img/*'])
+      .then(target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067', type: 'forward')
+  end
+  it { should have_rule.actions(target_group_name: 'my-alb-target-group', type: 'forward') }
+end
+```
+
 ### its(:listener_arn), its(:load_balancer_arn), its(:port), its(:protocol), its(:certificates), its(:ssl_policy)
 ## <a name="alb_target_group">alb_target_group</a>
 

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -150,6 +150,7 @@ describe alb_listener('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:li
       .if(field: 'path-pattern', values: ['/img/*'])
       .then(target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067', type: 'forward')
   end
+  it { should have_rule.conditions([{ field: 'path-pattern', values: ['/admin/*'] }, { field: 'host-header', values: ['admin.example.com'] }]) }
   it { should have_rule.actions(target_group_name: 'my-alb-target-group', type: 'forward') }
 end
 ```

--- a/lib/awspec/helper/finder/alb.rb
+++ b/lib/awspec/helper/finder/alb.rb
@@ -28,6 +28,17 @@ module Awspec::Helper
       rescue
         return nil
       end
+
+      def select_rule_by_alb_listener_id(id)
+        selected = []
+        next_marker = nil
+        loop do
+          res = elbv2_client.describe_rules(marker: next_marker, listener_arn: id)
+          selected += res.rules unless res.nil?
+          (res.nil? && next_marker = res.next_marker) || break
+        end
+        selected
+      end
     end
   end
 end

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -45,7 +45,7 @@ require 'awspec/matcher/have_origin'
 # Kms
 require 'awspec/matcher/have_key_policy'
 
-# WafWebAcl
+# WafWebAcl / AlbListener
 require 'awspec/matcher/have_rule'
 
 # CloudWatch Logs

--- a/lib/awspec/matcher/have_rule.rb
+++ b/lib/awspec/matcher/have_rule.rb
@@ -1,6 +1,7 @@
 RSpec::Matchers.define :have_rule do |rule_id|
-  match do |web_acl|
-    web_acl.has_rule?(rule_id, @priority, @action)
+  match do |type|
+    return type.has_rule?(rule_id, @priority, @action) if type.instance_of?(Awspec::Type::WafWebAcl)
+    type.has_rule?(rule_id, @priority, @conditions, @actions) if type.instance_of?(Awspec::Type::AlbListener)
   end
 
   chain :priority do |priority|
@@ -13,5 +14,21 @@ RSpec::Matchers.define :have_rule do |rule_id|
 
   chain :action do |action|
     @action = action
+  end
+
+  chain :conditions do |conditions|
+    @conditions = conditions
+  end
+
+  chain :actions do |actions|
+    @actions = actions
+  end
+
+  chain :if do |conditions|
+    @conditions = conditions
+  end
+
+  chain :then do |actions|
+    @actions = actions
   end
 end

--- a/lib/awspec/stub/alb_listener.rb
+++ b/lib/awspec/stub/alb_listener.rb
@@ -51,6 +51,66 @@ Aws.config[:elasticloadbalancingv2] = {
           protocol: 'HTTP'
         }
       ]
+    },
+    describe_target_groups: {
+      target_groups: [
+        {
+          health_check_interval_seconds: 30,
+          health_check_path: '/',
+          health_check_port: 'traffic-port',
+          health_check_protocol: 'HTTP',
+          health_check_timeout_seconds: 5,
+          healthy_threshold_count: 5,
+          load_balancer_arns: [
+            'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:loadbalancer/app/my-alb/1aa1bb1cc1ddee11'
+          ],
+          matcher: {
+            http_code: '200'
+          },
+          port: 80,
+          protocol: 'HTTP',
+          target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067',
+          target_group_name: 'my-alb-target-group',
+          unhealthy_threshold_count: 2,
+          vpc_id: 'vpc-ab123cde'
+        }
+      ]
+    },
+    describe_rules: {
+      rules: [
+        {
+          actions: [
+            {
+              target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067',
+              type: 'forward'
+            }
+          ],
+          conditions: [
+            {
+              field: 'path-pattern',
+              values: [
+                '/img/*'
+              ]
+            }
+          ],
+          is_default: false,
+          priority: '10',
+          rule_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:listener-rule/app/my-alb/1aa1bb1cc1ddee11/f2f7dc8efc522ab2/9683b2d02a6cabee'
+        },
+        {
+          actions: [
+            {
+              target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:targetgroup/my-targets/73e2d6bc24d8a067',
+              type: 'forward'
+            }
+          ],
+          conditions: [
+          ],
+          is_default: true,
+          priority: 'default',
+          rule_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:listener-rule/app/my-alb/1aa1bb1cc1ddee11/f2f7dc8efc522ab2/defaaaaaaaultbbbb'
+        }
+      ]
     }
   }
 }

--- a/lib/awspec/stub/alb_listener.rb
+++ b/lib/awspec/stub/alb_listener.rb
@@ -81,6 +81,31 @@ Aws.config[:elasticloadbalancingv2] = {
         {
           actions: [
             {
+              target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/55556bc24d8a067/55556bc24d8a067',
+              type: 'forward'
+            }
+          ],
+          conditions: [
+            {
+              field: 'host-header',
+              values: [
+                'admin.example.com'
+              ]
+            },
+            {
+              field: 'path-pattern',
+              values: [
+                '/admin/*'
+              ]
+            }
+          ],
+          is_default: false,
+          priority: '50',
+          rule_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:listener-rule/app/my-alb/1aa1bb1cc1ddee11/7777778efc522ab2/7777778efc522ab2'
+        },
+        {
+          actions: [
+            {
               target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067',
               type: 'forward'
             }

--- a/lib/awspec/type/alb_listener.rb
+++ b/lib/awspec/type/alb_listener.rb
@@ -29,7 +29,8 @@ module Awspec::Type
         end
         true
       end
-      ret.single_resource("rule_id = #{rule_id}, priority = #{priority}, conditions = #{conditions}, actions = #{actions}")
+      ret.single_resource("rule_id = #{rule_id}, priority = #{priority}, \
+conditions = #{conditions}, actions = #{actions}")
     end
   end
 end

--- a/lib/awspec/type/alb_listener.rb
+++ b/lib/awspec/type/alb_listener.rb
@@ -7,5 +7,29 @@ module Awspec::Type
     def id
       @id ||= resource_via_client.listener_arn if resource_via_client
     end
+
+    def has_rule?(rule_id = nil, priority = nil, conditions = nil, actions = nil)
+      rules = select_rule_by_alb_listener_id(id)
+      ret = rules.select do |rule|
+        conditions = [conditions] if conditions.is_a?(Hash)
+        actions = [actions] if actions.is_a?(Hash)
+        next false if !rule_id.nil? && rule.rule_arn != rule_id
+        next false if !priority.nil? && rule.priority != priority
+        next false if !conditions.nil? && rule.conditions.map(&:to_h) != conditions
+        unless actions.nil?
+          actions = actions.map do |action|
+            if action.key?(:target_group_name)
+              target_group = find_alb_target_group(action[:target_group_name])
+              action[:target_group_arn] = target_group.target_group_arn
+              action.delete(:target_group_name)
+            end
+            action
+          end
+          next false if rule.actions.map(&:to_h) != actions
+        end
+        true
+      end
+      ret.single_resource("rule_id = #{rule_id}, priority = #{priority}, conditions = #{conditions}, actions = #{actions}")
+    end
   end
 end

--- a/lib/awspec/type/alb_listener.rb
+++ b/lib/awspec/type/alb_listener.rb
@@ -15,7 +15,7 @@ module Awspec::Type
         actions = [actions] if actions.is_a?(Hash)
         next false if !rule_id.nil? && rule.rule_arn != rule_id
         next false if !priority.nil? && rule.priority != priority
-        next false if !conditions.nil? && rule.conditions.map(&:to_h) != conditions
+        next false if !conditions.nil? && rule.conditions.map(&:to_h).sort_by(&:to_s) != conditions.sort_by(&:to_s)
         unless actions.nil?
           actions = actions.map do |action|
             if action.key?(:target_group_name)
@@ -25,7 +25,7 @@ module Awspec::Type
             end
             action
           end
-          next false if rule.actions.map(&:to_h) != actions
+          next false if rule.actions.map(&:to_h).sort_by(&:to_s) != actions.sort_by(&:to_s)
         end
         true
       end

--- a/spec/type/alb_listener_spec.rb
+++ b/spec/type/alb_listener_spec.rb
@@ -17,5 +17,6 @@ describe alb_listener('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:li
       .if(field: 'path-pattern', values: ['/img/*'])
       .then(target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067', type: 'forward')
   end
+  it { should have_rule.conditions([{ field: 'path-pattern', values: ['/admin/*'] }, { field: 'host-header', values: ['admin.example.com'] }]) }
   it { should have_rule.actions(target_group_name: 'my-alb-target-group', type: 'forward') }
 end

--- a/spec/type/alb_listener_spec.rb
+++ b/spec/type/alb_listener_spec.rb
@@ -6,4 +6,16 @@ describe alb_listener('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:li
   it { should exist }
   its(:port) { should eq 80 }
   its(:protocol) { should eq 'HTTP' }
+  it { should have_rule('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:listener-rule/app/my-alb/1aa1bb1cc1ddee11/f2f7dc8efc522ab2/9683b2d02a6cabee') }
+  it do
+    should have_rule.priority('10')
+      .conditions(field: 'path-pattern', values: ['/img/*'])
+      .actions(target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067', type: 'forward')
+  end
+  it do
+    should have_rule.priority('10')
+      .if(field: 'path-pattern', values: ['/img/*'])
+      .then(target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067', type: 'forward')
+  end
+  it { should have_rule.actions(target_group_name: 'my-alb-target-group', type: 'forward') }
 end


### PR DESCRIPTION
```ruby
describe alb_listener('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:listener/app/my-alb/1aa1bb1cc1ddee11/f2f7dc8efc522ab2') do
  it { should have_rule('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:listener-rule/app/my-alb/1aa1bb1cc1ddee11/f2f7dc8efc522ab2/9683b2d02a6cabee') }
  it do
    should have_rule.priority('10')
      .conditions(field: 'path-pattern', values: ['/img/*'])
      .actions(target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067', type: 'forward')
  end
  it do
    should have_rule.priority('10')
      .if(field: 'path-pattern', values: ['/img/*'])
      .then(target_group_arn: 'arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:123456789012:targetgroup/73e2d6bc24d8a067/73e2d6bc24d8a067', type: 'forward')
  end
  it { should have_rule.actions(target_group_name: 'my-alb-target-group', type: 'forward') }
end
```