### PR TITLE
Add ec2_credit_specification

### DIFF
--- a/doc/_resource_types/ec2.md
+++ b/doc/_resource_types/ec2.md
@@ -39,6 +39,16 @@ describe ec2('my-ec2-classic') do
 end
 ```
 
+### have_credit_specification
+
+The credit option for CPU usage of T2 or T3 instance.
+
+```ruby
+describe ec2('my-ec2') do
+  it { should have_credit_specification('unlimited') }
+end
+```
+
 ### have_ebs
 
 ```ruby

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -884,6 +884,17 @@ end
 ```
 
 
+### have_credit_specification
+
+The credit option for CPU usage of T2 or T3 instance.
+
+```ruby
+describe ec2('my-ec2') do
+  it { should have_credit_specification('unlimited') }
+end
+```
+
+
 ### have_ebs
 
 ```ruby

--- a/lib/awspec/generator/spec/ec2.rb
+++ b/lib/awspec/generator/spec/ec2.rb
@@ -19,6 +19,7 @@ module Awspec::Generator
           eips = select_eip_by_instance_id(instance_id)
           volumes = select_ebs_by_instance_id(instance_id)
           network_interfaces = select_network_interface_by_instance_id(instance_id)
+          credit_specification = find_ec2_credit_specifications(instance_id)
           content = ERB.new(ec2_spec_template, nil, '-').result(binding).gsub(/^\n/, '')
         end
         specs.join("\n")
@@ -69,6 +70,9 @@ describe ec2('<%= instance_id %>') do
 <% network_interfaces.each do |interface| %>
   it { should have_network_interface('<%= interface.network_interface_id %>') }
 <% end %>
+<%- if credit_specification.cpu_credits -%>
+  it { should have_credit_specification('<%= credit_specification.cpu_credits %>') }
+<%- end -%>
 end
 EOF
         template

--- a/lib/awspec/helper/finder/ec2.rb
+++ b/lib/awspec/helper/finder/ec2.rb
@@ -28,6 +28,13 @@ module Awspec::Helper
                                                      })
       end
 
+      def find_ec2_credit_specifications(id)
+        res = ec2_client.describe_instance_credit_specifications({
+                                                                   instance_ids: [id]
+                                                                 })
+        res.instance_credit_specifications.first if res.instance_credit_specifications.count == 1
+      end
+
       def find_ec2_status(id)
         res = ec2_client.describe_instance_status({
                                                     instance_ids: [id]

--- a/lib/awspec/stub/ec2.rb
+++ b/lib/awspec/stub/ec2.rb
@@ -222,6 +222,14 @@ Aws.config[:ec2] = {
           interface_type: nil
         }
       ]
+    },
+    describe_instance_credit_specifications: {
+      instance_credit_specifications: [
+        {
+          instance_id: 'i-ec12345a',
+          cpu_credits: 'unlimited'
+        }
+      ]
     }
   }
 }

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -132,6 +132,11 @@ module Awspec::Type
       return true if ret
     end
 
+    def has_credit_specification?(cpu_credits)
+      ret = find_ec2_credit_specifications(id)
+      ret.cpu_credits == cpu_credits
+    end
+
     private
 
     def match_group_ids?(sg_ids)

--- a/spec/generator/spec/ec2_spec.rb
+++ b/spec/generator/spec/ec2_spec.rb
@@ -21,6 +21,7 @@ describe ec2('my-ec2') do
   it { should have_eip('123.0.456.789') }
   it { should have_ebs('my-volume') }
   it { should have_network_interface('eni-12ab3cde') }
+  it { should have_credit_specification('unlimited') }
 end
 EOF
     expect(ec2.generate_by_vpc_id('my-vpc').to_s.gsub(/\n/, "\n")).to eq spec

--- a/spec/type/ec2_spec.rb
+++ b/spec/type/ec2_spec.rb
@@ -37,6 +37,7 @@ describe 'single security group' do
     end
     it { should have_tag('Name').value('my-ec2') }
     it { should have_iam_instance_profile('Ec2IamProfileName') }
+    it { should have_credit_specification('unlimited') }
   end
 
   describe ec2('my-ec2') do


### PR DESCRIPTION
Add the EC2 credit options.
There are cases where the document returns an error in cases other than t2 / t3,
In fact the standard will be returned.

- [Class: Aws::EC2::Client — AWS SDK for Ruby V3](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/EC2/Client.html#describe_instance_credit_specifications-instance_method)
> If you specify an instance ID that is not valid, such as an instance that is not a T2 or T3 instance, an error is returned.
