### PR TITLE
If "unit" is nil it will not generate.

### DIFF
--- a/lib/awspec/generator/spec/cloudwatch_alarm.rb
+++ b/lib/awspec/generator/spec/cloudwatch_alarm.rb
@@ -26,7 +26,9 @@ describe cloudwatch_alarm('<%= alarm.alarm_name %>') do
   its(:state_value) { should eq '<%= alarm.state_value %>' }
   its(:statistic) { should eq '<%= alarm.statistic %>' }
   its(:period) { should eq <%= alarm.period %> }
+<%- if alarm.unit != nil -%>
   its(:unit) { should eq '<%= alarm.unit %>' }
+<% end -%>
   its(:evaluation_periods)  { should eq <%= alarm.evaluation_periods %> }
   its(:datapoints_to_alarm)  { should eq <%= alarm.datapoints_to_alarm %> }
   its(:threshold)  { should eq <%= alarm.threshold %> }


### PR DESCRIPTION
Hi, @k1LoW 

I fixed it so that it does not generate if "unit" is nil.
Please confirm.

Regards.

以下, Japanese ですいません.

CloudWatch Alarm を generate した際に, unit に値が設定されていないと, 以下のように generate されてしまい, テストを流すと fail してしまいます.

```ruby
# cloudwatch_alarm_spec.rb
describe cloudwatch_alarm('alarm name') do
  it { should exist }
... 略 ...
  its(:unit) { should eq '' }
```

以下, テスト結果の抜粋.

```
# test output
  11) cloudwatch_alarm 'alarm name' unit should eq ""
      Failure/Error: its(:unit) { should eq '' }

        expected: ""
             got: nil

        (compared using ==)
```

その対応として, `unit` が `nil` の場合には, `its(:unit) { should eq '' }` を書き出さないようしました.

以下, [describe_alarms](https://docs.aws.amazon.com/sdkforruby/api/Aws/CloudWatch/Client.html#describe_alarms-instance_method) の実行結果です.

```ruby
$ bundle exec ruby --version
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin15]
$ bundle exec ruby test.rb
#<struct Aws::CloudWatch::Types::DescribeAlarmsOutput
 metric_alarms=
  [#<struct Aws::CloudWatch::Types::MetricAlarm
... snip ...
    period=60,
    unit=nil,
    evaluation_periods=5,
    datapoints_to_alarm=3,
    threshold=50.0,
    comparison_operator="GreaterThanOrEqualToThreshold",
    treat_missing_data="missing",
    evaluate_low_sample_count_percentile=nil>],
 next_token=nil>
```