### PR TITLE
CI against Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 matrix:
   include:
+    - rvm: 2.6.2
+      env: RUBYGEMS_VERSION=
     - rvm: 2.5.3
       env: RUBYGEMS_VERSION=
     - rvm: 2.4.5


### PR DESCRIPTION
Hi!

Ruby 2.6.2 has been released 💎 

- https://www.ruby-lang.org/en/news/2019/03/13/ruby-2-6-2-released/

This patch adds Ruby 2.6.2 to CI.