### PR TITLE
Fix: Security group permissions check for VPC endpoint prefix lists

### DIFF
--- a/lib/awspec/stub/security_group.rb
+++ b/lib/awspec/stub/security_group.rb
@@ -127,7 +127,17 @@ Aws.config[:ec2] = {
                   peering_status: 'active'
                 }
               ]
-            }
+            },
+            {
+              from_port: 443,
+              to_port: 443,
+              ip_protocol: 'tcp',
+              prefix_list_ids: [
+                {
+                  prefix_list_id: 'pl-a5321fa3'
+                }
+              ]
+            },
           ]
         }
       ]

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -91,6 +91,10 @@ module Awspec::Type
 
     def cidr_opened?(permission, cidr)
       return true unless cidr
+      ret = permission.prefix_list_ids.select do |prefix_list_id|
+        prefix_list_id.prefix_list_id == cidr
+      end
+      return true if ret.count >0
       ret = permission.ip_ranges.select do |ip_range|
         # if the cidr is an IP address then do a true CIDR match
         if cidr =~ /^\d+\.\d+\.\d+\.\d+/

--- a/spec/type/security_group_spec.rb
+++ b/spec/type/security_group_spec.rb
@@ -17,10 +17,11 @@ describe security_group('sg-1a2b3cd4') do
   its(:inbound) { should be_opened_only(70_000).protocol('tcp').for(['100.45.67.89/32', '100.45.67.12/32']) }
   its(:outbound) { should be_opened_only(50_000).protocol('tcp').for('100.45.67.12/32') }
   its(:inbound) { should be_opened.protocol('all').for('sg-3a4b5cd6') }
+  its(:outbound) { should be_opened.protocol('tcp').for('pl-a5321fa3')}
   its(:inbound_permissions_count) { should eq 7 }
   its(:ip_permissions_count) { should eq 7 }
-  its(:outbound_permissions_count) { should eq 2 }
-  its(:ip_permissions_egress_count) { should eq 2 }
+  its(:outbound_permissions_count) { should eq 3 }
+  its(:ip_permissions_egress_count) { should eq 3 }
   its(:inbound_rule_count) { should eq 8 }
   its(:outbound_rule_count) { should eq 2 }
 


### PR DESCRIPTION
Fixes #282 