### PR TITLE
Patches for RouteTable, CloudWatchLogs and CloudTrail resources

### DIFF
--- a/doc/_resource_types/cloudtrail.md
+++ b/doc/_resource_types/cloudtrail.md
@@ -37,3 +37,11 @@ describe cloudtrail('my-trail') do
   it { should be_logging }
 end
 ```
+
+### have_tag
+
+```ruby
+describe cloudtrail('my-trail') do
+  it { should have_tag('Name').value('my-trail') }
+end
+```

--- a/doc/_resource_types/cloudwatch_logs.md
+++ b/doc/_resource_types/cloudwatch_logs.md
@@ -38,3 +38,11 @@ describe cloudwatch_logs('my-cloudwatch-logs-group') do
   end
 end
 ```
+
+### have_tag
+
+```ruby
+describe cloudwatch_logsl('my-cloudwatch-logs-group') do
+  it { should have_tag('Name').value('my-cloudwatch-logs-group') }
+end
+```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -537,6 +537,7 @@ describe cloudtrail('my-trail') do
 end
 ```
 
+
 ### be_multi_region_trail
 
 ```ruby
@@ -563,6 +564,14 @@ describe cloudtrail('my-trail') do
 end
 ```
 
+
+### have_tag
+
+```ruby
+describe cloudtrail('my-trail') do
+  it { should have_tag('Name').value('my-trail') }
+end
+```
 
 ### its(:name), its(:s3_bucket_name), its(:s3_key_prefix), its(:sns_topic_name), its(:sns_topic_arn), its(:include_global_service_events), its(:is_multi_region_trail), its(:home_region), its(:trail_arn), its(:log_file_validation_enabled), its(:cloud_watch_logs_log_group_arn), its(:cloud_watch_logs_role_arn), its(:kms_key_id), its(:has_custom_event_selectors), its(:is_organization_trail)
 ## <a name="cloudwatch_alarm">cloudwatch_alarm</a>
@@ -670,6 +679,15 @@ describe cloudwatch_logs('my-cloudwatch-logs-group') do
     should have_subscription_filter('my-cloudwatch-logs-subscription-filter')\
       .filter_pattern('[host, ident, authuser, date, request, status, bytes]')
   end
+end
+```
+
+
+### have_tag
+
+```ruby
+describe cloudwatch_logsl('my-cloudwatch-logs-group') do
+  it { should have_tag('Name').value('my-cloudwatch-logs-group') }
 end
 ```
 

--- a/lib/awspec/helper/finder/cloudtrail.rb
+++ b/lib/awspec/helper/finder/cloudtrail.rb
@@ -15,6 +15,12 @@ module Awspec::Helper
         cloudtrail_client.get_trail_status(name: id)
       end
 
+      def get_trail_tags(arn)
+        cloudtrail_client.list_tags(
+          resource_id_list: [arn]
+        )[:resource_tag_list].first[:tags_list]
+      end
+
       def is_logging?(id)
         ret = get_trail_status(id).is_logging
       end

--- a/lib/awspec/helper/finder/cloudwatch_logs.rb
+++ b/lib/awspec/helper/finder/cloudwatch_logs.rb
@@ -64,6 +64,10 @@ module Awspec::Helper
         log_groups
       end
 
+      def find_tags_by_log_group_name(id)
+        cloudwatch_logs_client.list_tags_log_group(log_group_name: id)[:tags]
+      end
+
       filter_types = %w(metric subscription)
       filter_types.each do |type|
         define_method 'select_all_cloudwatch_logs_' + type + '_filter' do |*args|

