### PR TITLE
Add `be_connected_to_vpc` `have_vpc_peering_connection` matcher to vpc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
 
 before_install:
   - gem update --system
+  - gem pristine bundler
   
 script:
   - bundle exec rake spec

--- a/doc/_resource_types/vpc.md
+++ b/doc/_resource_types/vpc.md
@@ -14,6 +14,16 @@ describe vpc('vpc-ab123cde') do
 end
 ```
 
+### be_connected_to_vpc
+
+```ruby
+describe vpc('vpc-ab123cde') do
+  it { should be_connected_to_vpc('vpc-bcd1235e') }
+  it { should be_connected_to_vpc('vpc-bcd1235e').as_accepter }
+  it { should_not be_connected_to_vpc('vpc-bcd1235e').as_requester }
+end
+```
+
 ### have_network_acl
 
 ```ruby
@@ -37,6 +47,16 @@ end
 ```ruby
 describe vpc('vpc-ab123cde') do
   it { should have_tag('Stack').value('Networking') }
+end
+```
+
+### have_vpc_peering_connection
+
+```ruby
+describe vpc('vpc-ab123cde') do
+  it { should have_vpc_peering_connection('pcx-c56789de') }
+  it { should have_vpc_peering_connection('pcx-c56789de').as_accepter }
+  it { should_not have_vpc_peering_connection('pcx-c56789de').as_requester }
 end
 ```
 

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -2454,6 +2454,17 @@ end
 ```
 
 
+### be_connected_to_vpc
+
+```ruby
+describe vpc('vpc-ab123cde') do
+  it { should be_connected_to_vpc('vpc-bcd1235e') }
+  it { should be_connected_to_vpc('vpc-bcd1235e').as_accepter }
+  it { should_not be_connected_to_vpc('vpc-bcd1235e').as_requester }
+end
+```
+
+
 ### have_network_acl
 
 ```ruby
@@ -2479,6 +2490,17 @@ end
 ```ruby
 describe vpc('vpc-ab123cde') do
   it { should have_tag('Stack').value('Networking') }
+end
+```
+
+
+### have_vpc_peering_connection
+
+```ruby
+describe vpc('vpc-ab123cde') do
+  it { should have_vpc_peering_connection('pcx-c56789de') }
+  it { should have_vpc_peering_connection('pcx-c56789de').as_accepter }
+  it { should_not have_vpc_peering_connection('pcx-c56789de').as_requester }
 end
 ```
 

--- a/lib/awspec/helper/finder/vpc.rb
+++ b/lib/awspec/helper/finder/vpc.rb
@@ -72,6 +72,17 @@ module Awspec::Helper
                                                           })
         res.vpc_peering_connections.single_resource(vpc_peering_connection_id)
       end
+
+      def select_vpc_peering_connection_by_vpc_id(vpc_id, status_code = nil)
+        params = {}
+        params = { filters: [{ name: 'status-code', values: [status_code] }] } if status_code
+        vpc_peering_connections = ec2_client.describe_vpc_peering_connections(params).map do |res|
+          res.vpc_peering_connections
+        end.flatten
+        vpc_peering_connections.select do |conn|
+          conn.accepter_vpc_info.vpc_id == vpc_id || conn.requester_vpc_info.vpc_id == vpc_id
+        end
+      end
     end
   end
 end

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -60,3 +60,7 @@ require 'awspec/matcher/belong_to_domain'
 
 # Alb Target Group
 require 'awspec/matcher/belong_to_alb'
+
+# VPC
+require 'awspec/matcher/be_connected_to_vpc'
+require 'awspec/matcher/have_vpc_peering_connection'

--- a/lib/awspec/matcher/be_connected_to_vpc.rb
+++ b/lib/awspec/matcher/be_connected_to_vpc.rb
@@ -1,0 +1,13 @@
+RSpec::Matchers.define :be_connected_to_vpc do |vpc_id|
+  match do |vpc|
+    vpc.connected_to_vpc?(vpc_id, @accepter_or_requester)
+  end
+
+  chain :as_accepter do
+    @accepter_or_requester = 'accepter'
+  end
+
+  chain :as_requester do
+    @accepter_or_requester = 'requester'
+  end
+end

