### PR TITLE
Fix API Gateway test failure if more that 25 APIs in API Gateway

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -267,7 +267,7 @@ end
 
 ### have_tag
 
-### its(:architecture), its(:creation_date), its(:image_id), its(:image_location), its(:image_type), its(:public), its(:kernel_id), its(:owner_id), its(:platform), its(:ramdisk_id), its(:state), its(:description), its(:ena_support), its(:hypervisor), its(:image_owner_alias), its(:name), its(:root_device_name), its(:root_device_type), its(:sriov_net_support), its(:state_reason), its(:virtualization_type)
+### its(:architecture), its(:creation_date), its(:image_id), its(:image_location), its(:image_type), its(:public), its(:kernel_id), its(:owner_id), its(:platform), its(:platform_details), its(:usage_operation), its(:ramdisk_id), its(:state), its(:description), its(:ena_support), its(:hypervisor), its(:image_owner_alias), its(:name), its(:root_device_name), its(:root_device_type), its(:sriov_net_support), its(:state_reason), its(:virtualization_type)
 ### :unlock: Advanced use
 
 `ami` can use `Aws::EC2::Image` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Image.html).
@@ -894,7 +894,7 @@ end
 ```
 
 
-### its(:availability_zone), its(:create_time), its(:encrypted), its(:kms_key_id), its(:outpost_arn), its(:size), its(:snapshot_id), its(:state), its(:volume_id), its(:iops), its(:volume_type), its(:fast_restored)
+### its(:availability_zone), its(:create_time), its(:encrypted), its(:kms_key_id), its(:outpost_arn), its(:size), its(:snapshot_id), its(:state), its(:volume_id), its(:iops), its(:volume_type), its(:fast_restored), its(:multi_attach_enabled)
 ### :unlock: Advanced use
 
 `ebs` can use `Aws::EC2::Volume` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Volume.html).
@@ -1467,7 +1467,7 @@ end
 ```
 
 
-### its(:domain_id), its(:domain_name), its(:arn), its(:created), its(:deleted), its(:endpoint), its(:endpoints), its(:processing), its(:upgrade_processing), its(:elasticsearch_version), its(:access_policies), its(:snapshot_options), its(:vpc_options), its(:cognito_options), its(:encryption_at_rest_options), its(:node_to_node_encryption_options), its(:advanced_options), its(:log_publishing_options), its(:service_software_options), its(:domain_endpoint_options)
+### its(:domain_id), its(:domain_name), its(:arn), its(:created), its(:deleted), its(:endpoint), its(:endpoints), its(:processing), its(:upgrade_processing), its(:elasticsearch_version), its(:access_policies), its(:snapshot_options), its(:vpc_options), its(:cognito_options), its(:encryption_at_rest_options), its(:node_to_node_encryption_options), its(:advanced_options), its(:log_publishing_options), its(:service_software_options), its(:domain_endpoint_options), its(:advanced_security_options)
 ## <a name="elastictranscoder_pipeline">elastictranscoder_pipeline</a>
 
 ElastictranscoderPipeline resource type.

--- a/lib/awspec/helper/finder/apigateway.rb
+++ b/lib/awspec/helper/finder/apigateway.rb
@@ -2,17 +2,23 @@ module Awspec::Helper
   module Finder
     module Apigateway
       def find_apigateway_by_id(id)
-        rest_apis = apigateway_client.get_rest_apis
-        rest_apis.items.each do |item|
-          return item if item.id == id
+        apis = []
+        apigateway_client.get_rest_apis(limit: 500).each do |response|
+          apis += response.items
+        end
+        apis.each do |api|
+          return api if api.id == id
         end
         nil
       end
 
       def find_apigateway_by_name(name)
-        rest_apis = apigateway_client.get_rest_apis
-        rest_apis.items.each do |item|
-          return item if item.name == name
+        apis = []
+        apigateway_client.get_rest_apis(limit: 500).each do |response|
+          apis += response.items
+        end
+        apis.each do |api|
+          return api if api.name == name
         end
         nil
       end


### PR DESCRIPTION
This is addressing issue #504. Increased the number of APIs returned from the default 25 to the maximum of 500 and added pagination in case more than 500 APIs exist. All API Gateway tests pass.
I am creating a new PR because I moved my changes onto a different branch to follow contributing conventions. 