### PR TITLE
Remove the unnecessary `puts`

### DIFF
--- a/lib/awspec/helper/finder/sns_topic.rb
+++ b/lib/awspec/helper/finder/sns_topic.rb
@@ -44,7 +44,6 @@ module Awspec::Helper
         # Awspec::NoExistingResource will be raised.
         begin
           response = sns_client.get_topic_attributes({ topic_arn: topic_arn })
-          puts response
           topic = SnsTopic.new(response.attributes)
         rescue Aws::SNS::Errors::NotFound
           topic = nil


### PR DESCRIPTION
Hi!

On master branch (c32b2cdb02d8cc8b2d71ed7efc6c8c0095e37eb1), `bundle exec bin/toolbox docgen > doc/resource_types.md` would generate a file difference as below:

```sh
$ git rev-parse --abbrev-ref @
master
$ git rev-parse HEAD
c32b2cdb02d8cc8b2d71ed7efc6c8c0095e37eb1
$
$ bundle exec bin/toolbox docgen > doc/resource_types.md
$ git diff | cat
diff --git a/doc/resource_types.md b/doc/resource_types.md
index 0e86006..5a6b9b3 100644
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -1,3 +1,4 @@
+{:attributes=>{"Policy"=>"{\\\"Version\\\":\\\"2008-10-17\\\",\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Sid\\\":\\\"__default_statement_ID\\\",\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Resource\\\":\\\"arn:aws:sns:us-east-1:123456789:foobar-lambda-sample\\\",\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"123456789\\\"}}}]}", "Owner"=>"123456789", "SubscriptionsPending"=>"0", "TopicArn"=>"arn:aws:sns:us-east-1:123456789:foobar", "EffectiveDeliveryPolicy"=>"{\\\"http\\\":{\\\"defaultHealthyRetryPolicy\\\":{\\\"minDelayTarget\\\":20,\\\"maxDelayTarget\\\":20,\\\"numRetries\\\":3,\\\"numMaxDelayRetries\\\":0,\\\"numNoDelayRetries\\\":0,\\\"numMinDelayRetries\\\":0,\\\"backoffFunction\\\":\\\"linear\\\"},\\\"disableSubscriptionOverrides\\\":false}}", "SubscriptionsConfirmed"=>"1", "DisplayName"=>"Useless", "SubscriptionsDeleted"=>"0"}}
 # Resource Types

 [acm](#acm)
$
```

I found that the cause is an unnecessary `puts`, and this PR removes that `puts`.