### PR TITLE
Fix FrozenError on route53_hosted_zone.has_record_set

### DIFF
--- a/lib/awspec/type/route53_hosted_zone.rb
+++ b/lib/awspec/type/route53_hosted_zone.rb
@@ -13,7 +13,7 @@ module Awspec::Type
     end
 
     def has_record_set?(name, type, value, options = {})
-      name.gsub!(/\*/, '\\\052') # wildcard support
+      name = name.gsub(/\*/, '\\\052') # wildcard support
       ret = resource_via_client_record_sets.find do |record_set|
         # next if record_set.type != type.upcase
         next unless record_set.type.casecmp(type) == 0


### PR DESCRIPTION
Hello.
Thank you for your great project. 

Currently route53_hosted_zone have_record_set raises a FrozenError when "frozen_string_literal" is enabled.

Thanks.