### PR TITLE
Support for testing absence of inline policies

### DIFF
--- a/doc/_resource_types/iam_group.md
+++ b/doc/_resource_types/iam_group.md
@@ -67,6 +67,14 @@ DOC
 end
 ```
 
+You can test absence of inline policies.
+
+```ruby
+describe iam_group('my-iam-group') do
+  it { should_not have_inline_policy }
+end
+```
+
 ### advanced
 
 `iam_group` can use `Aws::IAM::Group` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/IAM/Group.html).

--- a/doc/_resource_types/iam_group.md
+++ b/doc/_resource_types/iam_group.md
@@ -31,7 +31,7 @@ describe iam_group('my-iam-group') do
 end
 ```
 
-### have_inline_group
+### have_inline_policy
 
 ```ruby
 describe iam_group('my-iam-group') do

--- a/doc/_resource_types/iam_role.md
+++ b/doc/_resource_types/iam_role.md
@@ -51,6 +51,14 @@ DOC
 end
 ```
 
+You can test absence of inline policies.
+
+```ruby
+describe iam_role('my-iam-role') do
+  it { should_not have_inline_policy }
+end
+```
+
 ### advanced
 
 `iam_role` can use `Aws::IAM::Role` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/IAM/Role.html).

--- a/doc/_resource_types/iam_user.md
+++ b/doc/_resource_types/iam_user.md
@@ -51,6 +51,14 @@ DOC
 end
 ```
 
+You can test absence of inline policies.
+
+```ruby
+describe iam_user('my-iam-user') do
+  it { should_not have_inline_policy }
+end
+```
+
 ### belong_to_iam_group
 
 ```ruby

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -1798,6 +1798,14 @@ DOC
 end
 ```
 
+You can test absence of inline policies.
+
+```ruby
+describe iam_role('my-iam-role') do
+  it { should_not have_inline_policy }
+end
+```
+
 
 ### its(:path), its(:role_name), its(:role_id), its(:arn), its(:create_date), its(:assume_role_policy_document), its(:description), its(:max_session_duration), its(:permissions_boundary), its(:tags)
 ### :unlock: Advanced use
@@ -1875,6 +1883,14 @@ describe iam_user('my-iam-user') do
 }
 DOC
   end
+end
+```
+
+You can test absence of inline policies.
+
+```ruby
+describe iam_user('my-iam-user') do
+  it { should_not have_inline_policy }
 end
 ```
 

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -1670,6 +1670,49 @@ end
 
 ### have_inline_policy
 
+```ruby
+describe iam_group('my-iam-group') do
+  it { should have_inline_policy('InlineEC2FullAccess') }
+  it do
+    should have_inline_policy('InlineEC2FullAccess').policy_document(<<-'DOC')
+{
+  "Statement": [
+    {
+      "Action": "ec2:*",
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "elasticloadbalancing:*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "cloudwatch:*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "autoscaling:*",
+      "Resource": "*"
+    }
+  ]
+}
+DOC
+  end
+end
+```
+
+You can test absence of inline policies.
+
+```ruby
+describe iam_group('my-iam-group') do
+  it { should_not have_inline_policy }
+end
+```
+
+
 ### its(:path), its(:group_name), its(:group_id), its(:arn), its(:create_date)
 ### :unlock: Advanced use
 

--- a/lib/awspec/type/iam_group.rb
+++ b/lib/awspec/type/iam_group.rb
@@ -28,12 +28,21 @@ module Awspec::Type
     end
 
     def has_inline_policy?(policy_name, document = nil)
+      return has_any_inline_policies? unless policy_name
+
       res = iam_client.get_group_policy({
                                           group_name: id,
                                           policy_name: policy_name
                                         })
       return JSON.parse(URI.decode(res.policy_document)) == JSON.parse(document) if document
       res
+    end
+
+    private
+
+    def has_any_inline_policies?
+      res = iam_client.list_group_policies(group_name: id)
+      !res.policy_names.empty?
     end
   end
 end

--- a/lib/awspec/type/iam_role.rb
+++ b/lib/awspec/type/iam_role.rb
@@ -18,12 +18,21 @@ module Awspec::Type
     end
 
     def has_inline_policy?(policy_name, document = nil)
+      return has_any_inline_policies? unless policy_name
+
       res = iam_client.get_role_policy({
                                          role_name: resource_via_client.role_name,
                                          policy_name: policy_name
                                        })
       return JSON.parse(URI.decode(res.policy_document)) == JSON.parse(document) if document
       res
+    end
+
+    private
+
+    def has_any_inline_policies?
+      res = iam_client.list_role_policies(role_name: resource_via_client.role_name)
+      !res.policy_names.empty?
     end
   end
 end

--- a/lib/awspec/type/iam_user.rb
+++ b/lib/awspec/type/iam_user.rb
@@ -18,12 +18,21 @@ module Awspec::Type
     end
 
     def has_inline_policy?(policy_name, document = nil)
+      return has_any_inline_policies? unless policy_name
+
       res = iam_client.get_user_policy({
                                          user_name: resource_via_client.user_name,
                                          policy_name: policy_name
                                        })
       return JSON.parse(URI.decode(res.policy_document)) == JSON.parse(document) if document
       res
+    end
+
+    private
+
+    def has_any_inline_policies?
+      res = iam_client.list_user_policies(user_name: resource_via_client.user_name)
+      !res.policy_names.empty?
     end
   end
 end

--- a/spec/type/iam_group_spec.rb
+++ b/spec/type/iam_group_spec.rb
@@ -5,6 +5,7 @@ describe iam_group('my-iam-group') do
   it { should exist }
   it { should have_iam_user('my-iam-user') }
   it { should have_iam_policy('ReadOnlyAccess') }
+  it { should have_inline_policy }
   it { should have_inline_policy('InlineEC2FullAccess') }
   it do
     should have_inline_policy('InlineEC2FullAccess').policy_document(<<-'DOC')

--- a/spec/type/iam_role_spec.rb
+++ b/spec/type/iam_role_spec.rb
@@ -4,6 +4,7 @@ Awspec::Stub.load 'iam_role'
 describe iam_role('my-iam-role') do
   it { should exist }
   it { should have_iam_policy('ReadOnlyAccess') }
+  it { should have_inline_policy }
   it { should have_inline_policy('AllowS3BucketAccess') }
   it do
     should have_inline_policy('AllowS3BucketAccess').policy_document(<<-'DOC')

--- a/spec/type/iam_user_spec.rb
+++ b/spec/type/iam_user_spec.rb
@@ -5,6 +5,7 @@ describe iam_user('my-iam-user') do
   it { should exist }
   it { should belong_to_iam_group('my-iam-group') }
   it { should have_iam_policy('ReadOnlyAccess') }
+  it { should have_inline_policy }
   it { should have_inline_policy('AllowS3BucketAccess') }
   it do
     should have_inline_policy('AllowS3BucketAccess').policy_document(<<-'DOC')


### PR DESCRIPTION
Fixes #222 .

Hi!

This PR enables awspec users to test absence of inline policies as below:

```ruby
describe iam_user('my-iam-user') do
  it { should_not have_inline_policy }
end
```

Also, this PR contains typo fix `have_inline_group` -> `have_inline_policy` in `iam_group.md`.