--- a/lib/awspec/stub/cloudtrail.rb
+++ b/lib/awspec/stub/cloudtrail.rb
@@ -6,12 +6,30 @@ Aws.config[:cloudtrail] = {
           name: 'my-trail',
           include_global_service_events: true,
           is_multi_region_trail: true,
-          log_file_validation_enabled: true
+          log_file_validation_enabled: true,
+          trail_arn: 'my-trail-arn'
         }
       ]
     },
     get_trail_status: {
       is_logging: true
+    },
+    list_tags: {
+      resource_tag_list: [
+        {
+          resource_id: 'my-trail-arn',
+          tags_list: [
+            {
+              key: 'key_one',
+              value: 'value_one'
+            },
+            {
+              key: 'key_two',
+              value: 'value_two'
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/lib/awspec/stub/cloudwatch_logs.rb
+++ b/lib/awspec/stub/cloudwatch_logs.rb
@@ -29,6 +29,13 @@ Aws.config[:cloudwatchlogs] = {
           filter_pattern: '[host, ident, authuser, date, request, status, bytes]'
         }
       ]
+    },
+    list_tags_log_group: {
+      tags: {
+        "key_one" => "value_one",
+        "key_two" => "value_two"
+      }
     }
+
   }
 }

--- a/lib/awspec/stub/cloudwatch_logs.rb
+++ b/lib/awspec/stub/cloudwatch_logs.rb
@@ -32,8 +32,8 @@ Aws.config[:cloudwatchlogs] = {
     },
     list_tags_log_group: {
       tags: {
-        "key_one" => "value_one",
-        "key_two" => "value_two"
+        'key_one' => 'value_one',
+        'key_two' => 'value_two'
       }
     }
 

--- a/lib/awspec/type/cloudtrail.rb
+++ b/lib/awspec/type/cloudtrail.rb
@@ -25,5 +25,11 @@ module Awspec::Type
     def logging?
       is_logging?(id)
     end
+
+    def has_tag?(tag_key, tag_value)
+      get_trail_tags(resource_via_client.trail_arn).find do |tag|
+        tag.key == tag_key && tag.value == tag_value
+      end
+    end
   end
 end

--- a/lib/awspec/type/cloudwatch_logs.rb
+++ b/lib/awspec/type/cloudwatch_logs.rb
@@ -27,5 +27,11 @@ module Awspec::Type
       end
       return true if ret.filter_name == filter_name
     end
+
+    def has_tag?(tag_key, tag_value)
+      find_tags_by_log_group_name(resource_via_client.log_group_name).find do |key, value|
+        key == tag_key && value == tag_value
+      end
+    end
   end
 end

--- a/lib/awspec/type/route_table.rb
+++ b/lib/awspec/type/route_table.rb
@@ -54,7 +54,8 @@ module Awspec::Type
       cgw = find_customer_gateway(gateway_id)
       return true if cgw && cgw.customer_gateway_id == route.gateway_id
       # nat gateway
-      return true if route.nat_gateway_id == gateway_id
+      nat = find_nat_gateway(gateway_id)
+      return true if nat.nat_gateway_id == route.nat_gateway_id
       false
     end
 
@@ -68,7 +69,8 @@ module Awspec::Type
 
     def target_nat?(route, nat_gateway_id)
       # nat
-      route.nat_gateway_id == nat_gateway_id
+      nat = find_nat_gateway(nat_gateway_id)
+      nat.nat_gateway_id == route.nat_gateway_id
     end
 
     def target_vpc_peering_connection?(route, vpc_peering_connection_id)

--- a/spec/type/cloudtrail_spec.rb
+++ b/spec/type/cloudtrail_spec.rb
@@ -7,4 +7,5 @@ describe cloudtrail('my-trail') do
   it { should be_multi_region_trail }
   it { should have_log_file_validation_enabled }
   it { should be_logging }
+  it { should have_tag('key_one').value('value_one') }
 end

--- a/spec/type/cloudwatch_logs_spec.rb
+++ b/spec/type/cloudwatch_logs_spec.rb
@@ -11,4 +11,5 @@ describe cloudwatch_logs('my-cloudwatch-logs-group') do
     should have_subscription_filter('my-cloudwatch-logs-subscription-filter')\
       .filter_pattern('[host, ident, authuser, date, request, status, bytes]')
   end
+  it { should have_tag('key_one').value('value_one') }
 end


### PR DESCRIPTION
This PR adds three commits that patch some methods in the RouteTable, CloudWatchLogs and CloudTrail resources, due to holes we found while using this at work.

`RouteTable#target_gateway?`: modifies the check for when `gateway_id` points to a NAT gateway, to ensure that both an ID and name work for the  `gateway_id` value
`RouteTable#target_nat?`: modifies the check so that both an ID and name work for the `nat_gateway_id` value

Added `has_tags?` to the `CloudWatchLogs` and `CloudTrail` resources to allow for use of the `have_tag` matcher in specs. This required patching the corresponding finders to user the necessary AWS SDK methods to fetch the tags separately.

