### PR TITLE
Feature/lambda env var

### DIFF
--- a/doc/_resource_types/lambda.md
+++ b/doc/_resource_types/lambda.md
@@ -6,6 +6,35 @@ describe lambda('my-lambda-function-name') do
 end
 ```
 
+### have_env_vars
+
+Useful to validate if there are environment variables configured in the Lambda:
+
+```ruby
+describe lambda('my-lambda-function-name') do
+  it { should have_env_vars() }
+end
+```
+
+### have_env_var
+
+Useful to validate if there is a specific environment variable declared in the Lambda. You probably will want to use it with `have_env_var_value`.
+
+## have_env_var_value
+
+Validates if a specific environment variable has the expected value. More useful to use with `have_env_var` because if the variable isn't available, it will fail without notifying that the variable is missing.
+
+```ruby
+expected.each_pair do |key, value|
+  context "environment variable #{key}" do
+    it { should have_env_var(key) }
+    it { should have_env_var_value(key, value) }
+  end
+end
+```
+
+`expected` would be a hash that has the environment variables names as keys.
+
 ### have_event_source
 
-This matcher does not support Amazon S3 event sources. ( [See SDK doc](http://docs.aws.amazon.com/sdkforruby/api/Aws/Lambda/Client.html#list_event_source_mappings-instance_method) )
+This matcher does not support Amazon S3 event sources ([see SDK doc](http://docs.aws.amazon.com/sdkforruby/api/Aws/Lambda/Client.html#list_event_source_mappings-instance_method)).

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -2017,11 +2017,42 @@ end
 ```
 
 
+### have_env_var
+
+Useful to validate if there is a specific environment variable declared in the Lambda. You probably will want to use it with `have_env_var_value`.
+
+## have_env_var_value
+
+Validates if a specific environment variable has the expected value. More useful to use with `have_env_var` because if the variable isn't available, it will fail without notifying that the variable is missing.
+
+```ruby
+expected.each_pair do |key, value|
+  context "environment variable #{key}" do
+    it { should have_env_var(key) }
+    it { should have_env_var_value(key, value) }
+  end
+end
+```
+
+`expected` would be a hash that has the environment variables names as keys.
+
+
+### have_env_vars
+
+Useful to validate if there are environment variables configured in the Lambda:
+
+```ruby
+describe lambda('my-lambda-function-name') do
+  it { should have_env_vars() }
+end
+```
+
+
 ### have_event_source
 
