### PR TITLE
Fix/issue 356

### DIFF
--- a/lib/awspec/helper/finder/lambda.rb
+++ b/lib/awspec/helper/finder/lambda.rb
@@ -23,7 +23,7 @@ module Awspec::Helper
       end
 
       def select_all_lambda_functions
-        res = lambda_client.list_functions.map do |response|
+        lambda_client.list_functions.map do |response|
           response.functions
         end.flatten
       end

--- a/lib/awspec/helper/finder/s3.rb
+++ b/lib/awspec/helper/finder/s3.rb
@@ -13,6 +13,16 @@ module Awspec::Helper
         nil
       end
 
+      def head_object(id, key)
+        res = s3_client.head_object({
+                                      bucket: id,
+                                      key: key.sub(%r(\A/), '')
+                                    })
+        res.data.class == Aws::S3::Types::HeadObjectOutput
+      rescue Aws::S3::Errors::NotFound
+        false
+      end
+
       def find_bucket_cors(id)
         s3_client.get_bucket_cors(bucket: id)
       rescue Aws::S3::Errors::ServiceError

--- a/lib/awspec/type/ec2.rb
+++ b/lib/awspec/type/ec2.rb
@@ -90,7 +90,7 @@ module Awspec::Type
     def has_network_interface?(network_interface_id, device_index = nil)
       res = find_network_interface(network_interface_id)
       interfaces = resource_via_client.network_interfaces
-      ret = interfaces.find do |interface|
+      interfaces.find do |interface|
         next false if device_index && interface.attachment.device_index != device_index
         interface.network_interface_id == res.network_interface_id
       end
@@ -98,7 +98,7 @@ module Awspec::Type
 
     def has_event?(event_code)
       status = find_ec2_status(id)
-      ret = status.events.find do |event|
+      status.events.find do |event|
         event.code == event_code
       end
     end

--- a/lib/awspec/type/s3_bucket.rb
+++ b/lib/awspec/type/s3_bucket.rb
@@ -1,5 +1,7 @@
 module Awspec::Type
   class S3Bucket < ResourceBase
+    aws_resource Aws::S3::Bucket
+
     def resource_via_client
       @resource_via_client ||= find_bucket(@display_name)
     end

--- a/spec/type/lambda_spec.rb
+++ b/spec/type/lambda_spec.rb
@@ -37,7 +37,7 @@ describe lambda('my-lambda-function-name') do
   end
 end
 
-describe lambda('not-exist-function') do
+describe lambda('no-existing-function') do
   it { should_not exist }
   methods = %w(environment description runtime handler code_size timeout memory_size last_modified code_sha_256 version
                kms_key_arn revision_id layers tracing_config)

--- a/spec/type/s3_bucket_spec.rb
+++ b/spec/type/s3_bucket_spec.rb
@@ -4,20 +4,20 @@ Awspec::Stub.load 's3_bucket'
 describe s3_bucket('my-bucket') do
   it { should exist }
   it { should have_object('path/to/object') }
-
   its(:acl_owner) { should eq 'my-bucket-owner' }
   its(:acl_grants_count) { should eq 3 }
+  its(:cors_rules_count) { should eq 2 }
   it { should have_acl_grant(grantee: 'my-bucket-owner', permission: 'FULL_CONTROL') }
   it { should have_acl_grant(grantee: 'http://acs.amazonaws.com/groups/s3/LogDelivery', permission: 'WRITE') }
   it { should have_acl_grant(grantee: '68f4bb06b094152df53893bfba57760e', permission: 'READ') }
 
-  its(:cors_rules_count) { should eq 2 }
   it do
     should have_cors_rule(
       allowed_methods: ['GET'],
       allowed_origins: ['*']
     )
   end
