### PR TITLE
Add datapoints_to_alarm for cloudwatch_alarm generator

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -986,7 +986,7 @@ describe ecs_service('my-ecs-service') do
 end
 ```
 
-### its(:service_arn), its(:service_name), its(:cluster_arn), its(:load_balancers), its(:service_registries), its(:status), its(:desired_count), its(:running_count), its(:pending_count), its(:launch_type), its(:platform_version), its(:task_definition), its(:role_arn), its(:created_at), its(:placement_constraints), its(:placement_strategy), its(:network_configuration), its(:health_check_grace_period_seconds)
+### its(:service_arn), its(:service_name), its(:cluster_arn), its(:load_balancers), its(:service_registries), its(:status), its(:desired_count), its(:running_count), its(:pending_count), its(:launch_type), its(:platform_version), its(:task_definition), its(:role_arn), its(:created_at), its(:placement_constraints), its(:placement_strategy), its(:network_configuration), its(:health_check_grace_period_seconds), its(:scheduling_strategy)
 ## <a name="ecs_task_definition">ecs_task_definition</a>
 
 ECS Task Definition resource type.

--- a/lib/awspec/generator/spec/cloudwatch_alarm.rb
+++ b/lib/awspec/generator/spec/cloudwatch_alarm.rb
@@ -28,6 +28,7 @@ describe cloudwatch_alarm('<%= alarm.alarm_name %>') do
   its(:period) { should eq <%= alarm.period %> }
   its(:unit) { should eq '<%= alarm.unit %>' }
   its(:evaluation_periods)  { should eq <%= alarm.evaluation_periods %> }
+  its(:datapoints_to_alarm)  { should eq <%= alarm.datapoints_to_alarm %> }
   its(:threshold)  { should eq <%= alarm.threshold %> }
   its(:comparison_operator)  { should eq '<%= alarm.comparison_operator %>' }
 end

--- a/lib/awspec/stub/cloudwatch_alarm.rb
+++ b/lib/awspec/stub/cloudwatch_alarm.rb
@@ -30,6 +30,7 @@ Aws.config[:cloudwatch] = {
           period: 300,
           unit: 'Seconds',
           evaluation_periods: 1,
+          datapoints_to_alarm: 1,
           threshold: 5.0,
           comparison_operator: 'LessThanOrEqualToThreshold'
         }

--- a/spec/generator/spec/cloudwatch_alarm_spec.rb
+++ b/spec/generator/spec/cloudwatch_alarm_spec.rb
@@ -19,6 +19,7 @@ describe cloudwatch_alarm('my-cloudwatch-alarm') do
   its(:period) { should eq 300 }
   its(:unit) { should eq 'Seconds' }
   its(:evaluation_periods)  { should eq 1 }
+  its(:datapoints_to_alarm)  { should eq 1 }
   its(:threshold)  { should eq 5.0 }
   its(:comparison_operator)  { should eq 'LessThanOrEqualToThreshold' }
 end


### PR DESCRIPTION
Hi, @k1LoW 

Add datapoints_to_alarm method for cloudwatch alarm generator.

* https://docs.aws.amazon.com/sdkforruby/api/Aws/CloudWatch/Types/MetricAlarm.html#datapoints_to_alarm-instance_method

Please confirm.

Regards.

Yohei