-This matcher does not support Amazon S3 event sources. ( [See SDK doc](http://docs.aws.amazon.com/sdkforruby/api/Aws/Lambda/Client.html#list_event_source_mappings-instance_method) )
+This matcher does not support Amazon S3 event sources ([see SDK doc](http://docs.aws.amazon.com/sdkforruby/api/Aws/Lambda/Client.html#list_event_source_mappings-instance_method)).
 
-### its(:function_name), its(:function_arn), its(:runtime), its(:role), its(:handler), its(:code_size), its(:description), its(:timeout), its(:memory_size), its(:last_modified), its(:code_sha_256), its(:version), its(:vpc_config), its(:dead_letter_config), its(:environment), its(:kms_key_arn), its(:tracing_config), its(:master_arn), its(:revision_id), its(:layers)
+### its(:function_name), its(:function_arn), its(:runtime), its(:role), its(:handler), its(:code_size), its(:description), its(:timeout), its(:memory_size), its(:last_modified), its(:code_sha_256), its(:version), its(:vpc_config), its(:dead_letter_config), its(:kms_key_arn), its(:master_arn), its(:revision_id), its(:layers)
 ## <a name="launch_configuration">launch_configuration</a>
 
 LaunchConfiguration resource type.

--- a/lib/awspec/generator/doc/type/lambda.rb
+++ b/lib/awspec/generator/doc/type/lambda.rb
@@ -7,7 +7,7 @@ module Awspec::Generator
           @type_name = 'Lambda'
           @type = Awspec::Type::Lambda.new('my-lambda-function-name')
           @ret = @type.resource_via_client
-          @matchers = []
+          @matchers = %w(have_env_var have_env_vars)
           @ignore_matchers = []
           @describes = []
         end

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -78,3 +78,8 @@ require 'awspec/matcher/have_subscription_attributes'
 # Redshift
 require 'awspec/matcher/belong_to_cluster_subnet_group'
 require 'awspec/matcher/have_cluster_parameter_group'
+
+# Lambda
+require 'awspec/matcher/have_env_vars'
+require 'awspec/matcher/have_env_var'
+require 'awspec/matcher/have_env_var_value'

--- a/lib/awspec/matcher/have_env_var.rb
+++ b/lib/awspec/matcher/have_env_var.rb
@@ -1,0 +1,2 @@
+RSpec::Matchers.define :have_env_var do
+end

--- a/lib/awspec/matcher/have_env_var.rb
+++ b/lib/awspec/matcher/have_env_var.rb
@@ -1,2 +1,9 @@
-RSpec::Matchers.define :have_env_var do
+RSpec::Matchers.define :have_env_var do |env_var|
+  match do |lambda_function|
+    lambda_function.environment.variables.key?(env_var)
+  end
+
+  description do
+    'exist'
+  end
 end

--- a/lib/awspec/matcher/have_env_var_value.rb
+++ b/lib/awspec/matcher/have_env_var_value.rb
@@ -1,0 +1,18 @@
+RSpec::Matchers.define :have_env_var_value do |env_var, value|
+  match do |lambda_function|
+    if lambda_function.environment.variables.key?(env_var)
+      lambda_function.environment.variables[env_var] == value
+    else
+      false
+    end
+  end
+
+  description do
+    "have the value #{value}"
+  end
+
+  failure_message do |lambda_function|
+    current_value = lambda_function.environment.variables[env_var]
+    "Environment variable #{env_var} don't have the value #{value}, but #{current_value}"
+  end
+end

--- a/lib/awspec/matcher/have_env_vars.rb
+++ b/lib/awspec/matcher/have_env_vars.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define :have_env_vars do
   match do |lambda_function|
-    lambda_function.environment.variables.empty?
+    !lambda_function.environment.variables.empty?
   end
 end

--- a/lib/awspec/matcher/have_env_vars.rb
+++ b/lib/awspec/matcher/have_env_vars.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :have_env_vars do
+  match do |lambda_function|
+    lambda_function.environment.variables.empty?
+  end
+end

--- a/lib/awspec/stub/lambda.rb
+++ b/lib/awspec/stub/lambda.rb
@@ -10,7 +10,33 @@ Aws.config[:lambda] = {
           handler: 'lambda_function.lambda_handler',
           timeout: 5,
           memory_size: 256,
-          code_size: 1234
+          code_size: 1234,
+          last_modified: Time.new(2018, 12, 05, 19, 10, 44, '+00:00'),
+          code_sha_256: 'LAI9GRLpJD/dq2D7Uopwaeh354tsd8fQsSI6eSH0xOIs=',
+          version: '$LATEST',
+          role: 'arn:aws:iam::123456789:role/foobarVPCRole',
+          kms_key_arn: nil,
+          revision_id: '8d01897515-bcb0-43c7-9b14-e6d14fyyff4d',
+          layers: nil,
+          tracing_config:
+            #<struct Aws::Lambda::Types::TracingConfigResponse mode="PassThrough">
+            {
+              mode: 'PassThrough'
+            },
+          environment:
+            #<struct Aws::Lambda::Types::EnvironmentResponse
+            {
+            variables:
+              {
+                'ENDPOINT_URL' => 'https://foobar.sns.us-east-1.vpce.amazonaws.com',
+                'ENV_NAME' => 'QA',
+                'LOG_LEVEL' => 'DEBUG',
+                'FOOBAR_TOPIC' => 'arn:aws:sns:us-east-1:123456789:FoobarManager',
+                'RESOLVER1' => '10.196.138.1',
+                'RESOLVER2' => '10.196.136.2'
+              },
+              error: nil
+            }
         }
       ]
     },

--- a/lib/awspec/stub/lambda.rb
+++ b/lib/awspec/stub/lambda.rb
@@ -19,22 +19,22 @@ Aws.config[:lambda] = {
           revision_id: '8d01897515-bcb0-43c7-9b14-e6d14fyyff4d',
           layers: nil,
           tracing_config:
-            #<struct Aws::Lambda::Types::TracingConfigResponse mode="PassThrough">
+            # <struct Aws::Lambda::Types::TracingConfigResponse mode="PassThrough">
             {
               mode: 'PassThrough'
             },
           environment:
-            #<struct Aws::Lambda::Types::EnvironmentResponse
+            # <struct Aws::Lambda::Types::EnvironmentResponse
             {
-            variables:
-              {
-                'ENDPOINT_URL' => 'https://foobar.sns.us-east-1.vpce.amazonaws.com',
-                'ENV_NAME' => 'QA',
-                'LOG_LEVEL' => 'DEBUG',
-                'FOOBAR_TOPIC' => 'arn:aws:sns:us-east-1:123456789:FoobarManager',
-                'RESOLVER1' => '10.196.138.1',
-                'RESOLVER2' => '10.196.136.2'
-              },
+              variables:
+                {
+                  'ENDPOINT_URL' => 'https://foobar.sns.us-east-1.vpce.amazonaws.com',
+                  'ENV_NAME' => 'QA',
+                  'LOG_LEVEL' => 'DEBUG',
+                  'FOOBAR_TOPIC' => 'arn:aws:sns:us-east-1:123456789:FoobarManager',
+                  'RESOLVER1' => '10.196.138.1',
+                  'RESOLVER2' => '10.196.136.2'
+                },
               error: nil
             }
         }

--- a/lib/awspec/type/base.rb
+++ b/lib/awspec/type/base.rb
@@ -49,5 +49,11 @@ module Awspec::Type
     end
 
     undef :timeout
+
+    private
+
+    def check_existence
+      raise Awspec::NoExistingResource.new(self.class, @display_name) if resource_via_client.nil?
+    end
   end
 end

--- a/lib/awspec/type/iam_policy.rb
+++ b/lib/awspec/type/iam_policy.rb
@@ -57,10 +57,5 @@ module Awspec::Type
       end
     end
 
-    private
-
-    def check_existence
-      raise Awspec::NoExistingResource.new(self.class, @display_name) if resource_via_client.nil?
-    end
   end
 end

--- a/lib/awspec/type/iam_policy.rb
+++ b/lib/awspec/type/iam_policy.rb
@@ -56,6 +56,5 @@ module Awspec::Type
         !roles.empty?
       end
     end
-
   end
 end

--- a/lib/awspec/type/lambda.rb
+++ b/lib/awspec/type/lambda.rb
@@ -9,6 +9,7 @@ module Awspec::Type
     end
 
     def timeout
+      check_existence
       resource_via_client.timeout
     end
 

--- a/spec/type/iam_policy_spec.rb
+++ b/spec/type/iam_policy_spec.rb
@@ -28,5 +28,4 @@ describe iam_policy('unknow-iam-policy') do
       expect { subject.send(method_name, 'foobar') }.to raise_error(Awspec::NoExistingResource)
     end
   end
-
 end

--- a/spec/type/iam_policy_spec.rb
+++ b/spec/type/iam_policy_spec.rb
@@ -16,25 +16,17 @@ end
 
 describe iam_policy('unknow-iam-policy') do
   it { should_not exist }
-  it do
-    expect { subject.attachment_count }.to raise_error(Awspec::NoExistingResource)
+  methods = %w(attachment_count policy_id policy_name attachable?)
+  methods.each do |method_name|
+    it "#{method_name} raises Awspec::NoExistingResource" do
+      expect { subject.send(method_name) }.to raise_error(Awspec::NoExistingResource)
+    end
   end
-  it do
-    expect { subject.policy_id }.to raise_error(Awspec::NoExistingResource)
+  methods_with_param = %w(attached_to_user? attached_to_group? attached_to_role?)
+  methods_with_param.each do |method_name|
+    it "#{method_name} raises Awspec::NoExistingResource" do
+      expect { subject.send(method_name, 'foobar') }.to raise_error(Awspec::NoExistingResource)
+    end
   end
-  it do
-    expect { subject.policy_name }.to raise_error(Awspec::NoExistingResource)
-  end
-  it do
-    expect { subject.attachable? }.to raise_error(Awspec::NoExistingResource)
-  end
-  it do
-    expect { subject.attached_to_user?('foobar') }.to raise_error(Awspec::NoExistingResource)
-  end
-  it do
-    expect { subject.attached_to_group?('foobar') }.to raise_error(Awspec::NoExistingResource)
-  end
-  it do
-    expect { subject.attached_to_role?('foobar') }.to raise_error(Awspec::NoExistingResource)
-  end
+
 end

--- a/spec/type/lambda_spec.rb
+++ b/spec/type/lambda_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'awspec/error'
 Awspec::Stub.load 'lambda'
 
 describe lambda('my-lambda-function-name') do
@@ -9,8 +10,21 @@ describe lambda('my-lambda-function-name') do
   its(:code_size) { should eq 1234 }
   its(:timeout) { should eq 5 }
   its(:memory_size) { should eq 256 }
+  its(:last_modified) { should eq Time.new(2018, 12, 05, 19, 10, 44, '+00:00') }
+  its(:code_sha_256) { should eq 'LAI9GRLpJD/dq2D7Uopwaeh354tsd8fQsSI6eSH0xOIs=' }
+  its(:version) { should eq '$LATEST' }
+  its(:role) { should eq 'arn:aws:iam::123456789:role/foobarVPCRole' }
+  its(:kms_key_arn) { should be nil }
+  its(:revision_id) { should eq '8d01897515-bcb0-43c7-9b14-e6d14fyyff4d' }
+  its(:layers) { should be nil }
 end
 
 describe lambda('not-exist-function') do
   it { should_not exist }
+  methods = %w(description runtime handler code_size timeout memory_size last_modified code_sha_256 version RESOLVER1 kms_key_arn revision_id layers)
+  methods.each do |method_name|
+    it "#{method_name} raises Awspec::NoExistingResource" do
+      expect { subject.send(method_name) }.to raise_error(Awspec::NoExistingResource)
+    end
+  end
 end


### PR DESCRIPTION
Related to #423.
Adding more properties to be tested with Lambda.
Creating new matchers for Lambda (not tested yet).
Validating that non-existing Lambda function methods will raise `Awspec::NoExistingResource`.
Added custom matchers to check on Lambda environment variables.
Extended the spec of Lambda.
Updated documentation.
Fixed Rubocop issues.