### PR TITLE
Fix route53_hosted_zone resource type when record_sets has multiple TTLs

### DIFF
--- a/lib/awspec/stub/route53_hosted_zone.rb
+++ b/lib/awspec/stub/route53_hosted_zone.rb
@@ -57,6 +57,16 @@ Aws.config[:route53] = {
           ]
         },
         {
+          name: 'www.example.com.',
+          type: 'A',
+          ttl: 600,
+          resource_records: [
+            {
+              value: '123.456.7.890'
+            }
+          ]
+        },
+        {
           name: 'example.com.',
           type: 'NS',
           ttl: 172_800,

--- a/lib/awspec/type/route53_hosted_zone.rb
+++ b/lib/awspec/type/route53_hosted_zone.rb
@@ -17,12 +17,12 @@ module Awspec::Type
       ret = resource_via_client_record_sets.find do |record_set|
         # next if record_set.type != type.upcase
         next unless record_set.type.casecmp(type) == 0
-        options[:ttl] = record_set[:ttl] unless options[:ttl]
         if !record_set.resource_records.empty?
           sorted = record_set.resource_records.map { |r| r.value }.sort.join("\n")
+          ttl = options[:ttl] || record_set[:ttl]
           record_set.name == name && \
           value.split("\n").sort.join("\n") == sorted && \
-          record_set.ttl == options[:ttl]
+          record_set.ttl == ttl
         else
           # ALIAS
           record_set.name == name && \

--- a/spec/generator/spec/route53_hosted_zone_spec.rb
+++ b/spec/generator/spec/route53_hosted_zone_spec.rb
@@ -14,6 +14,7 @@ describe route53_hosted_zone('example.com.') do
   it { should have_record_set('*.example.com.').cname('example.com').ttl(3600) }
   it { should have_record_set('example.com.').mx('10 mail.example.com').ttl(3600) }
   it { should have_record_set('mail.example.com.').a('123.456.7.890').ttl(3600) }
+  it { should have_record_set('www.example.com.').a('123.456.7.890').ttl(600) }
   it { should have_record_set('example.com.').ns('ns-123.awsdns-45.net.
 ns-6789.awsdns-01.org.
 ns-2345.awsdns-67.co.uk.

--- a/spec/type/route53_hosted_zone_spec.rb
+++ b/spec/type/route53_hosted_zone_spec.rb
@@ -42,3 +42,10 @@ ns-2345.awsdns-67.co.uk.'
     it { should have_record_set('example.com.').ns(ns2) }
   end
 end
+
+describe route53_hosted_zone('example.com.') do
+  context 'route53_hosted_zone support without ttl option in multiple ttls' do
+    # TTL of first A record (example.com.) is 3600, but TTL of target A record is 600.
+    it { should have_record_set('www.example.com.').a('123.456.7.890') }
+  end
+end


### PR DESCRIPTION
`route53_hosted_zone` fails when record_sets has multiple TTLs.

For example, TTL of a record is 3600 and one of another record is 600. In that case `options[:ttl]` in previous code was fixed 3600, and therefore other test failed when TTL is NOT 3600.