### PR TITLE
Support for testing a record set without a record value

### DIFF
--- a/doc/_resource_types/route53_hosted_zone.md
+++ b/doc/_resource_types/route53_hosted_zone.md
@@ -11,6 +11,8 @@ end
 ```ruby
 describe route53_hosted_zone('example.com.') do
   its(:resource_record_set_count) { should eq 6 }
+  it { should have_record_set('example.com.') }
+  it { should have_record_set('example.com.').type('a') }
   it { should have_record_set('example.com.').a('123.456.7.890') }
   it { should have_record_set('*.example.com.').cname('example.com') }
   it { should have_record_set('example.com.').mx('10 mail.example.com') }

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -2868,6 +2868,8 @@ end
 ```ruby
 describe route53_hosted_zone('example.com.') do
   its(:resource_record_set_count) { should eq 6 }
+  it { should have_record_set('example.com.') }
+  it { should have_record_set('example.com.').type('a') }
   it { should have_record_set('example.com.').a('123.456.7.890') }
   it { should have_record_set('*.example.com.').cname('example.com') }
   it { should have_record_set('example.com.').mx('10 mail.example.com') }

--- a/lib/awspec/matcher/have_record_set.rb
+++ b/lib/awspec/matcher/have_record_set.rb
@@ -29,4 +29,8 @@ RSpec::Matchers.define :have_record_set do |name|
     @options = {} if @options.nil?
     @options[:ttl] = ttl
   end
+
+  chain :type do |type|
+    @type = type
+  end
 end

--- a/spec/type/route53_hosted_zone_spec.rb
+++ b/spec/type/route53_hosted_zone_spec.rb
@@ -4,6 +4,8 @@ Awspec::Stub.load 'route53_hosted_zone'
 describe route53_hosted_zone('example.com.') do
   it { should exist }
   its(:resource_record_set_count) { should eq 8 }
+  it { should have_record_set('example.com.') }
+  it { should have_record_set('example.com.').type('a') }
   it { should have_record_set('example.com.').a('123.456.7.890') }
   it { should have_record_set('*.example.com.').cname('example.com') }
   it { should have_record_set('example.com.').mx('10 mail.example.com') }


### PR DESCRIPTION
Fixes #318.

The have_record_set matcher always required a value as below:

```ruby
describe route53_hosted_zone('foo.') do
  it { should have_record_set('bar.foo.').a('192.168.0.1') }
end
```

But, as discussed in #318, sometimes want to test a record set regardless of a value of record.

This PR enables awspec user test a record without its value as below:

```ruby
describe route53_hosted_zone('foo.') do
  # Test if a hosted zone has a given record.
  it { should have_record_set('bar.foo.') }

  # Test if a hosted zone has a given record and a given type.
  it { should have_record_set('bar.foo.').type('a') }
end
```

What do you think about this PR?. I would appreciate receiving a feedback.