### PR TITLE
Fix API Gateway test failure if more that 25 APIs in API Gateway

### DIFF
--- a/lib/awspec/helper/finder/apigateway.rb
+++ b/lib/awspec/helper/finder/apigateway.rb
@@ -2,17 +2,23 @@ module Awspec::Helper
   module Finder
     module Apigateway
       def find_apigateway_by_id(id)
-        rest_apis = apigateway_client.get_rest_apis
-        rest_apis.items.each do |item|
-          return item if item.id == id
+        apis = []
+        apigateway_client.get_rest_apis(limit: 500).each do |response|
+          apis += response.items
+        end
+        apis.each do |api|
+          return api if api.id == id
         end
         nil
       end
 
       def find_apigateway_by_name(name)
-        rest_apis = apigateway_client.get_rest_apis
-        rest_apis.items.each do |item|
-          return item if item.name == name
+        apis = []
+        apigateway_client.get_rest_apis(limit: 500).each do |response|
+          apis += response.items
+        end
+        apis.each do |api|
+          return api if api.name == name
         end
         nil
       end


### PR DESCRIPTION
This is addressing issue #504. Increased the number of APIs returned from the default 25 to the maximum of 500 and added pagination in case more than 500 APIs exist. All API Gateway tests pass. 