### PR TITLE
adjust aws paging

### DIFF
--- a/lib/awspec/helper/finder/cloudfront.rb
+++ b/lib/awspec/helper/finder/cloudfront.rb
@@ -8,7 +8,10 @@ module Awspec::Helper
           selected += res.distribution_list.items.select do |item|
             item.id == id || item.domain_name == id
           end
-          (res.next_page? && res = res.next_page) || break
+          break unless res.distribution_list.is_truncated
+          res = cloudfront_client.list_distributions({
+                                                       marker: res.distribution_list.next_marker
+                                                     })
         end
 
         selected.single_resource(id)

--- a/lib/awspec/helper/finder/cloudwatch.rb
+++ b/lib/awspec/helper/finder/cloudwatch.rb
@@ -20,7 +20,10 @@ module Awspec::Helper
 
         loop do
           selected += res.metric_alarms
-          (res.next_page? && res = res.next_page) || break
+          break if res.next_token.nil?
+          res = cloudwatch_client.describe_alarms({
+                                                    next_token: res.next_token
+                                                  })
         end
 
         selected

--- a/lib/awspec/helper/finder/ebs.rb
+++ b/lib/awspec/helper/finder/ebs.rb
@@ -30,7 +30,10 @@ module Awspec::Helper
 
         loop do
           selected += res.volumes.select { |v| v.attachments.count > 0 }
-          (res.next_page? && res = res.next_page) || break
+          break if res.next_token.nil?
+          res = ec2_client.describe_volumes({
+                                              next_token: res.next_token
+                                            })
         end
 
         selected

--- a/lib/awspec/helper/finder/elastictranscoder.rb
+++ b/lib/awspec/helper/finder/elastictranscoder.rb
@@ -8,7 +8,10 @@ module Awspec::Helper
           selected += res.pipelines.select do |pipeline|
             pipeline.id == id || pipeline.name == id
           end
-          (res.next_page? && res = res.next_page) || break
+          break if res.next_page_token.nil?
+          res = elastictranscoder_client.list_pipelines({
+                                                          page_token: res.next_page_token
+                                                        })
         end
 
         selected.single_resource(id)

--- a/lib/awspec/helper/finder/lambda.rb
+++ b/lib/awspec/helper/finder/lambda.rb
@@ -9,7 +9,10 @@ module Awspec::Helper
           selected += res.functions.select do |function|
             function.function_name == id || function.function_arn == id
           end
-          (res.next_page? && res = res.next_page) || break
+          break if res.next_marker.nil?
+          res = lambda_client.list_functions({
+                                               marker: res.next_marker
+                                             })
         end
 
         selected.single_resource(id)

--- a/lib/awspec/helper/finder/rds.rb
+++ b/lib/awspec/helper/finder/rds.rb
@@ -30,7 +30,11 @@ module Awspec::Helper
           res.parameters.each do |param|
             parameters[param.parameter_name] = param.parameter_value
           end
-          (res.next_page? && res = res.next_page) || break
+          break if res.marker.nil?
+          res = rds_client.describe_db_parameters({
+                                                    db_parameter_group_name: parameter_group,
+                                                    marker: res.marker
+                                                  })
         end
         parameters
       end

--- a/lib/awspec/helper/finder/redshift.rb
+++ b/lib/awspec/helper/finder/redshift.rb
@@ -24,7 +24,11 @@ module Awspec::Helper
           res.parameters.each do |param|
             parameters[param.parameter_name] = param.parameter_value
           end
-          (res.respond_to?(:next_page?) && res.next_page? && res = res.next_page) || break
+          break if res.marker.nil?
+          res = redshift_client.describe_cluster_parameters({
+                                                              parameter_group_name: parameter_group,
+                                                              marker: res.marker
+                                                            })
         end
         parameters
       end

--- a/lib/awspec/helper/finder/route53.rb
+++ b/lib/awspec/helper/finder/route53.rb
@@ -10,7 +10,11 @@ module Awspec::Helper
               selected.push(hosted_zone)
             end
           end
-          (res.next_page? && res = res.next_page) || break
+
+          break unless res.is_truncated
+          res = route53_client.list_hosted_zones({
+                                                   marker: res.next_marker
+                                                 })
         end
         selected.single_resource(id)
       end
@@ -22,7 +26,13 @@ module Awspec::Helper
                                                        })
         loop do
           selected += res.resource_record_sets
-          (res.next_page? && res = res.next_page) || break
+          break unless res.is_truncated
+
+          res = route53_client.list_resource_record_sets({
+                                                           hosted_zone_id: id,
+                                                           start_record_name: res.next_record_name,
+                                                           start_record_type: res.next_record_type
+                                                         })
         end
         selected
       end

--- a/lib/awspec/type/elasticache_cache_parameter_group.rb
+++ b/lib/awspec/type/elasticache_cache_parameter_group.rb
@@ -17,7 +17,11 @@ module Awspec::Type
         res.parameters.each do |param|
           parameters[param.parameter_name] = param.parameter_value
         end
-        (res.next_page? && res = res.next_page) || break
+        break if res.marker.nil?
+        res = elasticache_client.describe_cache_parameters({
+                                                             cache_parameter_group_name: @display_name,
+                                                             marker: res.marker
+                                                           })
       end
       @resource_via_client ||= parameters
     end

--- a/lib/awspec/version.rb
+++ b/lib/awspec/version.rb
@@ -1,3 +1,3 @@
 module Awspec
-  VERSION = '1.18.2'
+  VERSION = '1.18.3'
 end


### PR DESCRIPTION
This PR is to adjust the object instances that were using the `next_page` construct to using either the provided `is_trucated` or `marker` construct provided in the responses from AWS.

The existing `next_page` construct objects were no longer able to pull AWS Object lists that are over 100 items long.  Making this change restores that ability to these AWS objects.