### PR TITLE
Add `have_tag` to elb resource type

### DIFF
--- a/doc/_resource_types/cloudfront_distribution.md
+++ b/doc/_resource_types/cloudfront_distribution.md
@@ -17,6 +17,7 @@ end
 ### have_custom_response_error_code
 
 ```ruby
+describe cloudfront_distribution('123456789zyxw.cloudfront.net') do
   it do
     should have_custom_response_error_code(400)
       .error_caching_min_ttl(60)
@@ -33,6 +34,7 @@ end
     should have_custom_response_error_code(500)
       .error_caching_min_ttl(60)
   end
+end
 ```
 
 ### have_origin

--- a/doc/_resource_types/elb.md
+++ b/doc/_resource_types/elb.md
@@ -47,3 +47,12 @@ describe elb('my-elb') do
   it { should belong_to_vpc('my-vpc') }
 end
 ```
+
+### have_tag
+
+```ruby
+describe elb('my-elb') do
+  it { should have_tag('Name').value('my-elb') }
+  it { should have_tag('my-tag-key').value('my-tag-value') }
+end
+```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -334,6 +334,7 @@ end
 ### have_custom_response_error_code
 
 ```ruby
+describe cloudfront_distribution('123456789zyxw.cloudfront.net') do
   it do
     should have_custom_response_error_code(400)
       .error_caching_min_ttl(60)
@@ -350,6 +351,7 @@ end
     should have_custom_response_error_code(500)
       .error_caching_min_ttl(60)
   end
+end
 ```
 
 
@@ -1274,6 +1276,15 @@ end
 ```
 
 
+### have_tag
+
+```ruby
+describe elb('my-elb') do
+  it { should have_tag('Name').value('my-elb') }
+  it { should have_tag('my-tag-key').value('my-tag-value') }
+end
+```
+
 ### belong_to_vpc
 
 ```ruby
@@ -1281,6 +1292,7 @@ describe elb('my-elb') do
   it { should belong_to_vpc('my-vpc') }
 end
 ```
+
 
 ### its(:health_check_target), its(:health_check_interval), its(:health_check_timeout), its(:health_check_unhealthy_threshold), its(:health_check_healthy_threshold), its(:load_balancer_name), its(:dns_name), its(:canonical_hosted_zone_name), its(:canonical_hosted_zone_name_id), its(:backend_server_descriptions), its(:availability_zones), its(:subnets), its(:vpc_id), its(:security_groups), its(:created_time), its(:scheme)
 ## <a name="iam_group">iam_group</a>

--- a/lib/awspec/generator/spec/elb.rb
+++ b/lib/awspec/generator/spec/elb.rb
@@ -47,6 +47,9 @@ describe elb('<%= lb.load_balancer_name %>') do
 <% lb[:listener_descriptions].each do |desc| %>
   it { should have_listener(protocol: '<%= desc.listener.protocol %>', port: <%= desc.listener.load_balancer_port %>, instance_protocol: '<%= desc.listener.instance_protocol %>', instance_port: <%= desc.listener.instance_port %>) }
 <% end %>
+<% select_all_elb_tags(lb.load_balancer_name).each do |tag| %>
+  it { should have_tag('<%= tag.key %>').value('<%= tag.value %>') }
+<% end %>
 end
 EOF
         template

--- a/lib/awspec/helper/finder/elb.rb
+++ b/lib/awspec/helper/finder/elb.rb
@@ -16,6 +16,13 @@ module Awspec::Helper
           lb.vpc_id == vpc_id
         end
       end
+
+      def select_all_elb_tags(id)
+        res = elb_client.describe_tags({
+                                         load_balancer_names: [id]
+                                       })
+        res.tag_descriptions.single_resource(id).tags
+      end
     end
   end
 end

--- a/lib/awspec/stub/elb.rb
+++ b/lib/awspec/stub/elb.rb
@@ -37,6 +37,23 @@ Aws.config[:elasticloadbalancing] = {
           vpc_id: 'vpc-ab123cde'
         }
       ]
+    },
+    describe_tags: {
+      tag_descriptions: [
+        {
+          load_balancer_name: 'my-elb',
+          tags: [
+            {
+              key: 'Name',
+              value: 'my-elb'
+            },
+            {
+              key: 'my-tag-key',
+              value: 'my-tag-value'
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/lib/awspec/type/elb.rb
+++ b/lib/awspec/type/elb.rb
@@ -57,5 +57,12 @@ module Awspec::Type
           listener.instance_protocol == instance_protocol && listener.instance_port == instance_port
       end
     end
+
+    def has_tag?(tag_key, tag_value)
+      tag_set = select_all_elb_tags(@id)
+      tag_set.find do |tag|
+        tag.key == tag_key && tag.value == tag_value
+      end
+    end
   end
 end

--- a/spec/generator/spec/elb_spec.rb
+++ b/spec/generator/spec/elb_spec.rb
@@ -16,6 +16,8 @@ describe elb('my-elb') do
   its(:health_check_unhealthy_threshold) { should eq 10 }
   its(:health_check_healthy_threshold) { should eq 2 }
   it { should have_listener(protocol: 'HTTPS', port: 443, instance_protocol: 'HTTP', instance_port: 80) }
+  it { should have_tag('Name').value('my-elb') }
+  it { should have_tag('my-tag-key').value('my-tag-value') }
 end
 EOF
     expect(elb.generate_by_vpc_id('my-vpc').to_s.gsub(/\n/, "\n")).to eq spec

--- a/spec/type/elb_spec.rb
+++ b/spec/type/elb_spec.rb
@@ -8,4 +8,6 @@ describe elb('my-elb') do
   it { should have_subnet('my-subnet') }
   it { should have_listener(protocol: 'HTTPS', port: 443, instance_protocol: 'HTTP', instance_port: 80) }
   it { should belong_to_vpc('my-vpc') }
+  it { should have_tag('Name').value('my-elb') }
+  it { should have_tag('my-tag-key').value('my-tag-value') }
 end


### PR DESCRIPTION
Hi, @k1LoW 

I added "have_tag?" for elb resource test.

```ruby
describe elb('my-elb') do
  it { should have_tag('Name').value('my-elb') }
  it { should have_tag('my-tag-key').value('my-tag-value') }
end
```

And fixed part of document.(doc/_resource_types/cloudfront_distribution.md)
please confirm.

Thank you.