### PR TITLE
Add secrets manager resource

### DIFF
--- a/doc/_resource_types/cloudtrail.md
+++ b/doc/_resource_types/cloudtrail.md
@@ -37,3 +37,11 @@ describe cloudtrail('my-trail') do
   it { should be_logging }
 end
 ```
+
+### have_tag
+
+```ruby
+describe cloudtrail('my-trail') do
+  it { should have_tag('Name').value('my-trail') }
+end
+```

--- a/doc/_resource_types/cloudwatch_logs.md
+++ b/doc/_resource_types/cloudwatch_logs.md
@@ -38,3 +38,11 @@ describe cloudwatch_logs('my-cloudwatch-logs-group') do
   end
 end
 ```
+
+### have_tag
+
+```ruby
+describe cloudwatch_logsl('my-cloudwatch-logs-group') do
+  it { should have_tag('Name').value('my-cloudwatch-logs-group') }
+end
+```

--- a/doc/_resource_types/secretsmanager.md
+++ b/doc/_resource_types/secretsmanager.md
@@ -5,3 +5,11 @@ describe secretsmanager('my-secret') do
   it { should exist }
 end
 ```
+
+### have_tag
+
+```ruby
+describe secretsmanager('my-secret') do
+  it { should have_tag('Name').value('my-secret') }
+end
+```

--- a/doc/_resource_types/secretsmanager.md
+++ b/doc/_resource_types/secretsmanager.md
@@ -1,0 +1,7 @@
+### exist
+
+```ruby
+describe secretsmanager('my-secret') do
+  it { should exist }
+end
+```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -64,6 +64,7 @@
 | [route53_hosted_zone](#route53_hosted_zone)
 | [route_table](#route_table)
 | [s3_bucket](#s3_bucket)
+| [secretsmanager](#secretsmanager)
 | [security_group](#security_group)
 | [ses_identity](#ses_identity)
 | [sns_topic](#sns_topic)
@@ -3150,6 +3151,19 @@ describe s3_bucket('my-bucket') do
 end
 ```
 
+## <a name="secretsmanager">secretsmanager</a>
+
+Secretsmanager resource type.
+
+### exist
+
+```ruby
+describe secretsmanager('my-secret') do
+  it { should exist }
+end
+```
+
+### its(:arn), its(:name), its(:description), its(:kms_key_id), its(:rotation_enabled), its(:rotation_lambda_arn), its(:last_rotated_date), its(:last_changed_date), its(:last_accessed_date), its(:deleted_date), its(:owning_service)
 ## <a name="security_group">security_group</a>
 
 SecurityGroup resource type.

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -537,6 +537,7 @@ describe cloudtrail('my-trail') do
 end
 ```
 
+
 ### be_multi_region_trail
 
 ```ruby
