### PR TITLE
#443: SSM Parameters pagination issue, replaced with get_parameter AP…

### DIFF
--- a/lib/awspec/helper/finder/ssm_parameter.rb
+++ b/lib/awspec/helper/finder/ssm_parameter.rb
@@ -2,15 +2,9 @@ module Awspec::Helper
   module Finder
     module SsmParameter
       def find_ssm_parameter(name)
-        ssm_client.describe_parameters(
-          {
-            filters:  [
-              {
-                key: 'Name',
-                values: [name]
-              }
-            ]
-          }).parameters[0]
+        ssm_client.get_parameter({
+          name: name, with_decryption: false,
+        }).parameter
       end
 
       def find_parameter_tag(id, tag_key)


### PR DESCRIPTION
Replaced ssm parameters describe API call with get_parameter call to fix pagination issue.

It doesn't change the outside behavior so didn't touch the tests.