### PR TITLE
Ignore AWS managed keys when generating KMS spec files

### DIFF
--- a/lib/awspec/generator/spec/kms.rb
+++ b/lib/awspec/generator/spec/kms.rb
@@ -14,7 +14,7 @@ module Awspec::Generator
 describe kms('<%= kms_alias.alias_name.split('/').last %>') do
   it { should exist }
 <% if find_kms_key(kms_alias.target_key_id).enabled -%>
-  it { should be_enable }
+  it { should be_enabled }
 <% end -%>
 end
 <% end %>

--- a/lib/awspec/generator/spec/kms.rb
+++ b/lib/awspec/generator/spec/kms.rb
@@ -3,7 +3,7 @@ module Awspec::Generator
     class Kms
       include Awspec::Helper::Finder
       def generate_all
-        aliases = select_all_kms_aliases
+        aliases = select_all_kms_aliases.select { |kms_alias| customer_managed_key?(kms_alias) }
         raise 'Not Found alias' if aliases.empty?
         ERB.new(keys_spec_template, nil, '-').result(binding).chomp
       end
@@ -20,6 +20,14 @@ end
 <% end %>
 EOF
         template
+      end
+
+      private
+
+      def customer_managed_key?(kms_alias)
+        # An aliase that has no target key id field is predefined by AWS.
+        # see: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/KMS/Client.html#list_aliases-instance_method
+        !kms_alias.target_key_id.nil?
       end
     end
   end

--- a/lib/awspec/stub/kms.rb
+++ b/lib/awspec/stub/kms.rb
@@ -6,6 +6,10 @@ Aws.config[:kms] = {
           alias_arn: 'arn:aws:kms:us-east-1:1234567890:alias/my-kms-key',
           alias_name: 'alias/my-kms-key',
           target_key_id: 'b9989d41-eeaa-401f-8616-00546948aa92'
+        },
+        {
+          alias_arn: 'arn:aws:kms:us-east-1:1234567890:alias/aws/example',
+          alias_name: 'alias/aws/example'
         }
       ]
     },

--- a/spec/generator/spec/kms_spec.rb
+++ b/spec/generator/spec/kms_spec.rb
@@ -10,7 +10,7 @@ describe 'Awspec::Generator::Spec::Kms' do
 
 describe kms('my-kms-key') do
   it { should exist }
-  it { should be_enable }
+  it { should be_enabled }
 end
 EOF
     expect(kms.generate_all.to_s.gsub(/\n/, "\n")).to eq spec


### PR DESCRIPTION
Fixes #396.

If [AWS managed KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk) exist in an AWS account, the generate command for KMS fails as follows.

```sh
$ bundle exec awspec generate kms --profile tatsuya
bundler: failed to load command: awspec (/Users/hoshino/tmp/awspec/vendor/bundle/ruby/2.6.0/bin/awspec)
NoMethodError: undefined method `enabled' for nil:NilClass
  (erb):4:in `block in generate_all'
  (erb):1:in `each'
  (erb):1:in `generate_all'
# snip
```

Because the AWS managed keys are not shown in an AWS management console,
I think that it seems no problem to ignore those keys.
Therefore, this PR changes the awspec to ignore AWS managed keys when generating KMS spec files.

BTW, this PR also fixes typos about the KMS rspec matcher, `be_enable` -> `be_enabled`.