### PR TITLE
Add ability to test API resource paths for APIs in API Gateway

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -267,7 +267,7 @@ end
 
 ### have_tag
 
-### its(:architecture), its(:creation_date), its(:image_id), its(:image_location), its(:image_type), its(:public), its(:kernel_id), its(:owner_id), its(:platform), its(:ramdisk_id), its(:state), its(:description), its(:ena_support), its(:hypervisor), its(:image_owner_alias), its(:name), its(:root_device_name), its(:root_device_type), its(:sriov_net_support), its(:state_reason), its(:virtualization_type)
+### its(:architecture), its(:creation_date), its(:image_id), its(:image_location), its(:image_type), its(:public), its(:kernel_id), its(:owner_id), its(:platform), its(:platform_details), its(:usage_operation), its(:ramdisk_id), its(:state), its(:description), its(:ena_support), its(:hypervisor), its(:image_owner_alias), its(:name), its(:root_device_name), its(:root_device_type), its(:sriov_net_support), its(:state_reason), its(:virtualization_type)
 ### :unlock: Advanced use
 
 `ami` can use `Aws::EC2::Image` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Image.html).
@@ -283,6 +283,8 @@ describe apigateway('my-apigateway') do
   it { should exist }
 end
 ```
+
+### have_path
 
 ### its(:id), its(:name), its(:description), its(:created_date), its(:version), its(:warnings), its(:binary_media_types), its(:minimum_compression_size), its(:api_key_source), its(:policy), its(:tags)
 ## <a name="autoscaling_group">autoscaling_group</a>
@@ -894,7 +896,7 @@ end
 ```
 
 
-### its(:availability_zone), its(:create_time), its(:encrypted), its(:kms_key_id), its(:outpost_arn), its(:size), its(:snapshot_id), its(:state), its(:volume_id), its(:iops), its(:volume_type), its(:fast_restored)
+### its(:availability_zone), its(:create_time), its(:encrypted), its(:kms_key_id), its(:outpost_arn), its(:size), its(:snapshot_id), its(:state), its(:volume_id), its(:iops), its(:volume_type), its(:fast_restored), its(:multi_attach_enabled)
 ### :unlock: Advanced use
 
 `ebs` can use `Aws::EC2::Volume` resource (see http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Volume.html).
@@ -1467,7 +1469,7 @@ end
 ```
 
 
-### its(:domain_id), its(:domain_name), its(:arn), its(:created), its(:deleted), its(:endpoint), its(:endpoints), its(:processing), its(:upgrade_processing), its(:elasticsearch_version), its(:access_policies), its(:snapshot_options), its(:vpc_options), its(:cognito_options), its(:encryption_at_rest_options), its(:node_to_node_encryption_options), its(:advanced_options), its(:log_publishing_options), its(:service_software_options), its(:domain_endpoint_options)
+### its(:domain_id), its(:domain_name), its(:arn), its(:created), its(:deleted), its(:endpoint), its(:endpoints), its(:processing), its(:upgrade_processing), its(:elasticsearch_version), its(:access_policies), its(:snapshot_options), its(:vpc_options), its(:cognito_options), its(:encryption_at_rest_options), its(:node_to_node_encryption_options), its(:advanced_options), its(:log_publishing_options), its(:service_software_options), its(:domain_endpoint_options), its(:advanced_security_options)
 ## <a name="elastictranscoder_pipeline">elastictranscoder_pipeline</a>
 
 ElastictranscoderPipeline resource type.

--- a/lib/awspec/helper/finder/apigateway.rb
+++ b/lib/awspec/helper/finder/apigateway.rb
@@ -2,17 +2,23 @@ module Awspec::Helper
   module Finder
     module Apigateway
       def find_apigateway_by_id(id)
-        rest_apis = apigateway_client.get_rest_apis
-        rest_apis.items.each do |item|
-          return item if item.id == id
+        apis = []
+        apigateway_client.get_rest_apis(limit: 500).each do |response|
+          apis += response.items
+        end
+        apis.each do |api|
+          return api if api.id == id
         end
         nil
       end
 
       def find_apigateway_by_name(name)
-        rest_apis = apigateway_client.get_rest_apis
-        rest_apis.items.each do |item|
-          return item if item.name == name
+        apis = []
+        apigateway_client.get_rest_apis(limit: 500).each do |response|
+          apis += response.items
+        end
+        apis.each do |api|
+          return api if api.name == name
         end
         nil
       end

--- a/lib/awspec/helper/finder/apigateway.rb
+++ b/lib/awspec/helper/finder/apigateway.rb
@@ -22,6 +22,14 @@ module Awspec::Helper
         end
         nil
       end
+
+      def find_api_resources_by_id(api_id)
+        all_resources = []
+        apigateway_client.get_resources(rest_api_id: api_id, limit: 500).each do |response|
+          all_resources += response.items
+        end
+        all_resources != [] ? all_resources : nil
+      end
     end
   end
 end

--- a/lib/awspec/stub/apigateway.rb
+++ b/lib/awspec/stub/apigateway.rb
@@ -70,6 +70,20 @@ Aws.config[:apigateway] = {
           }
         }
       ]
+    },
+    get_resources: {
+      position: '1',
+      items: [
+        {
+          path: '/proxy'
+        },
+        {
+          path: '/zambonis'
+        },
+        {
+          path: '/zambonis/123'
+        }
+    ]
     }
   }
 }

--- a/lib/awspec/stub/apigateway.rb
+++ b/lib/awspec/stub/apigateway.rb
@@ -83,7 +83,7 @@ Aws.config[:apigateway] = {
         {
           path: '/zambonis/123'
         }
-    ]
+      ]
     }
   }
 }

--- a/lib/awspec/type/apigateway.rb
+++ b/lib/awspec/type/apigateway.rb
@@ -11,5 +11,14 @@ module Awspec::Type
     def id
       @id ||= resource_via_client.id if resource_via_client
     end
+
+    def has_path?(path)
+      check_existence
+      all_resources = find_api_resources_by_id(@id)
+      all_resources.each do |resource|
+        return true if resource.path == path
+      end
+      false
+    end
   end
 end

--- a/spec/type/apigateway_spec.rb
+++ b/spec/type/apigateway_spec.rb
@@ -13,6 +13,9 @@ describe apigateway('ohx0shePof') do
   its(:minimum_compression_size) { should eq 123 }
   its(:api_key_source) { should eq 'HEADER' }
   its(:policy) { should eq 'Honesty' }
+  it { should have_path('/proxy') }
+  it { should have_path('/zambonis') }
+  it { should have_path('/zambonis/123') }
 end
 
 describe apigateway('my-apigateway') do


### PR DESCRIPTION
Added the ability to test an API's resource path to see if they exist. I wanted this functionality so that I could that an API's resources have the paths I am expecting. I added resources with paths to the existing stub/apigateway.rb file and created tests for these in apigateway_spec.rb to make sure that the tests pass. All of the added tests are passing. 

Example usage:
```
describe apigateway('ohx0shePof') do
  it { should have_path('/zambonis') }
end
```