+
   it do
     should have_cors_rule(
       allowed_headers: ['*'],
@@ -49,39 +49,10 @@ describe s3_bucket('my-bucket') do
   end
 
   it { should have_logging_enabled(target_bucket: 'my-log-bucket', target_prefix: 'logs/') }
-
   it { should have_tag('env').value('dev') }
-
   it { should have_versioning_enabled }
-
   it { should have_mfa_delete_enabled }
-
   it { should have_server_side_encryption(algorithm: 'aws:kms') }
-
-  context 'nested attribute call' do
-    its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }
-    its('resource.name') { should eq 'my-bucket' }
-    its('resource.acl') { should be_an_instance_of(Awspec::ResourceReader) }
-    its(:acl) { should be_an_kind_of(Awspec::ResourceReader) }
-    it 'should be a Exception when black list method is called' do
-      expect { subject.delete }.to raise_error(
-        Awspec::BlackListForwardable::CalledMethodInBlackList,
-        'Method call :delete is black-listed'
-      )
-    end
-
-    its('acl.owner.display_name') { should eq 'my-bucket-owner' }
-  end
-end
-
-describe s3_bucket('my-bucket') do
-  it { should exist }
-  it { should have_object('path/to/object') }
-  its(:acl_grants_count) { should eq 3 }
-  it { should have_acl_grant(grantee: 'my-bucket-owner', permission: 'FULL_CONTROL') }
-  it { should have_acl_grant(grantee: 'http://acs.amazonaws.com/groups/s3/LogDelivery', permission: 'WRITE') }
-  it { should have_acl_grant(grantee: '68f4bb06b094152df53893bfba57760e', permission: 'READ') }
-  its(:acl_owner) { should eq 'my-bucket-owner' }
 end
 
 describe s3_bucket('my-bucket') do
@@ -104,5 +75,58 @@ describe s3_bucket('my-bucket') do
       transitions: [{ days: 5, storage_class: 'STANDARD_IA' }, { days: 10, storage_class: 'GLACIER' }],
       status: 'Enabled'
     )
+  end
+end
+
+describe s3_bucket('not-available') do
+  it { should_not exist }
+
+  methods = %w(acl_owner acl_grants_count cors_rules_count
+               has_versioning_enabled? has_versioning_enabled?
+               has_mfa_delete_enabled?)
+  methods.each do |method_name|
+    it "#{method_name} raises Awspec::NoExistingResource" do
+      expect { subject.send(method_name) }.to raise_error(Awspec::NoExistingResource)
+    end
+  end
+
+  methods_with_params = %w(has_object? has_policy?)
+  methods_with_params.each do |method_name|
+    it "#{method_name} raises Awspec::NoExistingResource" do
+      expect { subject.send(method_name, 'foo') }.to raise_error(Awspec::NoExistingResource)
+    end
+  end
+
+  it 'has_lifecycle_rule? raises Awspec::NoExistingResource' do
+    expect { subject.has_lifecycle_rule?({}) }.to raise_error(Awspec::NoExistingResource)
+  end
+
+  it 'has_server_side_encryption? raises Awspec::NoExistingResource' do
+    expect { subject.has_server_side_encryption?(algorithm: 'foo') }.to raise_error(Awspec::NoExistingResource)
+  end
+
+  it 'has_tag? raises Awspec::NoExistingResource' do
+    expect { subject.has_tag?('foo', 'bar') }.to raise_error(Awspec::NoExistingResource)
+  end
+
+  it 'has_acl_grant? raises Awspec::NoExistingResource' do
+    expect do
+      subject.has_acl_grant?(grantee: 'foo',
+                             permission: 'bar').to raise_error(Awspec::NoExistingResource)
+    end
+  end
+
+  it 'has_logging_enabled? raises Awspec::NoExistingResource' do
+    expect do
+      subject.has_logging_enabled?(target_bucket: 'my-log-bucket',
+                                   target_prefix: 'logs/').to raise_error(Awspec::NoExistingResource)
+    end
+  end
+
+  it 'has_cors_rule? raises Awspec::NoExistingResource' do
+    expect do
+      subject.has_cors_rule?(allowed_methods: ['GET'],
+                             allowed_origins: ['*']).to raise_error(Awspec::NoExistingResource)
+    end
   end
 end

