### PR TITLE
Add have_server_side_encryption matcher to s3_bucket

### DIFF
--- a/doc/_resource_types/s3_bucket.md
+++ b/doc/_resource_types/s3_bucket.md
@@ -130,6 +130,15 @@ describe s3_bucket('my-bucket') do
 end
 ```
 
+### have_server_side_encryption
+
+```
+describe s3_bucket('my-bucket') do
+  it { should have_server_side_encryption(algorithm: "AES256") }
+  it { should have_server_side_encryption(algorithm: "aws:kms") }
+end
+```
+
 ### advanced
 
 `s3_bucket` can use `Aws::S3::Bucket` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Bucket.html).

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -2551,7 +2551,7 @@ end
 ```
 
 
-### its(:vpc_id), its(:db_instance_identifier), its(:db_instance_class), its(:engine), its(:db_instance_status), its(:master_username), its(:db_name), its(:endpoint), its(:allocated_storage), its(:instance_create_time), its(:preferred_backup_window), its(:backup_retention_period), its(:db_security_groups), its(:availability_zone), its(:preferred_maintenance_window), its(:pending_modified_values), its(:latest_restorable_time), its(:multi_az), its(:engine_version), its(:auto_minor_version_upgrade), its(:read_replica_source_db_instance_identifier), its(:read_replica_db_instance_identifiers), its(:read_replica_db_cluster_identifiers), its(:license_model), its(:iops), its(:character_set_name), its(:secondary_availability_zone), its(:publicly_accessible), its(:status_infos), its(:storage_type), its(:tde_credential_arn), its(:db_instance_port), its(:db_cluster_identifier), its(:storage_encrypted), its(:kms_key_id), its(:dbi_resource_id), its(:ca_certificate_identifier), its(:domain_memberships), its(:copy_tags_to_snapshot), its(:monitoring_interval), its(:enhanced_monitoring_resource_arn), its(:monitoring_role_arn), its(:promotion_tier), its(:db_instance_arn), its(:timezone), its(:iam_database_authentication_enabled), its(:performance_insights_enabled), its(:performance_insights_kms_key_id), its(:performance_insights_retention_period), its(:enabled_cloudwatch_logs_exports), its(:processor_features), its(:deletion_protection), its(:listener_endpoint)
+### its(:vpc_id), its(:db_instance_identifier), its(:db_instance_class), its(:engine), its(:db_instance_status), its(:master_username), its(:db_name), its(:endpoint), its(:allocated_storage), its(:instance_create_time), its(:preferred_backup_window), its(:backup_retention_period), its(:db_security_groups), its(:availability_zone), its(:preferred_maintenance_window), its(:pending_modified_values), its(:latest_restorable_time), its(:multi_az), its(:engine_version), its(:auto_minor_version_upgrade), its(:read_replica_source_db_instance_identifier), its(:read_replica_db_instance_identifiers), its(:read_replica_db_cluster_identifiers), its(:license_model), its(:iops), its(:character_set_name), its(:secondary_availability_zone), its(:publicly_accessible), its(:status_infos), its(:storage_type), its(:tde_credential_arn), its(:db_instance_port), its(:db_cluster_identifier), its(:storage_encrypted), its(:kms_key_id), its(:dbi_resource_id), its(:ca_certificate_identifier), its(:domain_memberships), its(:copy_tags_to_snapshot), its(:monitoring_interval), its(:enhanced_monitoring_resource_arn), its(:monitoring_role_arn), its(:promotion_tier), its(:db_instance_arn), its(:timezone), its(:iam_database_authentication_enabled), its(:performance_insights_enabled), its(:performance_insights_kms_key_id), its(:performance_insights_retention_period), its(:enabled_cloudwatch_logs_exports), its(:processor_features), its(:deletion_protection), its(:associated_roles), its(:listener_endpoint)
 ### :unlock: Advanced use
 
 `rds` can use `Aws::RDS::DBInstance` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/RDS/DBInstance.html).
@@ -2925,6 +2925,16 @@ describe s3_bucket('my-bucket') do
 }
     POLICY
   end
+end
+```
+
+
+### have_server_side_encryption
+
+```
+describe s3_bucket('my-bucket') do
+  it { should have_server_side_encryption(algorithm: "AES256") }
+  it { should have_server_side_encryption(algorithm: "aws:kms") }
 end
 ```
 

--- a/lib/awspec/helper/finder/s3.rb
+++ b/lib/awspec/helper/finder/s3.rb
@@ -56,6 +56,13 @@ module Awspec::Helper
         nil
       end
 
+      def find_bucket_server_side_encryption(id)
+        res = s3_client.get_bucket_encryption(bucket: id)
+        res.server_side_encryption_configuration
+      rescue Aws::S3::Errors::ServiceError
+        nil
+      end
+
       def select_all_buckets
         s3_client.list_buckets.buckets
       end

--- a/lib/awspec/stub/s3_bucket.rb
+++ b/lib/awspec/stub/s3_bucket.rb
@@ -118,6 +118,18 @@ Aws.config[:s3] = {
           }
         }
       ]
+    },
+    get_bucket_encryption: {
+      server_side_encryption_configuration: {
+        rules: [
+          {
+            apply_server_side_encryption_by_default: {
+              sse_algorithm: 'aws:kms',
+              kms_master_key_id: '[FILTERED]'
+            }
+          }
+        ]
+      }
     }
   }
 }

--- a/lib/awspec/type/s3_bucket.rb
+++ b/lib/awspec/type/s3_bucket.rb
@@ -109,6 +109,14 @@ module Awspec::Type
       bv ? (bv.mfa_delete == 'Enabled') : false
     end
 
+    def has_server_side_encryption?(algorithm:)
+      configuration = find_bucket_server_side_encryption(id)
+      return false unless configuration
+
+      sse_algorithm = configuration.rules[0].apply_server_side_encryption_by_default.sse_algorithm
+      sse_algorithm ? (sse_algorithm == algorithm) : false
+    end
+
     private
 
     def cors_rules

--- a/spec/type/s3_bucket_spec.rb
+++ b/spec/type/s3_bucket_spec.rb
@@ -56,6 +56,8 @@ describe s3_bucket('my-bucket') do
 
   it { should have_mfa_delete_enabled }
 
+  it { should have_server_side_encryption(algorithm: 'aws:kms') }
+
   context 'nested attribute call' do
     its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }
     its('resource.name') { should eq 'my-bucket' }


### PR DESCRIPTION
Fixes #436 

This PR adds have_server_side_encryption matcher to s3_bucket.
This matcher is used as follows to test whether server side encryption enabled or not.

```
describe s3_bucket('my-bucket') do
  it { should have_server_side_encryption(algorithm: 'aws:kms') }
end
```

I would appreciate receiving a feedback.