### PR TITLE
Bugfix/no method error

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -3244,7 +3244,7 @@ end
 ```
 
 
-### its(:default_action), its(:web_acl_id), its(:name), its(:metric_name)
+### its(:default_action), its(:web_acl_id), its(:name), its(:metric_name), its(:web_acl_arn)
 # Account and Attributes
 
 ## <a name="account">account</a>

--- a/lib/awspec/error.rb
+++ b/lib/awspec/error.rb
@@ -3,6 +3,26 @@ module Awspec
   end
   class InvalidAccountError < StandardError
   end
+  ##
+  # The exception when sending message to a unavailable AWS resource.
+  #
+  # It should be raised everytime a resource is not available (or doesn't
+  # exist) before trying to invoke a method from it and raising instead
+  # NoMethodError exception.
   class NoExistingResource < StandardError
+    ##
+    # Overrides the superclass initialize method to include more information
+    # and default error message.
+    # Expected parameters:
+    # - resource_type: the name of the resource type. Probably the class method return is the best option to be used.
+    # - id: the string used to search for the AWS resource. It will vary depending on the resource type, but probably
+    # will be an string.
+
+    def initialize(resource_type, id)
+      @resource_type = resource_type
+      @id = id
+      message = "The resource type #{resource_type} with id #{id} does not exist"
+      super message
+    end
   end
 end

--- a/lib/awspec/error.rb
+++ b/lib/awspec/error.rb
@@ -3,4 +3,6 @@ module Awspec
   end
   class InvalidAccountError < StandardError
   end
+  class NoExistingResource < StandardError
+  end
 end

--- a/lib/awspec/resource_reader.rb
+++ b/lib/awspec/resource_reader.rb
@@ -46,6 +46,7 @@ module Awspec
       @resource_via_client = resource
     end
 
+    # TODO: this method is specific to DynamoDB and probably should be moved somewhere else
     def describe_time_to_live(*args)
       @resource_via_client.send('describe_time_to_live', *args)
     end

--- a/lib/awspec/type/base.rb
+++ b/lib/awspec/type/base.rb
@@ -1,6 +1,7 @@
 require 'aws-sdk'
 require 'awspec/resource_reader'
 require 'awspec/helper/finder'
+require 'awspec/error'
 
 module Awspec::Type
   class Base
@@ -36,8 +37,11 @@ module Awspec::Type
     def method_missing(name)
       name_str = name.to_s if name.class == Symbol
       describe = name_str.tr('-', '_').to_sym
+
       if !resource_via_client.nil? && resource_via_client.members.include?(describe)
         resource_via_client[describe]
+      elsif resource_via_client.nil?
+        raise Awspec::NoExistingResource.new(self.class, @display_name)
       else
         super unless self.respond_to?(:resource)
         method_missing_via_black_list(name, delegate_to: resource)

--- a/lib/awspec/type/iam_policy.rb
+++ b/lib/awspec/type/iam_policy.rb
@@ -10,21 +10,6 @@ module Awspec::Type
       @id ||= resource_via_client.policy_id if resource_via_client
     end
 
-    def attachment_count
-      check_existence
-      resource_via_client.attachment_count
-    end
-
-    def policy_id
-      check_existence
-      resource_via_client.policy_id
-    end
-
-    def policy_name
-      check_existence
-      resource_via_client.policy_name
-    end
-
     def attachable?
       check_existence
       resource_via_client.is_attachable
@@ -75,7 +60,7 @@ module Awspec::Type
     private
 
     def check_existence
-      raise Awspec::NoExistingResource, "The policy with display name #{id} does not exist" if resource_via_client.nil?
+      raise Awspec::NoExistingResource.new(self.class, @display_name) if resource_via_client.nil?
     end
   end
 end

--- a/lib/awspec/type/iam_policy.rb
+++ b/lib/awspec/type/iam_policy.rb
@@ -75,9 +75,7 @@ module Awspec::Type
     private
 
     def check_existence
-      if resource_via_client.nil?
-        raise Awspec::NoExistingResource.new("The policy with display name #{id} does not exist")
-      end
+      raise Awspec::NoExistingResource, "The policy with display name #{id} does not exist" if resource_via_client.nil?
     end
   end
 end

--- a/lib/awspec/type/iam_policy.rb
+++ b/lib/awspec/type/iam_policy.rb
@@ -1,3 +1,5 @@
+require 'awspec/error'
+
 module Awspec::Type
   class IamPolicy < ResourceBase
     def resource_via_client
@@ -8,11 +10,28 @@ module Awspec::Type
       @id ||= resource_via_client.policy_id if resource_via_client
     end
 
+    def attachment_count
+      check_existence
+      resource_via_client.attachment_count
+    end
+
+    def policy_id
+      check_existence
+      resource_via_client.policy_id
+    end
+
+    def policy_name
+      check_existence
+      resource_via_client.policy_name
+    end
+
     def attachable?
+      check_existence
       resource_via_client.is_attachable
     end
 
     def attached_to_user?(user_id = nil)
+      check_existence
       users = select_attached_users(id)
       if user_id
         user = find_iam_user(user_id)
@@ -26,6 +45,7 @@ module Awspec::Type
     end
 
     def attached_to_group?(group_id = nil)
+      check_existence
       groups = select_attached_groups(@id)
       if group_id
         group = find_iam_group(group_id)
@@ -39,6 +59,7 @@ module Awspec::Type
     end
 
     def attached_to_role?(role_id = nil)
+      check_existence
       roles = select_attached_roles(@id)
       if role_id
         role = find_iam_role(role_id)
@@ -48,6 +69,14 @@ module Awspec::Type
         end
       else
         !roles.empty?
+      end
+    end
+
+    private
+
+    def check_existence
+      if resource_via_client.nil?
+        raise Awspec::NoExistingResource.new("The policy with display name #{id} does not exist")
       end
     end
   end

--- a/spec/type/iam_policy_spec.rb
+++ b/spec/type/iam_policy_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'awspec/error'
 Awspec::Stub.load 'iam_policy'
 
 describe iam_policy('my-iam-policy') do
@@ -11,4 +12,29 @@ describe iam_policy('my-iam-policy') do
   it { should be_attached_to_group('my-iam-group') }
   it { should be_attached_to_user('my-iam-user') }
   it { should be_attached_to_role('HelloIAmGodRole') }
+end
+
+describe iam_policy('unknow-iam-policy') do
+  it { should_not exist }
+  it do
+    expect { subject.attachment_count }.to raise_error(Awspec::NoExistingResource)
+  end
+  it do
+    expect { subject.policy_id }.to raise_error(Awspec::NoExistingResource)
+  end
+  it do
+    expect { subject.policy_name }.to raise_error(Awspec::NoExistingResource)
+  end
+  it do
+    expect { subject.attachable? }.to raise_error(Awspec::NoExistingResource)
+  end
+  it do
+    expect { subject.attached_to_user?('foobar') }.to raise_error(Awspec::NoExistingResource)
+  end
+  it do
+    expect { subject.attached_to_group?('foobar') }.to raise_error(Awspec::NoExistingResource)
+  end
+  it do
+    expect { subject.attached_to_role?('foobar') }.to raise_error(Awspec::NoExistingResource)
+  end
 end


### PR DESCRIPTION
See https://github.com/k1LoW/awspec/issues/421
Added new methods to Awspec::Type::IamPolicy in order to use delegation and check the existence of the policy as returned by the respective finder.
Created the exception Awspec::NoExistingResource to raise an error if the policy is not available.
Extended the unit tests to include those use cases.