### PR TITLE
(ref #414) Domain Name and ARN Support for acm

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -85,6 +85,8 @@ end
 
 ### be_pending_validation, be_issued, be_inactive, be_expired, be_validation_timed_out, be_revoked, be_failed
 
+### have_domain_name
+
 ### have_domain_validation_option
 
 ```ruby

--- a/lib/awspec/generator/doc/type/acm.rb
+++ b/lib/awspec/generator/doc/type/acm.rb
@@ -5,7 +5,7 @@ module Awspec::Generator
         def initialize
           super
           @type_name = 'Acm'
-          @type = Awspec::Type::Acm.new('example.com')
+          @type = Awspec::Type::Acm.new('example.jp')
           @ret = @type.resource_via_client
           @matchers = [
             Awspec::Type::Acm::STATUSES.map { |status| 'be_' + status.downcase }.join(', ')

--- a/lib/awspec/generator/spec/acm.rb
+++ b/lib/awspec/generator/spec/acm.rb
@@ -16,12 +16,21 @@ describe acm('<%= certificate.domain_name %>') do
 <%- if certificate.status == 'ISSUED' -%>
   it { should be_issued }
 <% end -%>
+  it { should have_domain_name('<%= certificate.domain_name %>') }
+  its(:certificate_arn) { should eq '<%= certificate.certificate_arn %>' }
   its(:type) { should eq '<%= certificate.type %>' }
 <%- certificate.domain_validation_options.each do |domain_validation_option| -%>
 <%- unless domain_validation_option.validation_status.nil? -%>
-  it { should have_domain_validation_option(domain_name: '<%= domain_validation_option.domain_name %>', validation_method: '<%= domain_validation_option.validation_method%>', validation_status: '<%= domain_validation_option.validation_status %>') }
+  it do
+    should have_domain_validation_option(domain_name: '<%= domain_validation_option.domain_name %>',
+                                         validation_method: '<%= domain_validation_option.validation_method%>',
+                                         validation_status: '<%= domain_validation_option.validation_status %>')
+  end
 <%- else -%>
-  it { should have_domain_validation_option(domain_name: '<%= domain_validation_option.domain_name %>', validation_method: '<%= domain_validation_option.validation_method%>') }
+  it do
+    should have_domain_validation_option(domain_name: '<%= domain_validation_option.domain_name %>',
+                                         validation_method: '<%= domain_validation_option.validation_method%>')
+  end
 <%- end -%>
 <%- end -%>
 end

--- a/lib/awspec/stub/acm.rb
+++ b/lib/awspec/stub/acm.rb
@@ -3,19 +3,28 @@ Aws.config[:acm] = {
     list_certificates: {
       certificate_summary_list: [
         {
+          certificate_arn: 'arn:aws:acm:region:123456789010:certificate/12345678-1234-1234-1234-123456789000',
+          domain_name: 'example.jp'
+        },
+        {
           certificate_arn: 'arn:aws:acm:region:123456789010:certificate/12345678-1234-1234-1234-123456789010',
           domain_name: 'example.com'
+        },
+        {
+          certificate_arn: 'arn:aws:acm:region:123456789010:certificate/12345678-1234-1234-1234-123456789011',
+          domain_name: 'example.com'
         }
-      ]
+      ],
+      next_token: nil
     },
     describe_certificate: {
       certificate: {
-        certificate_arn: 'arn:aws:acm:region:123456789010:certificate/12345678-1234-1234-1234-123456789010',
-        domain_name: 'example.com',
+        certificate_arn: 'arn:aws:acm:region:123456789010:certificate/12345678-1234-1234-1234-123456789000',
+        domain_name: 'example.jp',
         status: 'ISSUED',
         type: 'AMAZON_ISSUED',
         domain_validation_options: [
-          domain_name: 'example.com',
+          domain_name: 'example.jp',
           validation_status: 'SUCCESS',
           validation_method: 'DNS'
         ]

--- a/lib/awspec/type/acm.rb
+++ b/lib/awspec/type/acm.rb
@@ -24,6 +24,11 @@ module Awspec::Type
       end
     end
 
+    def has_domain_name?(domain)
+      resource_via_client.domain_name == domain && \
+      resource_via_client.certificate_arn == id
+    end
+
     def has_domain_validation_option?(domain_name:, validation_method:, validation_status: nil)
       resource_via_client.domain_validation_options.find do |domain_validation_option|
         validation_status ||= domain_validation_option.validation_status

--- a/spec/type/acm_spec.rb
+++ b/spec/type/acm_spec.rb
@@ -1,8 +1,30 @@
 require 'spec_helper'
 Awspec::Stub.load 'acm'
 
-describe acm('example.com') do
+describe acm('example.jp') do
+  its(:certificate_arn) { should eq 'arn:aws:acm:region:123456789010:certificate/12345678-1234-1234-1234-123456789000' }
+end
+
+describe acm('arn:aws:acm:region:123456789010:certificate/12345678-1234-1234-1234-123456789000') do
   it { should exist }
   it { should be_issued }
+  it { should have_domain_name('example.jp') }
   its(:type) { should eq 'AMAZON_ISSUED' }
+  it do
+    should have_domain_validation_option(domain_name: 'example.jp',
+                                         validation_method: 'DNS',
+                                         validation_status: 'SUCCESS')
+  end
+end
+
+describe acm('arn:aws:acm:region:123456789010:certificate/12345678-1234-1234-1234-123456789011') do
+  it { should exist }
+end
+
+describe acm('example.com') do
+  it 'should be a Exception when duplicated domain name' do
+    expect { Awspec::Type::Acm.new('example.com').id }.to raise_error(
+      Awspec::DuplicatedResourceTypeError
+    )
+  end
 end


### PR DESCRIPTION
Hi, All

I fixed the following (reference #414 ).

```ruby
describe acm('exmaple.com') do
  ...
end

describe acm('arn:aws:acm:region:xxxxxx')
  ...
end
```

Thank you.
