### PR TITLE
Bug fixes

### DIFF
--- a/lib/awspec/resource_reader.rb
+++ b/lib/awspec/resource_reader.rb
@@ -4,7 +4,7 @@ module Awspec
     end
 
     def method_missing_via_black_list(name, delegate_to: nil)
-      raise ArguementError, 'delegate_to: must be specified' unless delegate_to
+      raise ArgumentError, 'delegate_to: must be specified' unless delegate_to
       if match_black_list?(name) && !match_white_list?(name)
         raise CalledMethodInBlackList, "Method call #{name.inspect} is black-listed"
       end
@@ -44,6 +44,10 @@ module Awspec
 
     def initialize(resource)
       @resource_via_client = resource
+    end
+
+    def describe_time_to_live(*args)
+        @resource_via_client.send('describe_time_to_live', *args)
     end
 
     def method_missing(name)

--- a/lib/awspec/resource_reader.rb
+++ b/lib/awspec/resource_reader.rb
@@ -47,7 +47,7 @@ module Awspec
     end
 
     def describe_time_to_live(*args)
-        @resource_via_client.send('describe_time_to_live', *args)
+      @resource_via_client.send('describe_time_to_live', *args)
     end
 
     def method_missing(name)


### PR DESCRIPTION
Fixed typo in exception.
Fixed bug regarding invoking describe_time_to_live method from the client of Aws::DynamoDB::Table class. The current way (before the fix) this was processed was to ignoring the two extra parameters passed to method_missing method and also not passing the required parameter of the table name. This might not be the best way to fix this, it looks like more a workaround. It seems a bit unproductive to have to pass again the table name, since the client itself is instantiated from the Aws::DynamoDB::Table instance, so a change in the API to hide complexity (in AWS SDK, the table and it's corresponding class are two different entities) this would be interesting too.