### PR TITLE
Docs: init process for existing RSpec project

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,16 @@ Or install it yourself as:
 
 ### STEP 1. Generate awspec init files
 
+If you're starting on a fresh RSpec project, you can use awspec to generate your init files:
+
     $ awspec init
+    
+If you're working on an exisitng RSpec project, you will need to add the following lines to your `spec_helper.rb` file:
+
+```ruby
+require 'awspec'
+Awsecrets.load(secrets_path: File.expand_path('./secrets.yml', File.dirname(__FILE__)))
+```
 
 ### STEP 2. Set AWS config
 


### PR DESCRIPTION
If you run `awspec` on a RSpec project that has already been initialized, it will fail with something like:

```
$ awspec init
!! spec/spec_helper.rb already exists
 + Rakefile
 + spec/.gitignore
!! .rspec already exists
```

It would be nice to document an alternative path for users who already have those files setup how they want

I'm not sure if what I documented here includes all the necessary steps, but I thought I would give it a go.