### PR TITLE
Add "have_custom_response_error_code" to cloudFront distribution resource type

### DIFF
--- a/doc/_resource_types/cloudfront_distribution.md
+++ b/doc/_resource_types/cloudfront_distribution.md
@@ -14,6 +14,27 @@ describe cloudfront_distribution('123456789zyxw.cloudfront.net') do
 end
 ```
 
+### have_custom_response_error_code
+
+```ruby
+  it do
+    should have_custom_response_error_code(400)
+      .error_caching_min_ttl(60)
+      .response_page_path('/path/to/400.html')
+      .response_code(400)
+  end
+  it do
+    should have_custom_response_error_code(403)
+      .error_caching_min_ttl(60)
+      .response_page_path('/path/to/403.html')
+      .response_code('403')
+  end
+  it do
+    should have_custom_response_error_code(500)
+      .error_caching_min_ttl(60)
+  end
+```
+
 ### have_origin
 
 ```ruby

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -331,6 +331,28 @@ end
 ```
 
 
+### have_custom_response_error_code
+
+```ruby
+  it do
+    should have_custom_response_error_code(400)
+      .error_caching_min_ttl(60)
+      .response_page_path('/path/to/400.html')
+      .response_code(400)
+  end
+  it do
+    should have_custom_response_error_code(403)
+      .error_caching_min_ttl(60)
+      .response_page_path('/path/to/403.html')
+      .response_code('403')
+  end
+  it do
+    should have_custom_response_error_code(500)
+      .error_caching_min_ttl(60)
+  end
+```
+
+
 ### have_origin
 
 ```ruby

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -41,6 +41,7 @@ require 'awspec/matcher/have_private_ip_address'
 
 # CloudFront
 require 'awspec/matcher/have_origin'
+require 'awspec/matcher/have_custom_response_error_code'
 
 # Kms
 require 'awspec/matcher/have_key_policy'

--- a/lib/awspec/matcher/have_custom_response_error_code.rb
+++ b/lib/awspec/matcher/have_custom_response_error_code.rb
@@ -1,0 +1,21 @@
+RSpec::Matchers.define :have_custom_response_error_code do |error_code|
+  match do |cloudfront_distribution|
+    cloudfront_distribution.has_custom_response_error_code?(error_code,
+                                                            response_page_path: @response_page_path,
+                                                            response_code: @response_code,
+                                                            error_caching_min_ttl: @error_caching_min_ttl
+                                                           )
+  end
+
+  chain :response_page_path do |response_page_path|
+    @response_page_path = response_page_path
+  end
+
+  chain :response_code do |response_code|
+    @response_code = response_code
+  end
+
+  chain :error_caching_min_ttl do |error_caching_min_ttl|
+    @error_caching_min_ttl = error_caching_min_ttl
+  end
+end

--- a/lib/awspec/stub/cloudfront_distribution.rb
+++ b/lib/awspec/stub/cloudfront_distribution.rb
@@ -176,7 +176,27 @@ Aws.config[:cloudfront] = {
               },
               custom_error_responses: {
                 quantity: 0,
-                items: []
+                items:
+                  [
+                    {
+                      error_code: 400,
+                      response_page_path: '/path/to/400.html',
+                      response_code: '400',
+                      error_caching_min_ttl: 60
+                    },
+                    {
+                      error_code: 403,
+                      response_page_path: '/path/to/403.html',
+                      response_code: '403',
+                      error_caching_min_ttl: 60
+                    },
+                    {
+                      error_code: 500,
+                      response_page_path: '',
+                      response_code: '',
+                      error_caching_min_ttl: 60
+                    }
+                  ]
               },
               comment: 'cf-s3-origin-hosting.dev.example.com',
               price_class: 'PriceClass_200',

--- a/lib/awspec/type/cloudfront_distribution.rb
+++ b/lib/awspec/type/cloudfront_distribution.rb
@@ -42,5 +42,19 @@ module Awspec::Type
       origin_path = domain_name_and_path.gsub(%r(\A[^/]*), '')
       has_origin?(nil, domain_name: domain_name, origin_path: origin_path)
     end
+
+    def has_custom_response_error_code?(error_code,
+                                        response_page_path: nil,
+                                        response_code: nil,
+                                        error_caching_min_ttl: nil)
+      return false unless [error_code, domain_name].any?
+      resource_via_client.custom_error_responses.items.find do |error|
+        next false if !error_code.nil? && error.error_code != error_code
+        next false if !response_page_path.nil? && error.response_page_path != response_page_path
+        next false if !response_code.nil? && error.response_code != response_code.to_s
+        next false if !error_caching_min_ttl.nil? && error.error_caching_min_ttl != error_caching_min_ttl
+        true
+      end
+    end
   end
 end

--- a/spec/type/cloudfront_distribution_spec.rb
+++ b/spec/type/cloudfront_distribution_spec.rb
@@ -22,4 +22,20 @@ end
 
 describe cloudfront_distribution('123456789zyxw.cloudfront.net') do
   it { should exist }
+  it do
+    should have_custom_response_error_code(400)
+      .error_caching_min_ttl(60)
+      .response_page_path('/path/to/400.html')
+      .response_code(400)
+  end
+  it do
+    should have_custom_response_error_code(403)
+      .error_caching_min_ttl(60)
+      .response_page_path('/path/to/403.html')
+      .response_code('403')
+  end
+  it do
+    should have_custom_response_error_code(500)
+      .error_caching_min_ttl(60)
+  end
 end


### PR DESCRIPTION
Hi,

I added "have_custom_response_error_code" for "Custom Error Responses" test.

```ruby
  it do
    should have_custom_response_error_code(400)
      .error_caching_min_ttl(60)
      .response_page_path('/path/to/400.html')
      .response_code(400)
  end
  it do
    should have_custom_response_error_code(403)
      .error_caching_min_ttl(60)
      .response_page_path('/path/to/403.html')
      .response_code('403')
  end
  it do
    should have_custom_response_error_code(500)
      .error_caching_min_ttl(60)
  end
```

please confirm.

Thank you.
