### PR TITLE
(ref #206 )Add tag description

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -1763,7 +1763,7 @@ end
 ```
 
 
-### its(:path), its(:role_name), its(:role_id), its(:arn), its(:create_date), its(:assume_role_policy_document), its(:description), its(:tags), its(:max_session_duration), its(:permissions_boundary)
+### its(:path), its(:role_name), its(:role_id), its(:arn), its(:create_date), its(:assume_role_policy_document), its(:description), its(:max_session_duration), its(:permissions_boundary), its(:tags)
 ### :unlock: Advanced use
 
 `iam_role` can use `Aws::IAM::Role` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/IAM/Role.html).
@@ -1852,7 +1852,7 @@ end
 ```
 
 
-### its(:path), its(:user_name), its(:user_id), its(:arn), its(:create_date), its(:password_last_used), its(:tags), its(:permissions_boundary)
+### its(:path), its(:user_name), its(:user_id), its(:arn), its(:create_date), its(:password_last_used), its(:permissions_boundary), its(:tags)
 ### :unlock: Advanced use
 
 `iam_user` can use `Aws::IAM::User` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/IAM/User.html).

--- a/lib/awspec/matcher/have_tag.rb
+++ b/lib/awspec/matcher/have_tag.rb
@@ -6,4 +6,8 @@ RSpec::Matchers.define :have_tag do |key|
   chain :value do |val|
     @value = val
   end
+
+  description do
+    "have tag \"#{key}\" value \"#{@value}\""
+  end
 end


### PR DESCRIPTION
Hi, All

Although a topic of the past,
It's modification proposal for #206 .
Add value to the output of have_tag.

How do you think about it?


- spec/ec2_spec.rb

```
require 'spec_helper'

describe ec2('test-instance') do
  it { should have_tag('Name').value('test-instance') }
  it { should have_tag('aws:ec2launchtemplate:id').value('lt-xxxxx') }
  it { should have_tag('aws:ec2launchtemplate:version').value('1') }
  it { should have_tag('Dummy').value('not exists key') }
end
```

- before

```
ec2 'test-instance'
  should have tag "Name"
  should have tag "aws:ec2launchtemplate:id" (FAILED - 1)
  should have tag "aws:ec2launchtemplate:version"
  should have tag "Dummy" (FAILED - 2)

Failures:

  1) ec2 'test-instance' should have tag "aws:ec2launchtemplate:id"
     Failure/Error: it { should have_tag('aws:ec2launchtemplate:id').value('lt-xxxxx') }
       expected ec2 'test-instance' to have tag "aws:ec2launchtemplate:id"
     # ./spec/ec2_spec.rb:5:in `block (2 levels) in <top (required)>'

  2) ec2 'test-instance' should have tag "Dummy"
     Failure/Error: it { should have_tag('Dummy').value('not exists key') }
       expected ec2 'test-instance' to have tag "Dummy"
     # ./spec/ec2_spec.rb:7:in `block (2 levels) in <top (required)>'

Finished in 0.54471 seconds (files took 3.47 seconds to load)
4 examples, 2 failures

Failed examples:

rspec ./spec/ec2_spec.rb:5 # ec2 'test-instance' should have tag "aws:ec2launchtemplate:id"
rspec ./spec/ec2_spec.rb:7 # ec2 'test-instance' should have tag "Dummy"
```

- after

```
ec2 'test-instance'
  should have tag "Name" value "test-instance"
  should have tag "aws:ec2launchtemplate:id" value "lt-xxxxx" (FAILED - 1)
  should have tag "aws:ec2launchtemplate:version" value "1"
  should have tag "Dummy" value "not exists key" (FAILED - 2)

Failures:

  1) ec2 'test-instance' should have tag "aws:ec2launchtemplate:id" value "lt-xxxxx"
     Failure/Error: it { should have_tag('aws:ec2launchtemplate:id').value('lt-xxxxx') }
       expected ec2 'test-instance' to have tag "aws:ec2launchtemplate:id" value "lt-xxxxx"
     # ./spec/ec2_spec.rb:5:in `block (2 levels) in <top (required)>'

  2) ec2 'test-instance' should have tag "Dummy" value "not exists key"
     Failure/Error: it { should have_tag('Dummy').value('not exists key') }
       expected ec2 'test-instance' to have tag "Dummy" value "not exists key"
     # ./spec/ec2_spec.rb:7:in `block (2 levels) in <top (required)>'

Finished in 0.6554 seconds (files took 7.03 seconds to load)
4 examples, 2 failures

Failed examples:

rspec ./spec/ec2_spec.rb:5 # ec2 'test-instance' should have tag "aws:ec2launchtemplate:id" value "lt-xxxxx"
rspec ./spec/ec2_spec.rb:7 # ec2 'test-instance' should have tag "Dummy" value "not exists key"
```
