### PR TITLE
Fix the bug that have_record_set passes tests in non-existent route53 record

### DIFF
--- a/lib/awspec/type/route53_hosted_zone.rb
+++ b/lib/awspec/type/route53_hosted_zone.rb
@@ -16,8 +16,10 @@ module Awspec::Type
       name = name.gsub(/\*/, '\\\052') # wildcard support
 
       record_sets = resource_via_client_record_sets.select { |record| record.name == name }
+      return false if record_sets.empty?
+
       # Check if the given record is registered regardless of type and value
-      return !record_sets.empty? if type.nil? && value.nil? && options.nil?
+      return true if type.nil? && value.nil? && options.nil?
 
       record_sets.select! { |record_set| record_set.type.casecmp(type) == 0 }
       return !record_sets.empty? if value.nil? && options.nil? || value.nil? && options.empty?

--- a/spec/type/route53_hosted_zone_spec.rb
+++ b/spec/type/route53_hosted_zone_spec.rb
@@ -12,6 +12,8 @@ describe route53_hosted_zone('example.com.') do
   it { should have_record_set('*.example.com.').cname('example.com') }
   it { should have_record_set('example.com.').mx('10 mail.example.com') }
   it { should have_record_set('mail.example.com.').a('123.456.7.890').ttl(3600) }
+  it { should_not have_record_set('notexist.example.com.') }
+  it { should_not have_record_set('notexist.example.com.').a('123.456.7.890').ttl(3600) }
   ns = 'ns-123.awsdns-45.net.
 ns-6789.awsdns-01.org.
 ns-2345.awsdns-67.co.uk.


### PR DESCRIPTION
Fix #488

When testing for non-existent route53 record, if using have_record_set with a type or value option, the test always passes regardless of whether the record exists or not.

```ruby
describe route53_hosted_zone('example.com.') do
  it do
    should_not have_record_set('notexist.example.com.').a('123.456.7.890') # always passes
  end
end
```

This change fixes that bug.