### PR TITLE
Add generator for autoscaling_group

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -1763,7 +1763,7 @@ end
 ```
 
 
-### its(:path), its(:role_name), its(:role_id), its(:arn), its(:create_date), its(:assume_role_policy_document), its(:description), its(:tags), its(:max_session_duration), its(:permissions_boundary)
+### its(:path), its(:role_name), its(:role_id), its(:arn), its(:create_date), its(:assume_role_policy_document), its(:description), its(:max_session_duration), its(:permissions_boundary), its(:tags)
 ### :unlock: Advanced use
 
 `iam_role` can use `Aws::IAM::Role` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/IAM/Role.html).
@@ -1852,7 +1852,7 @@ end
 ```
 
 
-### its(:path), its(:user_name), its(:user_id), its(:arn), its(:create_date), its(:password_last_used), its(:tags), its(:permissions_boundary)
+### its(:path), its(:user_name), its(:user_id), its(:arn), its(:create_date), its(:password_last_used), its(:permissions_boundary), its(:tags)
 ### :unlock: Advanced use
 
 `iam_user` can use `Aws::IAM::User` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/IAM/User.html).

--- a/lib/awspec/command/generate.rb
+++ b/lib/awspec/command/generate.rb
@@ -9,7 +9,7 @@ module Awspec
 
     types = %w(
       vpc ec2 rds security_group elb network_acl route_table subnet nat_gateway network_interface alb nlb
-      internet_gateway
+      internet_gateway autoscaling_group
     )
 
     types.each do |type|

--- a/lib/awspec/generator.rb
+++ b/lib/awspec/generator.rb
@@ -32,6 +32,7 @@ require 'awspec/generator/spec/eip'
 require 'awspec/generator/spec/rds_db_parameter_group'
 require 'awspec/generator/spec/rds_db_cluster_parameter_group'
 require 'awspec/generator/spec/codebuild'
+require 'awspec/generator/spec/autoscaling_group'
 
 # Doc
 require 'awspec/generator/doc/type'

--- a/lib/awspec/generator/spec/autoscaling_group.rb
+++ b/lib/awspec/generator/spec/autoscaling_group.rb
@@ -1,0 +1,52 @@
+module Awspec::Generator
+  module Spec
+    class AutoscalingGroup
+      include Awspec::Helper::Finder
+      def generate_by_vpc_id(vpc_id)
+        describes = %w(
+          auto_scaling_group_name auto_scaling_group_arn min_size max_size desired_capacity
+          default_cooldown availability_zones health_check_type health_check_grace_period
+          vpc_zone_identifier termination_policies new_instances_protected_from_scale_in
+        )
+        vpc = find_vpc(vpc_id)
+        raise 'Not Found VPC' unless vpc
+        @vpc_id = vpc[:vpc_id]
+        @vpc_tag_name = vpc.tag_name
+        autoscaling_groups = select_autoscaling_group_by_vpc_id(@vpc_id)
+        specs = autoscaling_groups.map do |autoscaling_group|
+          content = ERB.new(autoscaling_group_spec_template, nil, '-').result(binding).gsub(/^\n/, '')
+        end
+        specs.join("\n")
+      end
+
+      def autoscaling_group_spec_template
+        template = <<-'EOF'
+describe autoscaling_group('<%= autoscaling_group.auto_scaling_group_name %>') do
+  it { should exist }
+<% describes.each do |describe| %>
+<%- if autoscaling_group.members.include?(describe.to_sym) && !autoscaling_group[describe.to_sym].nil? -%>
+<%- if autoscaling_group[describe].is_a?(String) -%>
+  its(:<%= describe %>) { should eq '<%= autoscaling_group[describe] %>' }
+<%- else -%>
+  its(:<%= describe %>) { should eq <%= autoscaling_group[describe] %> }
+<%- end -%>
+<%- end -%>
+<% end %>
+<%- unless autoscaling_group.launch_configuration_name.nil? -%>
+  it { should have_launch_configuration('<%= autoscaling_group.launch_configuration_name %>') }
+<%- else -%>
+  its('launch_template.launch_template_name') { should eq '<%= autoscaling_group.launch_template.launch_template_name %>' }
+<%- end -%>
+<% autoscaling_group[:load_balancer_names].each do |desc| %>
+  it { should have_elb('<%= desc %>') }
+<% end %>
+<% autoscaling_group[:target_group_arns].each do |desc| %>
+  it { should have_alb_target_group('<%= desc.sub(/^.*targetgroup\/(.[^\/]*).*$/, '\1') %>') }
+<% end %>
+end
+EOF
+        template
+      end
+    end
+  end
+end

--- a/lib/awspec/helper/finder/autoscaling.rb
+++ b/lib/awspec/helper/finder/autoscaling.rb
@@ -36,6 +36,25 @@ module Awspec::Helper
         end
         ret.single_resource(device_id)
       end
+
+      def select_autoscaling_group_by_vpc_id(vpc_id)
+        subnets = []
+        select_subnet_by_vpc_id(vpc_id).each { |subnet| subnets << subnet.subnet_id }
+        req = {}
+        selected = []
+        loop do
+          res = autoscaling_client.describe_auto_scaling_groups(req)
+          res.auto_scaling_groups.select do |auto_scaling_group|
+            vpc_zone_identifiers = auto_scaling_group.vpc_zone_identifier.split(',')
+            selected.push(auto_scaling_group) if vpc_zone_identifiers.any? do |vpc_zone_identifier|
+              subnets.include?(vpc_zone_identifier)
+            end
+          end
+          break if res.next_token.nil?
+          req[:next_token] = res.next_token
+        end
+        selected
+      end
     end
   end
 end


### PR DESCRIPTION
Add generator for autoscaling_group.

```
  awspec generate autoscaling_group [vpc_id]                             # Generate autoscaling_group spec from VPC ID (or VPC "Name" tag)
```

- Output example:

```
describe autoscaling_group('my-auto-scaling-group') do
  it { should exist }
  its(:auto_scaling_group_name) { should eq 'my-auto-scaling-group' }
  its(:auto_scaling_group_arn) { should eq 'arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/my-auto-scaling-group' }
  its(:min_size) { should eq 0 }
  its(:max_size) { should eq 1 }
  its(:desired_capacity) { should eq 1 }
  its(:default_cooldown) { should eq 300 }
  its(:availability_zones) { should eq ["us-west-2c"] }
  its(:health_check_type) { should eq 'EC2' }
  its(:health_check_grace_period) { should eq 300 }
  its(:vpc_zone_identifier) { should eq 'subnet-12345678' }
  its(:termination_policies) { should eq ["Default"] }
  its(:new_instances_protected_from_scale_in) { should eq false }
  it { should have_launch_configuration('my-launch-config') }
  it { should have_elb('my-load-balancer') }
end
```