### PR TITLE
Fix sg cidr matching

### DIFF
--- a/lib/awspec/stub/security_group.rb
+++ b/lib/awspec/stub/security_group.rb
@@ -20,10 +20,10 @@ Aws.config[:ec2] = {
               ip_protocol: 'tcp',
               ip_ranges: [
                 {
-                  cidr_ip: '123.456.789.012/32'
+                  cidr_ip: '123.45.67.0/24'
                 },
                 {
-                  cidr_ip: '456.789.123.456/32'
+                  cidr_ip: '123.45.68.89/32'
                 }
               ],
               user_id_group_pairs: []
@@ -46,7 +46,7 @@ Aws.config[:ec2] = {
               ip_protocol: 'tcp',
               ip_ranges: [
                 {
-                  cidr_ip: '100.456.789.012/32'
+                  cidr_ip: '100.45.67.12/32'
                 }
               ],
               user_id_group_pairs: []
@@ -57,7 +57,7 @@ Aws.config[:ec2] = {
               ip_protocol: 'tcp',
               ip_ranges: [
                 {
-                  cidr_ip: '100.456.789.012/32'
+                  cidr_ip: '100.45.67.89/32'
                 }
               ],
               user_id_group_pairs: []
@@ -68,7 +68,7 @@ Aws.config[:ec2] = {
               ip_protocol: 'tcp',
               ip_ranges: [
                 {
-                  cidr_ip: '101.456.789.012/32'
+                  cidr_ip: '100.45.67.12/32'
                 }
               ],
               user_id_group_pairs: []
@@ -79,7 +79,7 @@ Aws.config[:ec2] = {
               ip_protocol: 'tcp',
               ip_ranges: [
                 {
-                  cidr_ip: '123.456.789.012/32'
+                  cidr_ip: '123.45.67.89/32'
                 }
               ],
               user_id_group_pairs: []
@@ -108,7 +108,7 @@ Aws.config[:ec2] = {
               ip_protocol: 'tcp',
               ip_ranges: [
                 {
-                  cidr_ip: '100.456.789.012/32'
+                  cidr_ip: '100.45.67.12/32'
                 }
               ]
             },

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -92,7 +92,13 @@ module Awspec::Type
     def cidr_opened?(permission, cidr)
       return true unless cidr
       ret = permission.ip_ranges.select do |ip_range|
-        ip_range.cidr_ip == cidr
+        # if the cidr is an IP address then do a true CIDR match
+        if cidr =~ /^\d+\.\d+\.\d+\.\d+/
+          net = IPAddr.new(ip_range.cidr_ip)
+          net.include?(cidr)
+        else
+          ip_range.cidr_ip == cidr
+        end
       end
       return true if ret.count > 0
       ret = permission.user_id_group_pairs.select do |sg|

--- a/spec/generator/spec/security_group_spec.rb
+++ b/spec/generator/spec/security_group_spec.rb
@@ -11,15 +11,15 @@ describe security_group('my-security-group-name') do
   it { should exist }
   its(:group_id) { should eq 'sg-1a2b3cd4' }
   its(:group_name) { should eq 'my-security-group-name' }
-  its(:inbound) { should be_opened(80).protocol('tcp').for('123.456.789.012/32') }
-  its(:inbound) { should be_opened(80).protocol('tcp').for('456.789.123.456/32') }
+  its(:inbound) { should be_opened(80).protocol('tcp').for('123.45.67.0/24') }
+  its(:inbound) { should be_opened(80).protocol('tcp').for('123.45.68.89/32') }
   its(:inbound) { should be_opened(22).protocol('tcp').for('group-name-sg') }
-  its(:inbound) { should be_opened(60000).protocol('tcp').for('100.456.789.012/32') }
-  its(:inbound) { should be_opened(70000).protocol('tcp').for('100.456.789.012/32') }
-  its(:inbound) { should be_opened(70000).protocol('tcp').for('101.456.789.012/32') }
-  its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.456.789.012/32') }
+  its(:inbound) { should be_opened(60000).protocol('tcp').for('100.45.67.12/32') }
+  its(:inbound) { should be_opened(70000).protocol('tcp').for('100.45.67.89/32') }
+  its(:inbound) { should be_opened(70000).protocol('tcp').for('100.45.67.12/32') }
+  its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.45.67.89/32') }
   its(:inbound) { should be_opened.protocol('all').for('sg-3a4b5cd6') }
-  its(:outbound) { should be_opened(50000).protocol('tcp').for('100.456.789.012/32') }
+  its(:outbound) { should be_opened(50000).protocol('tcp').for('100.45.67.12/32') }
   its(:outbound) { should be_opened(8080).protocol('tcp').for('group-in-other-aws-account-with-vpc-peering') }
   its(:inbound_rule_count) { should eq 8 }
   its(:outbound_rule_count) { should eq 2 }

--- a/spec/type/security_group_spec.rb
+++ b/spec/type/security_group_spec.rb
@@ -4,18 +4,18 @@ Awspec::Stub.load 'security_group'
 describe security_group('sg-1a2b3cd4') do
   it { should exist }
   its(:inbound) { should be_opened(80) }
-  its(:inbound) { should be_opened(80).protocol('tcp').for('123.456.789.012/32') }
-  its(:inbound) { should be_opened(80).protocol('tcp').for('456.789.123.456/32') }
+  its(:inbound) { should be_opened(80).protocol('tcp').for('123.45.67.128/25') }
+  its(:inbound) { should be_opened(80).protocol('tcp').for('123.45.68.89/32') }
   its(:inbound) { should be_opened(22) }
   its(:inbound) { should be_opened(22).protocol('tcp').for('sg-5a6b7cd8') }
-  its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.456.789.012/32') }
-  its(:inbound) { should_not be_opened('50010-50019').protocol('tcp').for('123.456.789.012/32') }
+  its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.45.67.89/32') }
+  its(:inbound) { should_not be_opened('50010-50019').protocol('tcp').for('123.45.67.89/32') }
   its(:outbound) { should be_opened(50_000) }
   its(:outbound) { should be_opened(8080).protocol('tcp').for('sg-9a8b7c6d') }
   its(:outbound) { should be_opened(8080).protocol('tcp').for('group-in-other-aws-account-with-vpc-peering') }
-  its(:inbound) { should be_opened_only(60_000).protocol('tcp').for('100.456.789.012/32') }
-  its(:inbound) { should be_opened_only(70_000).protocol('tcp').for(['100.456.789.012/32', '101.456.789.012/32']) }
-  its(:outbound) { should be_opened_only(50_000).protocol('tcp').for('100.456.789.012/32') }
+  its(:inbound) { should be_opened_only(60_000).protocol('tcp').for('100.45.67.12/32') }
+  its(:inbound) { should be_opened_only(70_000).protocol('tcp').for(['100.45.67.89/32', '100.45.67.12/32']) }
+  its(:outbound) { should be_opened_only(50_000).protocol('tcp').for('100.45.67.12/32') }
   its(:inbound) { should be_opened.protocol('all').for('sg-3a4b5cd6') }
   its(:inbound_permissions_count) { should eq 7 }
   its(:ip_permissions_count) { should eq 7 }


### PR DESCRIPTION
Fixes [#331](https://github.com/k1LoW/awspec/issues/331) to perform CIDR match of IP addresses to in tests.  The stub data and tests had invalid IP addresses which needed to be updated as well in order to pass.