### PR TITLE
Update resource_types.md - s3 lifecycle prefix

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -3014,7 +3014,7 @@ describe s3_bucket('my-bucket') do
   it do
     should have_lifecycle_rule(
       id: 'MyRuleName2',
-      filter: { prefix: '123/' },
+      filter: { prefix: '123/' }, 
       noncurrent_version_expiration: { noncurrent_days: 2 },
       expiration: { days: 3 },
       transitions: [{ days: 5, storage_class: 'STANDARD_IA' }, { days: 10, storage_class: 'GLACIER' }],

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -3014,7 +3014,7 @@ describe s3_bucket('my-bucket') do
   it do
     should have_lifecycle_rule(
       id: 'MyRuleName2',
-      prefix: '123/',
+      filter: { prefix: '123/' },
       noncurrent_version_expiration: { noncurrent_days: 2 },
       expiration: { days: 3 },
       transitions: [{ days: 5, storage_class: 'STANDARD_IA' }, { days: 10, storage_class: 'GLACIER' }],


### PR DESCRIPTION
Based on the output of `aws s3api get-bucket-lifecycle-configuration`, it looks to me like this documentation needs to be updated to match that output object:

```
{
    "Rules": [
        {
            "Status": "Enabled",
            "NoncurrentVersionExpiration": {
                "NoncurrentDays": 7
            },
            "Filter": {
                "Prefix": "data/"
            },
            "Expiration": {
                "Days": 7
            },
            "AbortIncompleteMultipartUpload": {
                "DaysAfterInitiation": 7
            },
            "ID": "ExpireData7Days"
        }
    ]
}
```