### PR TITLE
Replace URI.decode with URI.decode_www_form_component

### DIFF
--- a/lib/awspec/generator/spec/iam_group.rb
+++ b/lib/awspec/generator/spec/iam_group.rb
@@ -11,7 +11,7 @@ module Awspec::Generator
                                                 group_name: group.group_name,
                                                 policy_name: policy_name
                                               })
-            document = JSON.generate(JSON.parse(URI.decode(res.policy_document)))
+            document = JSON.generate(JSON.parse(URI.decode_www_form_component(res.policy_document)))
             "it { should have_inline_policy('#{policy_name}').policy_document('#{document}') }"
           end
           content = ERB.new(iam_group_spec_template, nil, '-').result(binding).gsub(/^\n/, '')

--- a/lib/awspec/generator/spec/iam_role.rb
+++ b/lib/awspec/generator/spec/iam_role.rb
@@ -11,7 +11,7 @@ module Awspec::Generator
                                                role_name: role.role_name,
                                                policy_name: policy_name
                                              })
-            document = JSON.generate(JSON.parse(URI.decode(res.policy_document)))
+            document = JSON.generate(JSON.parse(URI.decode_www_form_component(res.policy_document)))
             "it { should have_inline_policy('#{policy_name}').policy_document('#{document}') }"
           end
           content = ERB.new(iam_role_spec_template, nil, '-').result(binding).gsub(/^\n/, '')

--- a/lib/awspec/generator/spec/iam_user.rb
+++ b/lib/awspec/generator/spec/iam_user.rb
@@ -11,7 +11,7 @@ module Awspec::Generator
                                                user_name: user.user_name,
                                                policy_name: policy_name
                                              })
-            document = JSON.generate(JSON.parse(URI.decode(res.policy_document)))
+            document = JSON.generate(JSON.parse(URI.decode_www_form_component(res.policy_document)))
             "it { should have_inline_policy('#{policy_name}').policy_document('#{document}') }"
           end
           content = ERB.new(iam_user_spec_template, nil, '-').result(binding).gsub(/^\n/, '')

--- a/lib/awspec/type/iam_group.rb
+++ b/lib/awspec/type/iam_group.rb
@@ -34,7 +34,7 @@ module Awspec::Type
                                           group_name: id,
                                           policy_name: policy_name
                                         })
-      return JSON.parse(URI.decode(res.policy_document)) == JSON.parse(document) if document
+      return JSON.parse(URI.decode_www_form_component(res.policy_document)) == JSON.parse(document) if document
       res
     end
 

--- a/lib/awspec/type/iam_role.rb
+++ b/lib/awspec/type/iam_role.rb
@@ -24,7 +24,7 @@ module Awspec::Type
                                          role_name: resource_via_client.role_name,
                                          policy_name: policy_name
                                        })
-      return JSON.parse(URI.decode(res.policy_document)) == JSON.parse(document) if document
+      return JSON.parse(URI.decode_www_form_component(res.policy_document)) == JSON.parse(document) if document
       res
     end
 

--- a/lib/awspec/type/iam_user.rb
+++ b/lib/awspec/type/iam_user.rb
@@ -24,7 +24,7 @@ module Awspec::Type
                                          user_name: resource_via_client.user_name,
                                          policy_name: policy_name
                                        })
-      return JSON.parse(URI.decode(res.policy_document)) == JSON.parse(document) if document
+      return JSON.parse(URI.decode_www_form_component(res.policy_document)) == JSON.parse(document) if document
       res
     end
 

--- a/lib/awspec/type/kms.rb
+++ b/lib/awspec/type/kms.rb
@@ -14,7 +14,7 @@ module Awspec::Type
 
     def has_key_policy?(policy_name, document = nil)
       res = kms_client.get_key_policy(key_id: id, policy_name: policy_name)
-      return JSON.parse(URI.decode(res.policy)) == JSON.parse(document) if document
+      return JSON.parse(URI.decode_www_form_component(res.policy)) == JSON.parse(document) if document
       res
     end
   end


### PR DESCRIPTION
In Ruby 2.7, some resource types such as iam_user display a warning about URI.decode:

```
$ bundle exec ruby -v
ruby 2.7.3p183 (2021-04-05 revision 6847ee089d) [x86_64-linux]
$ bundle exec rake spec
iam_user 'awspec-sandbox'
  is expected to exist
  /home/hoshino/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/awspec-1.22.1/lib/awspec/type/iam_user.rb:27: warning: URI.unescape is obsolete
    is expected to have inline policy "awspec-sandbox-policy"
 ```

This is because awspec uses URI.decode (URI.unescape) and the API is obsolete:

- https://github.com/ruby/ruby/commit/238b979f1789f95262a267d8df6239806f2859cc
- https://github.com/ruby/ruby/commit/869e2dd8c8efc1e7a043c9eee82d97c47befbcc7

To suppress the warning, this patch replaces URI.decode with URI.decode_www_form_component.