### PR TITLE
Add CAA record support in route53_hosted_zone

### DIFF
--- a/lib/awspec/matcher/have_record_set.rb
+++ b/lib/awspec/matcher/have_record_set.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define :have_record_set do |name|
     hosted_zone.has_record_set?(name, @type, @value, @options)
   end
 
-  %w(soa a txt ns cname mx ptr srv spf aaaa).each do |type|
+  %w(soa a txt ns cname mx ptr srv spf aaaa caa).each do |type|
     chain type do |value|
       @type = type
       @value = value

--- a/lib/awspec/stub/route53_hosted_zone.rb
+++ b/lib/awspec/stub/route53_hosted_zone.rb
@@ -6,7 +6,7 @@ Aws.config[:route53] = {
           id: '/hostedzone/Z1A2BCDEF34GH5',
           name: 'example.com.',
           caller_reference: '',
-          resource_record_set_count: 6
+          resource_record_set_count: 8
         }
       ],
       marker: '',
@@ -94,6 +94,28 @@ Aws.config[:route53] = {
             dns_name: 's3-website-us-east-1.amazonaws.com.',
             evaluate_target_health: false
           }
+        },
+        {
+          name: 'example.com.',
+          type: 'CAA',
+          ttl: 600,
+          resource_records: [
+            {
+              value: '0 issue "amazon.com"'
+            },
+            {
+              value: '0 issue "amazontrust.com"'
+            },
+            {
+              value: '0 issue "awstrust.com"'
+            },
+            {
+              value: '0 issuewild "amazonaws.com"'
+            },
+            {
+              value: '0 iodef "mailto:support@example.com"'
+            }
+          ]
         }
       ],
       is_truncated: false,

--- a/spec/generator/spec/route53_hosted_zone_spec.rb
+++ b/spec/generator/spec/route53_hosted_zone_spec.rb
@@ -9,7 +9,7 @@ describe 'Awspec::Generator::Spec::Route53HostedZone' do
     spec = <<-'EOF'
 describe route53_hosted_zone('example.com.') do
   it { should exist }
-  its(:resource_record_set_count) { should eq 6 }
+  its(:resource_record_set_count) { should eq 8 }
   it { should have_record_set('example.com.').a('123.456.7.890').ttl(3600) }
   it { should have_record_set('*.example.com.').cname('example.com').ttl(3600) }
   it { should have_record_set('example.com.').mx('10 mail.example.com').ttl(3600) }
@@ -20,6 +20,11 @@ ns-6789.awsdns-01.org.
 ns-2345.awsdns-67.co.uk.
 ns-890.awsdns-12.com.').ttl(172800) }
   it { should have_record_set('s3.example.com.').alias('s3-website-us-east-1.amazonaws.com.', 'Z2ABCDEFGHIJKL') }
+  it { should have_record_set('example.com.').caa('0 issue "amazon.com"
+0 issue "amazontrust.com"
+0 issue "awstrust.com"
+0 issuewild "amazonaws.com"
+0 iodef "mailto:support@example.com"').ttl(600) }
 end
 EOF
     expect(route53_hosted_zone.generate_by_domain_name('example.com.').to_s.gsub(/\n/, "\n")).to eq spec

--- a/spec/type/route53_hosted_zone_spec.rb
+++ b/spec/type/route53_hosted_zone_spec.rb
@@ -3,7 +3,7 @@ Awspec::Stub.load 'route53_hosted_zone'
 
 describe route53_hosted_zone('example.com.') do
   it { should exist }
-  its(:resource_record_set_count) { should eq 6 }
+  its(:resource_record_set_count) { should eq 8 }
   it { should have_record_set('example.com.').a('123.456.7.890') }
   it { should have_record_set('*.example.com.').cname('example.com') }
   it { should have_record_set('example.com.').mx('10 mail.example.com') }
@@ -14,6 +14,12 @@ ns-2345.awsdns-67.co.uk.
 ns-890.awsdns-12.com.'
   it { should have_record_set('example.com.').ns(ns) }
   it { should have_record_set('s3.example.com.').alias('s3-website-us-east-1.amazonaws.com.', 'Z2ABCDEFGHIJKL') }
+  caa = '0 issue "amazon.com"
+0 issue "amazontrust.com"
+0 issue "awstrust.com"
+0 issuewild "amazonaws.com"
+0 iodef "mailto:support@example.com"'
+  it { should have_record_set('example.com.').caa(caa).ttl(600) }
 end
 
 describe route53_hosted_zone('example.com.') do
@@ -25,7 +31,7 @@ end
 
 describe route53_hosted_zone('Z1A2BCDEF34GH5') do
   it { should exist }
-  its(:resource_record_set_count) { should eq 6 }
+  its(:resource_record_set_count) { should eq 8 }
 end
 
 describe route53_hosted_zone('example.com.') do


### PR DESCRIPTION
This pull request adds CAA DNS record support in route53_hosted_zone.

About CAA record, please take a look at the following AWS documentations:
- http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html#CAAFormat
- http://docs.aws.amazon.com/acm/latest/userguide/setup-caa.html