### PR TITLE
Allow enabling http_wire_trace via env vars

### DIFF
--- a/lib/awspec/helper/finder.rb
+++ b/lib/awspec/helper/finder.rb
@@ -162,7 +162,8 @@ module Awspec::Helper
     }
 
     CLIENT_OPTIONS = {
-      http_proxy: ENV['http_proxy'] || ENV['https_proxy'] || nil
+      http_proxy: ENV['http_proxy'] || ENV['https_proxy'] || nil,
+      http_wire_trace: ENV['http_wire_trace'] || false
     }
 
     CLIENTS.each do |method_name, client|


### PR DESCRIPTION
Hi,

i'm not a ruby dev but we are using awspec. Now we have moved the execution to aws and facing wired connection issues:

```
1) iam_role 'DatabaseAdmin' is expected to exist
     Failure/Error: it { should exist }
     
     Seahorse::Client::NetworkingError:
       Failed to open TCP connection to : (getaddrinfo: Name does not resolve)
     # ./spec/rds_spec.rb:4:in `block (2 levels) in <top (required)>'
```

The wired thing is that it does not show a target where it tries to connect to. The other thing is that we can run `aws iam list-roles`without a problem through the proxy setup in env -> http-proxy / https-proxy