--- a/spec/type/s3_bucket_spec.rb
+++ b/spec/type/s3_bucket_spec.rb
@@ -53,6 +53,18 @@ describe s3_bucket('my-bucket') do
   it { should have_versioning_enabled }
   it { should have_mfa_delete_enabled }
   it { should have_server_side_encryption(algorithm: 'aws:kms') }
+
+  context 'nested attribute call' do
+    its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }
+    its('resource.name') { should eq 'my-bucket' }
+    its('resource.acl') { should be_an_instance_of(Awspec::ResourceReader) }
+    its(:acl) { should be_an_kind_of(Awspec::ResourceReader) }
+    it 'should be a Exception when black list method is called' do
+      expect { subject.delete }.to raise_error(Awspec::BlackListForwardable::CalledMethodInBlackList,
+                                               'Method call :delete is black-listed')
+    end
+    its('acl.owner.display_name') { should eq 'my-bucket-owner' }
+  end
 end
 
 describe s3_bucket('my-bucket') do

--- a/spec/type/sns_topic_spec.rb
+++ b/spec/type/sns_topic_spec.rb
@@ -37,7 +37,7 @@ end
 invalid_topic_arn = 'arn:aws:sns:us-east-1:123456789:invalid'
 
 describe sns_topic(invalid_topic_arn) do
-  context 'Issue https://github.com/k1LoW/awspec/issues/445 is stil open' do
+  context 'Issue https://github.com/k1LoW/awspec/issues/445 is still open' do
     it 'it does not exists'
     it ':name raises Awspec::NoExistingResource'
     it ':confirmed_subscriptions raises Awspec::NoExistingResource'

--- a/spec/type/sns_topic_spec.rb
+++ b/spec/type/sns_topic_spec.rb
@@ -33,3 +33,21 @@ describe sns_topic(topic_arn) do
     end
   end
 end
+
+invalid_topic_arn = 'arn:aws:sns:us-east-1:123456789:invalid'
+
+describe sns_topic(invalid_topic_arn) do
+  context 'Issue https://github.com/k1LoW/awspec/issues/445 is stil open' do
+    it 'it does not exists'
+    it ':name raises Awspec::NoExistingResource'
+    it ':confirmed_subscriptions raises Awspec::NoExistingResource'
+    it ':pending_subscriptions raises Awspec::NoExistingResource'
+    it ':topic_arn raises Awspec::NoExistingResource'
+    it ':display_name raises Awspec::NoExistingResource'
+    it ':deleted_subscriptions raises Awspec::NoExistingResource'
+    it ':subscriptions raises Awspec::NoExistingResource'
+    it ':id raises Awspec::NoExistingResource'
+    it 'matcher include_subscribed raises Awspec::NoExistingResource'
+    it 'matcher have_subscription_attributes raises Awspec::NoExistingResource'
+  end
+end


### PR DESCRIPTION
- Removed unused results allocation to variables.
- Moved the method `has_object?` body from `Awspec::Type::S3Bucket` to `Awspec::Helper::Finder::S3` to leave all interactions with AWS SDK in the Finder and to increase code by checking specific exception and proper
- Added the method `check_existance` on all methods from `Awspec::Type::S3Bucket` to all methods that would require the S3 bucket to exist in order to execute as expected.
- Not invoking the `aws_resource` method to load the `Aws::S3::Bucket` in `Awspec::Type::S3Bucket`, that makes the "protocol" of raising `Awspec::NoExistingResource` not to work properly.
- Added some caching to method `cors_rules` from `Awspec::Type::S3Bucket` by assigning the result to a instance variable.
- Refactored the `Awspec::Type::S3Bucket` spec to validate behavior of raising `Awspec::NoExistingResource`, removed duplicated specs and removed the testing of `Awspec::ResourceReader`, which probably shouldn't be there.