### PR TITLE
Remove unused variables

### DIFF
--- a/lib/awspec/helper/finder/s3.rb
+++ b/lib/awspec/helper/finder/s3.rb
@@ -2,8 +2,7 @@ module Awspec::Helper
   module Finder
     module S3
       def find_bucket(id)
-        res = s3_client.list_buckets
-        ret = s3_client.list_buckets[:buckets].find do |bucket|
+        s3_client.list_buckets[:buckets].find do |bucket|
           bucket.name == id
         end
       end


### PR DESCRIPTION
Hi.

This PR just removes unused variables in `Awspec::Helper::Finder::S3#find_bucket`.