### PR TITLE
Add a second check for "Throttling" exception to ClientWrap

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -1396,7 +1396,7 @@ describe elasticache('my-rep-group-001') do
 end
 ```
 
-### its(:cache_cluster_id), its(:configuration_endpoint), its(:client_download_landing_page), its(:cache_node_type), its(:engine), its(:engine_version), its(:cache_cluster_status), its(:num_cache_nodes), its(:preferred_availability_zone), its(:cache_cluster_create_time), its(:preferred_maintenance_window), its(:notification_configuration), its(:cache_security_groups), its(:cache_subnet_group_name), its(:cache_nodes), its(:auto_minor_version_upgrade), its(:replication_group_id), its(:snapshot_retention_limit), its(:snapshot_window), its(:auth_token_enabled), its(:auth_token_last_modified_date), its(:transit_encryption_enabled), its(:at_rest_encryption_enabled)
+### its(:cache_cluster_id), its(:configuration_endpoint), its(:client_download_landing_page), its(:cache_node_type), its(:engine), its(:engine_version), its(:cache_cluster_status), its(:num_cache_nodes), its(:preferred_availability_zone), its(:cache_cluster_create_time), its(:preferred_maintenance_window), its(:notification_configuration), its(:cache_security_groups), its(:cache_subnet_group_name), its(:cache_nodes), its(:auto_minor_version_upgrade), its(:replication_group_id), its(:snapshot_retention_limit), its(:snapshot_window), its(:auth_token_enabled), its(:auth_token_last_modified_date), its(:transit_encryption_enabled), its(:at_rest_encryption_enabled), its(:arn)
 ## <a name="elasticache_cache_parameter_group">elasticache_cache_parameter_group</a>
 
 ElasticacheCacheParameterGroup resource type.

--- a/lib/awspec/helper/client_wrap.rb
+++ b/lib/awspec/helper/client_wrap.rb
@@ -2,7 +2,7 @@ require 'awspec/config'
 
 module Awspec::Helper
   class ClientWrap
-    attr_reader :client, :backoff, :iteration, :backoff_limit, :symbol
+    attr_reader :client, :backoff, :iteration, :backoff_limit, :symbol1, :symbol2
     def initialize(real_client = nil)
       raise ArgumentError, 'Client can not be nil' if real_client.nil?
       config = Awspec::Config.instance
@@ -14,7 +14,8 @@ module Awspec::Helper
       @backoff_limit = config[:client_backoff_limit]
       # build the symbol we'll use to compare to any errors caught in method_missing
       # below.
-      @symbol = real_client.class.to_s.split('::').shift(2).push('Errors', 'RequestLimitExceeded').join('::').to_sym
+      @symbol1 = real_client.class.to_s.split('::').shift(2).push('Errors', 'RequestLimitExceeded').join('::').to_sym
+      @symbol2 = real_client.class.to_s.split('::').shift(2).push('Errors', 'Throttling').join('::').to_sym
     end
 
     protected
@@ -28,7 +29,7 @@ module Awspec::Helper
       begin
         results = client.send(m, *args, &block)
       rescue Exception => e # rubocop:disable Lint/RescueException
-        raise unless e.class.to_s == symbol.to_s && backoff < backoff_limit
+        raise unless (e.class.to_s == symbol1.to_s || e.class.to_s == symbol2.to_s) && backoff < backoff_limit
 
         @backoff = backoff + (iteration * iteration * 0.5)
         @iteration += 1

--- a/spec/lib/awspec/helper/client_wrap_spec.rb
+++ b/spec/lib/awspec/helper/client_wrap_spec.rb
@@ -159,6 +159,5 @@ describe Awspec::Helper::ClientWrap do
         expect(res).to eq 'done'
       end
     end
-
   end
 end


### PR DESCRIPTION
So, even with the ClientWrap meant to be doing exponential backoff/retry I was still getting failures due to rate limit throttling.

Dug a bit into the code and realised that the exception being thrown didn't match the exception expected by the code to retry, so added the one I was getting to the retry criteria.

Now not getting throttling errors