### PR TITLE
Security group rule

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -198,7 +198,7 @@ describe alb_listener('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:li
 end
 ```
 
-### its(:listener_arn), its(:load_balancer_arn), its(:port), its(:protocol), its(:certificates), its(:ssl_policy)
+### its(:listener_arn), its(:load_balancer_arn), its(:port), its(:protocol), its(:certificates), its(:ssl_policy), its(:alpn_policy)
 ## <a name="alb_target_group">alb_target_group</a>
 
 AlbTargetGroup resource type.
@@ -1620,7 +1620,7 @@ describe emr('my-emr') do
 end
 ```
 
-### its(:id), its(:name), its(:instance_collection_type), its(:log_uri), its(:requested_ami_version), its(:running_ami_version), its(:release_label), its(:auto_terminate), its(:termination_protected), its(:visible_to_all_users), its(:service_role), its(:normalized_instance_hours), its(:master_public_dns_name), its(:configurations), its(:security_configuration), its(:auto_scaling_role), its(:scale_down_behavior), its(:custom_ami_id), its(:ebs_root_volume_size), its(:repo_upgrade_on_boot), its(:cluster_arn), its(:outpost_arn), its(:step_concurrency_level)
+### its(:id), its(:name), its(:instance_collection_type), its(:log_uri), its(:log_encryption_kms_key_id), its(:requested_ami_version), its(:running_ami_version), its(:release_label), its(:auto_terminate), its(:termination_protected), its(:visible_to_all_users), its(:service_role), its(:normalized_instance_hours), its(:master_public_dns_name), its(:configurations), its(:security_configuration), its(:auto_scaling_role), its(:scale_down_behavior), its(:custom_ami_id), its(:ebs_root_volume_size), its(:repo_upgrade_on_boot), its(:cluster_arn), its(:outpost_arn), its(:step_concurrency_level)
 ## <a name="firehose">firehose</a>
 
 Firehose resource type.
@@ -2591,7 +2591,7 @@ describe nlb_listener('arn:aws:elasticloadbalancing:ap-northeast-1:1234567890:li
 end
 ```
 
-### its(:listener_arn), its(:load_balancer_arn), its(:port), its(:protocol), its(:certificates), its(:ssl_policy)
+### its(:listener_arn), its(:load_balancer_arn), its(:port), its(:protocol), its(:certificates), its(:ssl_policy), its(:alpn_policy)
 ## <a name="nlb_target_group">nlb_target_group</a>
 
 NlbTargetGroup resource type.
@@ -3199,6 +3199,10 @@ end
 ### be_opened_only
 
 ### be_outbound_opened_only
+
+### have_inbound_rule
+
+### have_outbound_rule
 
 ### have_tag
 

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -75,12 +75,75 @@ module Awspec::Type
     end
     alias_method :outbound_permissions_count, :ip_permissions_egress_count
 
+
+    def has_inbound_rule?(rule)
+      return resource_via_client.ip_permissions.find do |permission|
+        
+        result = true
+
+        result = false unless permission.ip_protocol == (rule[:ip_protocol]=="all" ? "-1" : rule[:ip_protocol])
+        result = false unless permission.ip_protocol == "-1" || permission.from_port == rule[:from_port]
+        result = false unless permission.ip_protocol == "-1" || permission.to_port == rule[:to_port]
+
+        if result
+          if rule[:ip_range]
+            result = permission.ip_ranges.find do | ip_range|
+              ip_range.cidr_ip == rule[:ip_range]
+            end
+          elsif rule[:group_pair]
+            result = permission.user_id_group_pairs.find do |pair|
+              result_g = true
+              result_g = false unless pair.group_id == rule[:group_pair][:group_id] || rule[:group_pair][:group_id].nil?
+              result_g = false unless pair.group_name == rule[:group_pair][:group_name] || rule[:group_pair][:group_name].nil?
+              result_g = false unless pair.user_id == rule[:group_pair][:user_id] || rule[:group_pair][:user_id].nil?
+              result_g = false unless pair.vpc_id == rule[:group_pair][:vpc_id] || rule[:group_pair][:vpc_id].nil?
+              result_g = false unless pair.vpc_peering_connection_id == rule[:group_pair][:vpc_peering_connection_id] || rule[:group_pair][:vpc_peering_connection_id].nil?
+              result_g = false unless pair.peering_status == rule[:group_pair][:peering_status] || rule[:group_pair][:peering_status].nil?
+              result_g
+            end
+          end
+        end
+        result
+      end
+    end
+    
     def inbound_rule_count
       resource_via_client.ip_permissions.reduce(0) do |sum, permission|
         sum += permission.ip_ranges.count + permission.user_id_group_pairs.count
       end
     end
 
+    def has_outbound_rule?(rule)
+      return resource_via_client.ip_permissions_egress.find do |permission|
+        
+        result = true
+        
+        result = false unless permission.ip_protocol == (rule[:ip_protocol]=="all" ? "-1" : rule[:ip_protocol])
+        result = false unless permission.ip_protocol == "-1" || permission.from_port == rule[:from_port]
+        result = false unless permission.ip_protocol == "-1" || permission.to_port == rule[:to_port]
+
+        if result
+          if rule[:ip_range]
+            result = permission.ip_ranges.find do | ip_range|
+              ip_range.cidr_ip == rule[:ip_range]
+            end
+          elsif rule[:group_pair]
+            result = permission.user_id_group_pairs.find do |pair|
+              result_g = true
+              result_g = false unless pair.group_id == rule[:group_pair][:group_id] || rule[:group_pair][:group_id].nil?
+              result_g = false unless pair.group_name == rule[:group_pair][:group_name] || rule[:group_pair][:group_name].nil?
+              result_g = false unless pair.user_id == rule[:group_pair][:user_id] || rule[:group_pair][:user_id].nil?
+              result_g = false unless pair.vpc_id == rule[:group_pair][:vpc_id] || rule[:group_pair][:vpc_id].nil?
+              result_g = false unless pair.vpc_peering_connection_id == rule[:group_pair][:vpc_peering_connection_id] || rule[:group_pair][:vpc_peering_connection_id].nil?
+              result_g = false unless pair.peering_status == rule[:group_pair][:peering_status] || rule[:group_pair][:peering_status].nil?
+              result_g
+            end
+          end
+        end
+        result
+      end
+    end
+    
     def outbound_rule_count
       resource_via_client.ip_permissions_egress.reduce(0) do |sum, permission|
         sum += permission.ip_ranges.count + permission.user_id_group_pairs.count

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -76,8 +76,6 @@ module Awspec::Type
     alias_method :outbound_permissions_count, :ip_permissions_egress_count
 
     def has_inbound_rule?(rule)
-      rule[:ip_protocol] = '-1' if rule[:ip_protocol] == 'all'
-
       resource_via_client.ip_permissions.find do |permission|
         sg_rule_match?(permission, rule)
       end
@@ -90,8 +88,6 @@ module Awspec::Type
     end
 
     def has_outbound_rule?(rule)
-      rule[:ip_protocol] = '-1' if rule[:ip_protocol] == 'all'
-
       resource_via_client.ip_permissions_egress.find do |permission|
         sg_rule_match?(permission, rule)
       end
@@ -162,6 +158,7 @@ module Awspec::Type
     end
 
     def sg_rule_match?(permission, rule)
+      rule[:ip_protocol] = '-1' if rule[:ip_protocol] == 'all'
       return false unless permission.ip_protocol == rule[:ip_protocol]
       return false unless permission.ip_protocol == '-1' || permission.from_port == rule[:from_port]
       return false unless permission.ip_protocol == '-1' || permission.to_port == rule[:to_port]

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -75,38 +75,14 @@ module Awspec::Type
     end
     alias_method :outbound_permissions_count, :ip_permissions_egress_count
 
-
     def has_inbound_rule?(rule)
-      return resource_via_client.ip_permissions.find do |permission|
-        
-        result = true
+      rule[:ip_protocol] = '-1' if rule[:ip_protocol] == 'all'
 
-        result = false unless permission.ip_protocol == (rule[:ip_protocol]=="all" ? "-1" : rule[:ip_protocol])
-        result = false unless permission.ip_protocol == "-1" || permission.from_port == rule[:from_port]
-        result = false unless permission.ip_protocol == "-1" || permission.to_port == rule[:to_port]
-
-        if result
-          if rule[:ip_range]
-            result = permission.ip_ranges.find do | ip_range|
-              ip_range.cidr_ip == rule[:ip_range]
-            end
-          elsif rule[:group_pair]
-            result = permission.user_id_group_pairs.find do |pair|
-              result_g = true
-              result_g = false unless pair.group_id == rule[:group_pair][:group_id] || rule[:group_pair][:group_id].nil?
-              result_g = false unless pair.group_name == rule[:group_pair][:group_name] || rule[:group_pair][:group_name].nil?
-              result_g = false unless pair.user_id == rule[:group_pair][:user_id] || rule[:group_pair][:user_id].nil?
-              result_g = false unless pair.vpc_id == rule[:group_pair][:vpc_id] || rule[:group_pair][:vpc_id].nil?
-              result_g = false unless pair.vpc_peering_connection_id == rule[:group_pair][:vpc_peering_connection_id] || rule[:group_pair][:vpc_peering_connection_id].nil?
-              result_g = false unless pair.peering_status == rule[:group_pair][:peering_status] || rule[:group_pair][:peering_status].nil?
-              result_g
-            end
-          end
-        end
-        result
+      resource_via_client.ip_permissions.find do |permission|
+        sg_rule_match?(permission, rule)
       end
     end
-    
+
     def inbound_rule_count
       resource_via_client.ip_permissions.reduce(0) do |sum, permission|
         sum += permission.ip_ranges.count + permission.user_id_group_pairs.count
@@ -114,36 +90,13 @@ module Awspec::Type
     end
 
     def has_outbound_rule?(rule)
-      return resource_via_client.ip_permissions_egress.find do |permission|
-        
-        result = true
-        
-        result = false unless permission.ip_protocol == (rule[:ip_protocol]=="all" ? "-1" : rule[:ip_protocol])
-        result = false unless permission.ip_protocol == "-1" || permission.from_port == rule[:from_port]
-        result = false unless permission.ip_protocol == "-1" || permission.to_port == rule[:to_port]
+      rule[:ip_protocol] = '-1' if rule[:ip_protocol] == 'all'
 
-        if result
-          if rule[:ip_range]
-            result = permission.ip_ranges.find do | ip_range|
-              ip_range.cidr_ip == rule[:ip_range]
-            end
-          elsif rule[:group_pair]
-            result = permission.user_id_group_pairs.find do |pair|
-              result_g = true
-              result_g = false unless pair.group_id == rule[:group_pair][:group_id] || rule[:group_pair][:group_id].nil?
-              result_g = false unless pair.group_name == rule[:group_pair][:group_name] || rule[:group_pair][:group_name].nil?
-              result_g = false unless pair.user_id == rule[:group_pair][:user_id] || rule[:group_pair][:user_id].nil?
-              result_g = false unless pair.vpc_id == rule[:group_pair][:vpc_id] || rule[:group_pair][:vpc_id].nil?
-              result_g = false unless pair.vpc_peering_connection_id == rule[:group_pair][:vpc_peering_connection_id] || rule[:group_pair][:vpc_peering_connection_id].nil?
-              result_g = false unless pair.peering_status == rule[:group_pair][:peering_status] || rule[:group_pair][:peering_status].nil?
-              result_g
-            end
-          end
-        end
-        result
+      resource_via_client.ip_permissions_egress.find do |permission|
+        sg_rule_match?(permission, rule)
       end
     end
-    
+
     def outbound_rule_count
       resource_via_client.ip_permissions_egress.reduce(0) do |sum, permission|
         sum += permission.ip_ranges.count + permission.user_id_group_pairs.count
@@ -206,6 +159,35 @@ module Awspec::Type
       else
         port.between?(from_port, to_port)
       end
+    end
+
+    def sg_rule_match?(permission, rule)
+      return false unless permission.ip_protocol == rule[:ip_protocol]
+      return false unless permission.ip_protocol == '-1' || permission.from_port == rule[:from_port]
+      return false unless permission.ip_protocol == '-1' || permission.to_port == rule[:to_port]
+
+      if rule[:ip_range]
+        return false unless permission.ip_ranges.find do |ip_range|
+          ip_range.cidr_ip == rule[:ip_range]
+        end
+      elsif rule[:group_pair]
+        return false unless permission.user_id_group_pairs.find do |pair|
+          group_pair_match?(pair, rule[:group_pair])
+        end
+      end
+      true
+    end
+
+    def group_pair_match?(actual_pair, rule_pair)
+      return false unless actual_pair.group_id == rule_pair[:group_id] || rule_pair[:group_id].nil?
+      return false unless actual_pair.group_name == rule_pair[:group_name] || rule_pair[:group_name].nil?
+      return false unless actual_pair.user_id == rule_pair[:user_id] || rule_pair[:user_id].nil?
+      return false unless actual_pair.vpc_id == rule_pair[:vpc_id] || rule_pair[:vpc_id].nil?
+      return false unless
+        actual_pair.vpc_peering_connection_id == rule_pair[:vpc_peering_connection_id] ||
+        rule_pair[:vpc_peering_connection_id].nil?
+      return false unless actual_pair.peering_status == rule_pair[:peering_status] || rule_pair[:peering_status].nil?
+      true
     end
   end
 end

--- a/spec/type/security_group_spec.rb
+++ b/spec/type/security_group_spec.rb
@@ -27,24 +27,6 @@ describe security_group('sg-1a2b3cd4') do
   its(:inbound_rule_count) { should eq 8 }
   its(:outbound_rule_count) { should eq 2 }
 
-  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 80, to_port: 80, ip_range: "123.45.67.0/24" })}
-  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 80, to_port: 80, ip_range: "123.45.68.89/32" })}
-  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 22, to_port: 22, group_pair: { group_id: "sg-5a6b7cd8" }})}
-  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 22, to_port: 22, group_pair: { group_name: "group-name-sg" }})}
-  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 60000, to_port: 60000, ip_range: "100.45.67.12/32" })}
-  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 70000, to_port: 70000, ip_range: "100.45.67.89/32" })}
-  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 70000, to_port: 70000, ip_range: "100.45.67.12/32" })}
-  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 50000, to_port: 50009, ip_range: "123.45.67.89/32" })}
-  it { should have_inbound_rule( { ip_protocol: "all", group_pair: {group_id: "sg-3a4b5cd6", user_id: "1234567890" }})}
-  it { should have_outbound_rule( { ip_protocol: "tcp", from_port: 50000, to_port: 50000, ip_range: "100.45.67.12/32" })}
-  it { should have_outbound_rule( { ip_protocol: "tcp", from_port: 8080, to_port: 8080, group_pair: {group_id: "sg-9a8b7c6d", user_id: "5678901234", vpc_id: "vpc-5b6a7c8f", vpc_peering_connection_id: "pcx-f9e8d7c6", peering_status: "active" }})}
-  it { should have_outbound_rule( { ip_protocol: "tcp", from_port: 443, to_port: 443, prefix_list_id: "pl-a5321fa3" })}
-  
-
-  
-  # its(:inbound) { should be_opened(22).protocol('tcp').for('group-name-sg') }
-  # its(:inbound) { should be_opened(22).protocol('tcp').for('my-db-sg') }
-
   it { should belong_to_vpc('vpc-ab123cde') }
   it { should belong_to_vpc('my-vpc') }
   it { should have_tag('env').value('dev') }
@@ -52,6 +34,63 @@ describe security_group('sg-1a2b3cd4') do
     its(:resource) { should be_an_instance_of(Awspec::ResourceReader) }
     its('resource.group_name') { should eq 'my-security-group-name' }
   end
+end
+
+describe security_group('sg-1a2b3cd4') do
+  it {
+    should have_inbound_rule({ ip_protocol: 'tcp', from_port: 80, to_port: 80, ip_range: '123.45.67.0/24' })
+  }
+  it {
+    should have_inbound_rule({ ip_protocol: 'tcp', from_port: 80, to_port: 80, ip_range: '123.45.68.89/32' })
+  }
+  it {
+    should have_inbound_rule({
+                               ip_protocol: 'tcp', from_port: 22, to_port: 22, group_pair: {
+                                 group_id: 'sg-5a6b7cd8'
+                               }
+                             })
+  }
+  it {
+    should have_inbound_rule({
+                               ip_protocol: 'tcp', from_port: 22, to_port: 22, group_pair: {
+                                 group_name: 'group-name-sg'
+                               }
+                             })
+  }
+  it {
+    should have_inbound_rule({ ip_protocol: 'tcp', from_port: 60_000, to_port: 60_000, ip_range: '100.45.67.12/32' })
+  }
+  it {
+    should have_inbound_rule({ ip_protocol: 'tcp', from_port: 70_000, to_port: 70_000, ip_range: '100.45.67.89/32' })
+  }
+  it {
+    should have_inbound_rule({ ip_protocol: 'tcp', from_port: 70_000, to_port: 70_000, ip_range: '100.45.67.12/32' })
+  }
+  it {
+    should have_inbound_rule({ ip_protocol: 'tcp', from_port: 50_000, to_port: 50_009, ip_range: '123.45.67.89/32' })
+  }
+  it {
+    should have_inbound_rule({ ip_protocol: 'all', group_pair: { group_id: 'sg-3a4b5cd6', user_id: '1234567890' } })
+  }
+  it {
+    should have_outbound_rule({ ip_protocol: 'tcp', from_port: 50_000, to_port: 50_000, ip_range: '100.45.67.12/32' })
+  }
+  it {
+    should have_outbound_rule({
+                                ip_protocol: 'tcp',
+                                from_port: 8080,
+                                to_port: 8080,
+                                group_pair: {
+                                  group_id: 'sg-9a8b7c6d',
+                                  user_id: '5678901234',
+                                  vpc_id: 'vpc-5b6a7c8f',
+                                  vpc_peering_connection_id: 'pcx-f9e8d7c6',
+                                  peering_status: 'active'
+                                }
+                              }
+                             )
+  }
+  it { should have_outbound_rule({ ip_protocol: 'tcp', from_port: 443, to_port: 443, prefix_list_id: 'pl-a5321fa3' }) }
 end
 
 describe security_group('my-security-group-name') do

--- a/spec/type/security_group_spec.rb
+++ b/spec/type/security_group_spec.rb
@@ -11,7 +11,7 @@ describe security_group('sg-1a2b3cd4') do
   its(:inbound) { should be_opened(22) }
   its(:inbound) { should be_opened(22).protocol('tcp').for('sg-5a6b7cd8') }
   its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.45.67.89/32') }
-  its(:inbound) { should_not be_opened('50010-50019').protocol('tcp').for('123.45.67.89/32') }
+  its(:inbound) { should_not be_opened('50000-50019').protocol('tcp').for('123.45.67.89/32') }
   its(:outbound) { should be_opened(50_000) }
   its(:outbound) { should be_opened(8080).protocol('tcp').for('sg-9a8b7c6d') }
   its(:outbound) { should be_opened(8080).protocol('tcp').for('group-in-other-aws-account-with-vpc-peering') }
@@ -27,6 +27,21 @@ describe security_group('sg-1a2b3cd4') do
   its(:inbound_rule_count) { should eq 8 }
   its(:outbound_rule_count) { should eq 2 }
 
+  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 80, to_port: 80, ip_range: "123.45.67.0/24" })}
+  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 80, to_port: 80, ip_range: "123.45.68.89/32" })}
+  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 22, to_port: 22, group_pair: { group_id: "sg-5a6b7cd8" }})}
+  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 22, to_port: 22, group_pair: { group_name: "group-name-sg" }})}
+  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 60000, to_port: 60000, ip_range: "100.45.67.12/32" })}
+  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 70000, to_port: 70000, ip_range: "100.45.67.89/32" })}
+  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 70000, to_port: 70000, ip_range: "100.45.67.12/32" })}
+  it { should have_inbound_rule( { ip_protocol: "tcp", from_port: 50000, to_port: 50009, ip_range: "123.45.67.89/32" })}
+  it { should have_inbound_rule( { ip_protocol: "all", group_pair: {group_id: "sg-3a4b5cd6", user_id: "1234567890" }})}
+  it { should have_outbound_rule( { ip_protocol: "tcp", from_port: 50000, to_port: 50000, ip_range: "100.45.67.12/32" })}
+  it { should have_outbound_rule( { ip_protocol: "tcp", from_port: 8080, to_port: 8080, group_pair: {group_id: "sg-9a8b7c6d", user_id: "5678901234", vpc_id: "vpc-5b6a7c8f", vpc_peering_connection_id: "pcx-f9e8d7c6", peering_status: "active" }})}
+  it { should have_outbound_rule( { ip_protocol: "tcp", from_port: 443, to_port: 443, prefix_list_id: "pl-a5321fa3" })}
+  
+
+  
   # its(:inbound) { should be_opened(22).protocol('tcp').for('group-name-sg') }
   # its(:inbound) { should be_opened(22).protocol('tcp').for('my-db-sg') }
 

--- a/spec/type/security_group_spec.rb
+++ b/spec/type/security_group_spec.rb
@@ -11,7 +11,7 @@ describe security_group('sg-1a2b3cd4') do
   its(:inbound) { should be_opened(22) }
   its(:inbound) { should be_opened(22).protocol('tcp').for('sg-5a6b7cd8') }
   its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.45.67.89/32') }
-  its(:inbound) { should_not be_opened('50000-50019').protocol('tcp').for('123.45.67.89/32') }
+  its(:inbound) { should_not be_opened('50010-50019').protocol('tcp').for('123.45.67.89/32') }
   its(:outbound) { should be_opened(50_000) }
   its(:outbound) { should be_opened(8080).protocol('tcp').for('sg-9a8b7c6d') }
   its(:outbound) { should be_opened(8080).protocol('tcp').for('group-in-other-aws-account-with-vpc-peering') }


### PR DESCRIPTION
So, this adds in extra tests for inbound and outbound rules.... It is currently failing rubocop, because it says the class is too long... it was longer that this, so I'm not sure how to make it much shorter! The only thing I can think of is to remove all the code to check individual ports, because in some senses that's obsolete, now we're testing the actual rules.

But that would break anyone who's using those tests at the moment (not that I think they work properly) - so would welcome suggestions.

thanks

Caroline