### PR TITLE
Add Rake task to generate docs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,3 +57,8 @@ if defined?(RSpec)
     RuboCop::RakeTask.new
   end
 end
+
+task :generate_docs do
+  docs = Awspec::Generator::Doc::Type.generate_doc
+  File.write('doc/resource_types.md', docs)
+end

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -6,7 +6,7 @@
 2. Generate template files (`bundle exec bin/toolbox template redshift`)
 3. Fill files with code.
 4. `bundle update` to update gems.
-5. Generate [doc/resource_types.md](doc/resource_types.md) (`bundle exec bin/toolbox docgen > doc/resource_types.md`)
+5. Generate [doc/resource_types.md](doc/resource_types.md) (`bundle exec rake generate_docs`)
 6. Run test (`bundle exec rake spec`)
 7. Push to the branch (`git push origin add-type-redshift`)
 8. Create a new Pull Request
@@ -15,7 +15,7 @@
 
 #### CI Failed 'Awspec::Generator::Doc::Type generate_doc output should be the same as doc/resource_types.md'
 
-Maybe, your `aws-sdk-ruby` is not latest. Please exec `bundle update` and `bundle exec bin/toolbox docgen > doc/resource_types.md`.
+Maybe, your `aws-sdk-ruby` is not latest. Please exec `bundle update` and `bundle exec rake generate_docs`.
 
 ( `aws-sdk-ruby` is often updated. )
 
@@ -24,7 +24,7 @@ Maybe, your `aws-sdk-ruby` is not latest. Please exec `bundle update` and `bundl
 1. Create your feature branch (`git checkout -b add-type-cf-limit`)
 2. Generate template files (`bundle exec bin/toolbox template cloudformation_account_attributes -a`) **with -a option**
 3. Fill files with code.
-4. Generate [doc/resource_types.md](doc/resource_types.md) (`bundle exec bin/toolbox docgen > doc/resource_types.md`)
+4. Generate [doc/resource_types.md](doc/resource_types.md) (`bundle exec rake generate_docs`)
 5. Run test (`bundle exec rake spec`)
 6. Push to the branch (`git push origin add-type-cf-limit`)
 7. Create a new Pull Request


### PR DESCRIPTION
I was actually working out why the `master` branch build was failing and came to the same conclusion as cc8251e. Given keeping the docs up to date is important (yay), maybe it's worth adding a Rake task to make it easier?

I've also updated the contributing docs.

I'm also not sure about the specific implementation here, since I have the Rake code reaching into the internals to generate the docs. If you'd like, this could do the same as the `toolbox` executable that was originally referenced in the docs. Anyway, let me know 😄 