### PR TITLE
Fix a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $ AWS_PROFILE=mycreds bundle exec rake spec
 
 ## Support AWS Resources
 
-[Resource Types infomation here](doc/resource_types.md)
+[Resource Types information here](doc/resource_types.md)
 
 ## awspec AWS key/secrets precedence
 


### PR DESCRIPTION
This PR fixes a typo in README, `infomation` -> `information`.