### PR TITLE
(ref #392) Change generate cloudwatch_logs

### DIFF
--- a/lib/awspec/generator/spec/cloudwatch_logs.rb
+++ b/lib/awspec/generator/spec/cloudwatch_logs.rb
@@ -15,7 +15,7 @@ module Awspec::Generator
       end
 
       def generate_log_stream_spec(log_group)
-        log_stream = find_cloudwatch_logs_stream_by_log_group_name(log_group)
+        log_stream = last_cloudwatch_logs_stream_by_log_group_name(log_group)
         "it { should have_log_stream('#{log_stream.log_stream_name}') }" unless log_stream.nil?
       end
 

--- a/lib/awspec/helper/finder/cloudwatch_logs.rb
+++ b/lib/awspec/helper/finder/cloudwatch_logs.rb
@@ -9,6 +9,10 @@ module Awspec::Helper
         end
       end
 
+      def last_cloudwatch_logs_stream_by_log_group_name(id)
+        cloudwatch_logs_client.describe_log_streams({ log_group_name: id }).log_streams.last
+      end
+
       def find_cloudwatch_logs_stream_by_log_group_name(id, stream_name)
         req = {
           log_group_name: id,


### PR DESCRIPTION
Hi @k1LoW ,
I'm sorry.
"generate cloudwatch_logs" will fail from #393 changed.
I Correct to "generate cloudwatch_logs" generate.

We tried acquiring all log streams, but Rate Exceed is easy to occur.
I think that is the reason why it was only the latest logstream.

-----
I replaced this because check failed with #397.
But it still fails.
