### PR TITLE
Add tag support to nat gateways

### DIFF
--- a/doc/_resource_types/nat_gateway.md
+++ b/doc/_resource_types/nat_gateway.md
@@ -29,3 +29,11 @@ describe nat_gateway('nat-7ff7777f') do
   it { should belong_to_vpc('my-vpc') }
 end
 ```
+
+### have_tag
+
+```ruby
+describe nat_gateway('nat-7ff7777f') do
+  it { should have_tag('Name').value('my-nat-gateway') }
+end
+```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -2299,6 +2299,14 @@ end
 ```
 
 
+### have_tag
+
+```ruby
+describe nat_gateway('nat-7ff7777f') do
+  it { should have_tag('Name').value('my-nat-gateway') }
+end
+```
+
 ### belong_to_vpc
 
 ```ruby
@@ -2307,7 +2315,8 @@ describe nat_gateway('nat-7ff7777f') do
 end
 ```
 
-### its(:create_time), its(:delete_time), its(:failure_code), its(:failure_message), its(:nat_gateway_id), its(:provisioned_bandwidth), its(:state), its(:subnet_id), its(:vpc_id), its(:tags)
+
+### its(:create_time), its(:delete_time), its(:failure_code), its(:failure_message), its(:nat_gateway_id), its(:provisioned_bandwidth), its(:state), its(:subnet_id), its(:vpc_id)
 ## <a name="network_acl">network_acl</a>
 
 NetworkAcl resource type.

--- a/lib/awspec/stub/nat_gateway.rb
+++ b/lib/awspec/stub/nat_gateway.rb
@@ -11,6 +11,12 @@ Aws.config[:ec2] = {
             allocation_id: 'unknown',
             private_ip: 'unknown',
             network_interface_id: 'unknown'
+          ],
+          tags: [
+            {
+              key: 'Name',
+              value: 'my-nat-gateway'
+            }
           ]
         }
       ],

--- a/lib/awspec/type/nat_gateway.rb
+++ b/lib/awspec/type/nat_gateway.rb
@@ -1,5 +1,7 @@
 module Awspec::Type
   class NatGateway < ResourceBase
+    tags_allowed
+
     def resource_via_client
       @resource_via_client ||= find_nat_gateway(@display_name)
     end

--- a/spec/type/nat_gateway_spec.rb
+++ b/spec/type/nat_gateway_spec.rb
@@ -6,4 +6,5 @@ describe nat_gateway('nat-7ff7777f') do
   it { should be_available }
   it { should have_eip('123.0.456.789') }
   it { should belong_to_vpc('my-vpc') }
+  it { should have_tag('Name').value('my-nat-gateway') }
 end


### PR DESCRIPTION
Fix #453 .

While #453 issue has been marked as a bug, it seems that `have_tag` matcher for nat gateway resources have been not supported yet.

This PR allow users to test about tags of nat gateways.