### PR TITLE
Added ALB existence checking

### DIFF
--- a/lib/awspec/helper/finder/alb.rb
+++ b/lib/awspec/helper/finder/alb.rb
@@ -6,7 +6,7 @@ module Awspec::Helper
         res.load_balancers.select do |lb|
           lb.type == 'application'
         end.single_resource(id)
-      rescue
+      rescue Aws::ElasticLoadBalancingV2::Errors::LoadBalancerNotFound
         return nil
       end
 
@@ -20,7 +20,7 @@ module Awspec::Helper
       def find_alb_listener(arn)
         res = elbv2_client.describe_listeners({ listener_arns: [arn] })
         res.listeners.single_resource(arn)
-      rescue
+      rescue StandardError
         return nil
       end
 
@@ -40,7 +40,7 @@ module Awspec::Helper
         res.target_groups.select do |tg|
           %w(HTTP HTTPS).include?(tg.protocol)
         end.single_resource(id)
-      rescue
+      rescue StandardError
         return nil
       end
 
@@ -60,7 +60,7 @@ module Awspec::Helper
         res.tag_descriptions.select do |resource|
           resource.resource_arn == id
         end.first.tags
-      rescue
+      rescue StandardError
         return nil
       end
     end

--- a/lib/awspec/type/alb.rb
+++ b/lib/awspec/type/alb.rb
@@ -15,11 +15,13 @@ module Awspec::Type
 
     STATES.each do |state|
       define_method state + '?' do
+        check_existence
         resource_via_client.state.code == state
       end
     end
 
     def has_security_group?(sg_id)
+      check_existence
       sgs = resource_via_client.security_groups
       ret = sgs.find do |sg|
         sg == sg_id
@@ -31,6 +33,7 @@ module Awspec::Type
     end
 
     def has_subnet?(subnet_id)
+      check_existence
       azs = resource_via_client.availability_zones
       ret = azs.find do |az|
         az.subnet_id == subnet_id


### PR DESCRIPTION
Now the Finder does rescue for specific expections.
The Type now checks for the AWS SDK corresponding object existence
before trying to invoke methods from it.