@@ -563,6 +564,14 @@ describe cloudtrail('my-trail') do
 end
 ```
 
+
+### have_tag
+
+```ruby
+describe cloudtrail('my-trail') do
+  it { should have_tag('Name').value('my-trail') }
+end
+```
 
 ### its(:name), its(:s3_bucket_name), its(:s3_key_prefix), its(:sns_topic_name), its(:sns_topic_arn), its(:include_global_service_events), its(:is_multi_region_trail), its(:home_region), its(:trail_arn), its(:log_file_validation_enabled), its(:cloud_watch_logs_log_group_arn), its(:cloud_watch_logs_role_arn), its(:kms_key_id), its(:has_custom_event_selectors), its(:is_organization_trail)
 ## <a name="cloudwatch_alarm">cloudwatch_alarm</a>
@@ -670,6 +679,15 @@ describe cloudwatch_logs('my-cloudwatch-logs-group') do
     should have_subscription_filter('my-cloudwatch-logs-subscription-filter')\
       .filter_pattern('[host, ident, authuser, date, request, status, bytes]')
   end
+end
+```
+
+
+### have_tag
+
+```ruby
+describe cloudwatch_logsl('my-cloudwatch-logs-group') do
+  it { should have_tag('Name').value('my-cloudwatch-logs-group') }
 end
 ```
 

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -3163,6 +3163,15 @@ describe secretsmanager('my-secret') do
 end
 ```
 
+
+### have_tag
+
+```ruby
+describe secretsmanager('my-secret') do
+  it { should have_tag('Name').value('my-secret') }
+end
+```
+
 ### its(:arn), its(:name), its(:description), its(:kms_key_id), its(:rotation_enabled), its(:rotation_lambda_arn), its(:last_rotated_date), its(:last_changed_date), its(:last_accessed_date), its(:deleted_date), its(:owning_service)
 ## <a name="security_group">security_group</a>
 

--- a/lib/awspec/generator/doc/type/secretsmanager.rb
+++ b/lib/awspec/generator/doc/type/secretsmanager.rb
@@ -5,7 +5,7 @@ module Awspec::Generator
         def initialize
           super
           @type_name = 'Secretsmanager'
-          @type = Awspec::Type::Secretsmanager.new('my-secrets-manager')
+          @type = Awspec::Type::Secretsmanager.new('my-secret')
           @ret = @type.resource_via_client
           @matchers = []
           @ignore_matchers = []

--- a/lib/awspec/generator/doc/type/secretsmanager.rb
+++ b/lib/awspec/generator/doc/type/secretsmanager.rb
@@ -1,0 +1,17 @@
+module Awspec::Generator
+  module Doc
+    module Type
+      class Secretsmanager < Base
+        def initialize
+          super
+          @type_name = 'Secretsmanager'
+          @type = Awspec::Type::Secretsmanager.new('my-secrets-manager')
+          @ret = @type.resource_via_client
+          @matchers = []
+          @ignore_matchers = []
+          @describes = []
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/helper/finder.rb
+++ b/lib/awspec/helper/finder.rb
@@ -46,6 +46,7 @@ require 'awspec/helper/finder/emr'
 require 'awspec/helper/finder/redshift'
 require 'awspec/helper/finder/codedeploy'
 require 'awspec/helper/finder/mq'
+require 'awspec/helper/finder/secretsmanager'
 
 require 'awspec/helper/finder/account_attributes'
 
@@ -101,6 +102,7 @@ module Awspec::Helper
     include Awspec::Helper::Finder::Redshift
     include Awspec::Helper::Finder::Codedeploy
     include Awspec::Helper::Finder::Mq
+    include Awspec::Helper::Finder::Secretsmanager
 
     CLIENTS = {
       ec2_client: Aws::EC2::Client,
@@ -144,7 +146,8 @@ module Awspec::Helper
       emr_client: Aws::EMR::Client,
       redshift_client: Aws::Redshift::Client,
       codedeploy_client: Aws::CodeDeploy::Client,
-      mq_client: Aws::MQ::Client
+      mq_client: Aws::MQ::Client,
+      secretsmanager_client: Aws::SecretsManager::Client
     }
 
     CLIENT_OPTIONS = {

--- a/lib/awspec/helper/finder/cloudtrail.rb
+++ b/lib/awspec/helper/finder/cloudtrail.rb
@@ -15,6 +15,12 @@ module Awspec::Helper
         cloudtrail_client.get_trail_status(name: id)
       end
 
+      def get_trail_tags(arn)
+        cloudtrail_client.list_tags(
+          resource_id_list: [arn]
+        )[:resource_tag_list].first[:tags_list]
+      end
+
       def is_logging?(id)
         ret = get_trail_status(id).is_logging
       end

--- a/lib/awspec/helper/finder/cloudwatch_logs.rb
+++ b/lib/awspec/helper/finder/cloudwatch_logs.rb
@@ -64,6 +64,10 @@ module Awspec::Helper
         log_groups
       end
 
+      def find_tags_by_log_group_name(id)
+        cloudwatch_logs_client.list_tags_log_group(log_group_name: id)[:tags]
+      end
+
       filter_types = %w(metric subscription)
       filter_types.each do |type|
         define_method 'select_all_cloudwatch_logs_' + type + '_filter' do |*args|

--- a/lib/awspec/helper/finder/secretsmanager.rb
+++ b/lib/awspec/helper/finder/secretsmanager.rb
@@ -1,0 +1,11 @@
+module Awspec::Helper
+  module Finder
+    module Secretsmanager
+      def find_secret(id)
+        secretsmanager_client.describe_secret({
+                                                secret_id: id
+                                              })
+      end
+    end
+  end
+end

--- a/lib/awspec/helper/type.rb
+++ b/lib/awspec/helper/type.rb
@@ -20,6 +20,7 @@ module Awspec
         elastictranscoder_pipeline waf_web_acl wafregional_web_acl customer_gateway vpn_gateway vpn_connection
         internet_gateway acm cloudwatch_logs dynamodb_table eip sqs ssm_parameter cloudformation_stack
         codebuild sns_topic redshift redshift_cluster_parameter_group codedeploy codedeploy_deployment_group
+        secretsmanager
       )
 
       ACCOUNT_ATTRIBUTES = %w(

--- a/lib/awspec/stub/cloudtrail.rb
+++ b/lib/awspec/stub/cloudtrail.rb
@@ -6,12 +6,30 @@ Aws.config[:cloudtrail] = {
           name: 'my-trail',
           include_global_service_events: true,
           is_multi_region_trail: true,
-          log_file_validation_enabled: true
+          log_file_validation_enabled: true,
+          trail_arn: 'my-trail-arn'
         }
       ]
     },
     get_trail_status: {
       is_logging: true
+    },
+    list_tags: {
+      resource_tag_list: [
+        {
+          resource_id: 'my-trail-arn',
+          tags_list: [
+            {
+              key: 'key_one',
+              value: 'value_one'
+            },
+            {
+              key: 'key_two',
+              value: 'value_two'
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/lib/awspec/stub/cloudwatch_logs.rb
+++ b/lib/awspec/stub/cloudwatch_logs.rb
@@ -29,6 +29,13 @@ Aws.config[:cloudwatchlogs] = {
           filter_pattern: '[host, ident, authuser, date, request, status, bytes]'
         }
       ]
+    },
+    list_tags_log_group: {
+      tags: {
+        "key_one" => "value_one",
+        "key_two" => "value_two"
+      }
     }
+
   }
 }

--- a/lib/awspec/stub/cloudwatch_logs.rb
+++ b/lib/awspec/stub/cloudwatch_logs.rb
@@ -32,8 +32,8 @@ Aws.config[:cloudwatchlogs] = {
     },
     list_tags_log_group: {
       tags: {
-        "key_one" => "value_one",
-        "key_two" => "value_two"
+        'key_one' => 'value_one',
+        'key_two' => 'value_two'
       }
     }
 

--- a/lib/awspec/stub/secretsmanager.rb
+++ b/lib/awspec/stub/secretsmanager.rb
@@ -1,0 +1,36 @@
+Aws.config[:secretsmanager] = {
+  stub_responses: {
+    describe_secret: {
+      arn: 'my-secret-arn',
+      description: 'my secret description',
+      kms_key_id: 'secret-kms-key-arn',
+      last_accessed_date: Time.at(1523923200),
+      last_changed_date: Time.at(1523477145.729),
+      last_rotated_date: Time.at(1525747253.72),
+      name: 'my-secret-name',
+      rotation_enabled: true,
+      rotation_lambda_arn: 'my-secret-rotation-lambda-arn',
+      rotation_rules: {
+        automatically_after_days: 30
+      },
+      tags: [
+        {
+          key: 'key_one',
+          value: 'value_one'
+        },
+        {
+          key: 'key_two',
+          value: 'value_two'
+        }
+      ],
+      version_ids_to_stages: {
+        'EXAMPLE1-90ab-cdef-fedc-ba987EXAMPLE' => [
+          'AWSPREVIOUS'
+        ],
+        'EXAMPLE2-90ab-cdef-fedc-ba987EXAMPLE' => [
+          'AWSCURRENT'
+        ]
+      }
+    }
+  }
+}

--- a/lib/awspec/type/cloudtrail.rb
+++ b/lib/awspec/type/cloudtrail.rb
@@ -25,5 +25,11 @@ module Awspec::Type
     def logging?
       is_logging?(id)
     end
+
+    def has_tag?(tag_key, tag_value)
+      get_trail_tags(resource_via_client.trail_arn).find do |tag|
+        tag.key == tag_key && tag.value == tag_value
+      end
+    end
   end
 end

--- a/lib/awspec/type/cloudwatch_logs.rb
+++ b/lib/awspec/type/cloudwatch_logs.rb
@@ -27,5 +27,11 @@ module Awspec::Type
       end
       return true if ret.filter_name == filter_name
     end
+
+    def has_tag?(tag_key, tag_value)
+      find_tags_by_log_group_name(resource_via_client.log_group_name).find do |key, value|
+        key == tag_key && value == tag_value
+      end
+    end
   end
 end

--- a/lib/awspec/type/route_table.rb
+++ b/lib/awspec/type/route_table.rb
@@ -54,7 +54,8 @@ module Awspec::Type
       cgw = find_customer_gateway(gateway_id)
       return true if cgw && cgw.customer_gateway_id == route.gateway_id
       # nat gateway
-      return true if route.nat_gateway_id == gateway_id
+      nat = find_nat_gateway(gateway_id)
+      return true if nat.nat_gateway_id == route.nat_gateway_id
       false
     end
 
@@ -68,7 +69,8 @@ module Awspec::Type
 
     def target_nat?(route, nat_gateway_id)
       # nat
-      route.nat_gateway_id == nat_gateway_id
+      nat = find_nat_gateway(nat_gateway_id)
+      nat.nat_gateway_id == route.nat_gateway_id
     end
 
     def target_vpc_peering_connection?(route, vpc_peering_connection_id)

--- a/lib/awspec/type/secretsmanager.rb
+++ b/lib/awspec/type/secretsmanager.rb
@@ -1,6 +1,7 @@
 module Awspec::Type
   class Secretsmanager < ResourceBase
     aws_resource Aws::SecretsManager
+    tags_allowed
 
     def resource_via_client
       @resource_via_client ||= find_secret(@display_name)

--- a/lib/awspec/type/secretsmanager.rb
+++ b/lib/awspec/type/secretsmanager.rb
@@ -1,0 +1,13 @@
+module Awspec::Type
+  class Secretsmanager < ResourceBase
+    aws_resource Aws::SecretsManager
+
+    def resource_via_client
+      @resource_via_client ||= find_secret(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.name if resource_via_client
+    end
+  end
+end

--- a/spec/type/cloudtrail_spec.rb
+++ b/spec/type/cloudtrail_spec.rb
@@ -7,4 +7,5 @@ describe cloudtrail('my-trail') do
   it { should be_multi_region_trail }
   it { should have_log_file_validation_enabled }
   it { should be_logging }
+  it { should have_tag('key_one').value('value_one') }
 end

--- a/spec/type/cloudwatch_logs_spec.rb
+++ b/spec/type/cloudwatch_logs_spec.rb
@@ -11,4 +11,5 @@ describe cloudwatch_logs('my-cloudwatch-logs-group') do
     should have_subscription_filter('my-cloudwatch-logs-subscription-filter')\
       .filter_pattern('[host, ident, authuser, date, request, status, bytes]')
   end
+  it { should have_tag('key_one').value('value_one') }
 end

--- a/spec/type/secretsmanager_spec.rb
+++ b/spec/type/secretsmanager_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+Awspec::Stub.load 'secretsmanager'
+
+describe secretsmanager('my-secret') do
+  it { should exist }
+end

--- a/spec/type/secretsmanager_spec.rb
+++ b/spec/type/secretsmanager_spec.rb
@@ -3,4 +3,5 @@ Awspec::Stub.load 'secretsmanager'
 
 describe secretsmanager('my-secret') do
   it { should exist }
+  it { should have_tag('key_one').value('value_one') }
 end


### PR DESCRIPTION
This PR adds a simple `secretsmanager` resource that gets the secret given the secret name or ID via the `describe_secret` API call, with the `exist` and `have_tag` matchers.