### PR TITLE
Change Awspec::Type::IamRole#id from role_id to role_name

### DIFF
--- a/lib/awspec/type/iam_role.rb
+++ b/lib/awspec/type/iam_role.rb
@@ -7,7 +7,7 @@ module Awspec::Type
     end
 
     def id
-      @id ||= resource_via_client.role_id if resource_via_client
+      @id ||= resource_via_client.role_name if resource_via_client
     end
 
     def has_iam_policy?(policy_id)


### PR DESCRIPTION
Because Aws::IAM::Role initialize using role_name ( see http://docs.aws.amazon.com/sdkforruby/api/Aws/IAM/Role.html#initialize-instance_method )