--- a/lib/awspec/matcher/have_vpc_peering_connection.rb
+++ b/lib/awspec/matcher/have_vpc_peering_connection.rb
@@ -1,0 +1,13 @@
+RSpec::Matchers.define :have_vpc_peering_connection do |vpc_peering_connection_id|
+  match do |vpc|
+    vpc.has_vpc_peering_connection?(vpc_peering_connection_id, @accepter_or_requester)
+  end
+
+  chain :as_accepter do
+    @accepter_or_requester = 'accepter'
+  end
+
+  chain :as_requester do
+    @accepter_or_requester = 'requester'
+  end
+end

--- a/lib/awspec/stub/vpc.rb
+++ b/lib/awspec/stub/vpc.rb
@@ -64,6 +64,42 @@ Aws.config[:ec2] = {
           ]
         }
       ]
+    },
+    describe_vpc_peering_connections: {
+      vpc_peering_connections: [
+        {
+          vpc_peering_connection_id: 'pcx-c56789de',
+          accepter_vpc_info: {
+            cidr_block: nil,
+            ipv_6_cidr_block_set: [],
+            cidr_block_set: [],
+            owner_id: '123453345554',
+            peering_options: nil,
+            vpc_id: 'vpc-ab123cde',
+            region: 'ap-northeast-1'
+          },
+          expiration_time: nil,
+          requester_vpc_info: {
+            cidr_block: nil,
+            ipv_6_cidr_block_set: [],
+            cidr_block_set: [],
+            owner_id: '192912349399',
+            peering_options: nil,
+            vpc_id: 'vpc-bcd1235e',
+            region: 'ap-northeast-1'
+          },
+          status: {
+            code: 'active',
+            message: 'Active'
+          },
+          tags: [
+            {
+              key: 'Name',
+              value: 'my-pcx'
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/lib/awspec/type/vpc.rb
+++ b/lib/awspec/type/vpc.rb
@@ -32,5 +32,31 @@ module Awspec::Type
       return false unless n
       n.vpc_id == id
     end
+
+    def connected_to_vpc?(vpc_id, accepter_or_requester = nil)
+      connections = select_vpc_peering_connection_by_vpc_id(vpc_id, 'active')
+      return connections.single_resource(vpc_id) unless accepter_or_requester
+
+      if accepter_or_requester == 'accepter'
+        connections.select do |conn|
+          conn.accepter_vpc_info.vpc_id == @id
+        end.single_resource(vpc_id)
+      elsif accepter_or_requester == 'requester'
+        connections.select do |conn|
+          conn.requester_vpc_info.vpc_id == @id
+        end.single_resource(vpc_id)
+      end
+    end
+
+    def has_vpc_peering_connection?(vpc_peering_connection_id, accepter_or_requester = nil)
+      connection = find_vpc_peering_connection(vpc_peering_connection_id)
+      res = if accepter_or_requester == 'accepter'
+              connection.accepter_vpc_info.vpc_id == @id
+            elsif accepter_or_requester == 'requester'
+              connection.requester_vpc_info.vpc_id == @id
+            else
+              connection
+            end
+    end
   end
 end

--- a/spec/type/vpc_spec.rb
+++ b/spec/type/vpc_spec.rb
@@ -8,6 +8,12 @@ describe vpc('vpc-ab123cde') do
   it { should have_route_table('my-route-table') }
   it { should have_network_acl('acl-1abc2d3e') }
   it { should have_network_acl('my-network-acl') }
+  it { should be_connected_to_vpc('vpc-bcd1235e') }
+  it { should be_connected_to_vpc('vpc-bcd1235e').as_accepter }
+  it { should_not be_connected_to_vpc('vpc-bcd1235e').as_requester }
+  it { should have_vpc_peering_connection('pcx-c56789de') }
+  it { should have_vpc_peering_connection('pcx-c56789de').as_accepter }
+  it { should_not have_vpc_peering_connection('pcx-c56789de').as_requester }
   context 'nested attribute call' do
     its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }
     its('route_tables.first.route_table_id') { should eq 'rtb-a12bcd34' }


### PR DESCRIPTION
```ruby
describe vpc('vpc-ab123cde') do
  it { should exist }
  it { should be_connected_to_vpc('vpc-bcd1235e') }
  it { should be_connected_to_vpc('vpc-bcd1235e').as_accepter }
  it { should_not be_connected_to_vpc('vpc-bcd1235e').as_requester }
  it { should have_vpc_peering_connection('pcx-c56789de') }
  it { should have_vpc_peering_connection('pcx-c56789de').as_accepter }
  it { should_not have_vpc_peering_connection('pcx-c56789de').as_requester }
end
```