### PR TITLE
Fixes for issue #434

### DIFF
--- a/lib/awspec/type/apigateway.rb
+++ b/lib/awspec/type/apigateway.rb
@@ -2,82 +2,14 @@ module Awspec::Type
   class Apigateway < ResourceBase
     aws_resource Aws::APIGateway::Client
 
-    def cache_values(res)
-      @id = res.id
-      @name = res.name
-      @description = res.description
-      @created_date = res.created_date
-      @version = res.version
-      @warnings = res.warnings
-      @binary_media_types = res.binary_media_types
-      @minimum_compression_size = res.minimum_compression_size
-      @api_key_source = res.api_key_source
-      @policy = res.policy
-      @endpoint_configuration = res.endpoint_configuration
-    end
-
     def resource_via_client
-      return unless @resource_via_client.nil?
-
-      @resource_via_client = find_apigateway_by_id(@display_name)
+      @resource_via_client ||= find_apigateway_by_id(@display_name)
       return @resource_via_client if @resource_via_client
-
       @resource_via_client = find_apigateway_by_name(@display_name)
     end
 
     def id
-      cache_values(resource_via_client) if @id.nil?
-      @id
-    end
-
-    def name
-      cache_values(resource_via_client) if @name.nil?
-      @name
-    end
-
-    def description
-      cache_values(resource_via_client) if @description.nil?
-      @description
-    end
-
-    def created_date
-      cache_values(resource_via_client) if @created_date.nil?
-      @created_date
-    end
-
-    def version
-      cache_values(resource_via_client) if @version.nil?
-      @version
-    end
-
-    def warnings
-      cache_values(resource_via_client) if @warnings.nil?
-      @warnings
-    end
-
-    def binary_media_types
-      cache_values(resource_via_client) if @binary_media_types.nil?
-      @binary_media_types
-    end
-
-    def minimum_compression_size
-      cache_values(resource_via_client) if @minimum_compression_size.nil?
-      @minimum_compression_size
-    end
-
-    def api_key_source
-      cache_values(resource_via_client) if @api_key_source.nil?
-      @api_key_source
-    end
-
-    def policy
-      cache_values(resource_via_client) if @policy.nil?
-      @policy
-    end
-
-    def endpoint_configuration
-      cache_values(resource_via_client) if @endpoint_configuration.nil?
-      @endpoint_configuration
+      @id ||= resource_via_client.id if resource_via_client
     end
   end
 end

--- a/lib/awspec/type/base.rb
+++ b/lib/awspec/type/base.rb
@@ -22,6 +22,10 @@ module Awspec::Type
       to_s
     end
 
+    def respond_to_missing?(method, include_private = false)
+      resource_via_client.respond_to?(method) || super unless resource_via_client.nil?
+    end
+
     def self.tags_allowed
       define_method :has_tag? do |key, value|
         begin


### PR DESCRIPTION
Added method `respond_to_missing?` to the `Awspec::Type::Base`, as declared in the issue #434 
Removed all getter methods declared in `Awspec::Type::Apigateway`, leaving it to be resolved by the base class.