### PR TITLE
Add eks_nodegroup type

### DIFF
--- a/doc/_resource_types/eks_nodegroup.md
+++ b/doc/_resource_types/eks_nodegroup.md
@@ -1,0 +1,14 @@
+### exist
+
+```ruby
+describe eks_nodegroup('my-eks-nodegroup'), cluster: 'my-cluster' do
+  it { should exist }
+end
+```
+### be_active, be_creating
+
+```ruby
+describe eks('my-eks-nodegroup'), cluster: 'my-cluster' do
+  it { should be_active }
+end
+```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -34,6 +34,7 @@
 | [efs](#efs)
 | [eip](#eip)
 | [eks](#eks)
+| [eks_nodegroup](#eks_nodegroup)
 | [elasticache](#elasticache)
 | [elasticache_cache_parameter_group](#elasticache_cache_parameter_group)
 | [elasticsearch](#elasticsearch)
@@ -1357,6 +1358,21 @@ end
 ```
 
 ### its(:name), its(:arn), its(:created_at), its(:version), its(:endpoint), its(:role_arn), its(:kubernetes_network_config), its(:logging), its(:identity), its(:status), its(:client_request_token), its(:platform_version), its(:tags), its(:encryption_config)
+## <a name="eks_nodegroup">eks_nodegroup</a>
+
+EksNodegroup resource type.
+
+### exist
+
+```ruby
+describe eks_nodegroup('my-eks-nodegroup'), cluster: 'my-cluster' do
+  it { should exist }
+end
+```
+
+### be_active, be_inactive
+
+### its(:nodegroup_name), its(:nodegroup_arn), its(:cluster_name), its(:version), its(:release_version), its(:created_at), its(:modified_at), its(:status), its(:capacity_type), its(:scaling_config), its(:instance_types), its(:subnets), its(:remote_access), its(:ami_type), its(:node_role), its(:labels), its(:resources), its(:disk_size), its(:health), its(:launch_template), its(:tags)
 ## <a name="elasticache">elasticache</a>
 
 Elasticache resource type.
@@ -1425,7 +1441,7 @@ describe elasticache('my-rep-group-001') do
 end
 ```
 
-### its(:cache_cluster_id), its(:configuration_endpoint), its(:client_download_landing_page), its(:cache_node_type), its(:engine), its(:engine_version), its(:cache_cluster_status), its(:num_cache_nodes), its(:preferred_availability_zone), its(:preferred_outpost_arn), its(:cache_cluster_create_time), its(:preferred_maintenance_window), its(:notification_configuration), its(:cache_security_groups), its(:cache_subnet_group_name), its(:cache_nodes), its(:auto_minor_version_upgrade), its(:replication_group_id), its(:snapshot_retention_limit), its(:snapshot_window), its(:auth_token_enabled), its(:auth_token_last_modified_date), its(:transit_encryption_enabled), its(:at_rest_encryption_enabled), its(:arn)
+### its(:cache_cluster_id), its(:configuration_endpoint), its(:client_download_landing_page), its(:cache_node_type), its(:engine), its(:engine_version), its(:cache_cluster_status), its(:num_cache_nodes), its(:preferred_availability_zone), its(:preferred_outpost_arn), its(:cache_cluster_create_time), its(:preferred_maintenance_window), its(:notification_configuration), its(:cache_security_groups), its(:cache_subnet_group_name), its(:cache_nodes), its(:auto_minor_version_upgrade), its(:replication_group_id), its(:snapshot_retention_limit), its(:snapshot_window), its(:auth_token_enabled), its(:auth_token_last_modified_date), its(:transit_encryption_enabled), its(:at_rest_encryption_enabled), its(:arn), its(:replication_group_log_delivery_enabled), its(:log_delivery_configurations)
 ## <a name="elasticache_cache_parameter_group">elasticache_cache_parameter_group</a>
 
 ElasticacheCacheParameterGroup resource type.

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -1283,7 +1283,7 @@ describe ecs_task_definition('my-ecs-task-definition') do
 end
 ```
 
-### its(:task_definition_arn), its(:family), its(:task_role_arn), its(:execution_role_arn), its(:network_mode), its(:revision), its(:volumes), its(:status), its(:requires_attributes), its(:placement_constraints), its(:compatibilities), its(:requires_compatibilities), its(:cpu), its(:memory), its(:inference_accelerators), its(:pid_mode), its(:ipc_mode), its(:proxy_configuration), its(:registered_at), its(:deregistered_at), its(:registered_by)
+### its(:task_definition_arn), its(:family), its(:task_role_arn), its(:execution_role_arn), its(:network_mode), its(:revision), its(:volumes), its(:status), its(:requires_attributes), its(:placement_constraints), its(:compatibilities), its(:requires_compatibilities), its(:cpu), its(:memory), its(:inference_accelerators), its(:pid_mode), its(:ipc_mode), its(:proxy_configuration), its(:registered_at), its(:deregistered_at), its(:registered_by), its(:ephemeral_storage)
 ## <a name="efs">efs</a>
 
 EFS resource type.

--- a/lib/awspec/generator/doc/type/eks_nodegroup.rb
+++ b/lib/awspec/generator/doc/type/eks_nodegroup.rb
@@ -1,0 +1,19 @@
+module Awspec::Generator
+  module Doc
+    module Type
+      class EksNodegroup < Base
+        def initialize
+          super
+          @type_name = 'EksNodegroup'
+          @type = Awspec::Type::EksNodegroup.new('my-eks-nodegroup')
+          @ret = @type.resource_via_client
+          @matchers = [
+            Awspec::Type::EksNodegroup::STATES.map { |state| 'be_' + state.downcase }.join(', ')
+          ]
+          @ignore_matchers = Awspec::Type::EksNodegroup::STATES.map { |state| 'be_' + state.downcase }
+          @describes = []
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/helper/finder/eks.rb
+++ b/lib/awspec/helper/finder/eks.rb
@@ -5,6 +5,11 @@ module Awspec::Helper
         res = eks_client.describe_cluster({ name: name })
         res.cluster
       end
+
+      def find_eks_nodegroup(cluster_name, group_name)
+        res = eks_client.describe_nodegroup({ cluster_name: cluster_name, nodegroup_name: group_name })
+        res.nodegroup
+      end
     end
   end
 end

--- a/lib/awspec/helper/type.rb
+++ b/lib/awspec/helper/type.rb
@@ -12,7 +12,7 @@ module Awspec
         batch_compute_environment batch_job_definition batch_job_queue cloudtrail
         cloudwatch_alarm cloudwatch_event directconnect_virtual_interface
         ebs ec2 ecr_repository ecs_cluster ecs_container_instance ecs_service ecs_task_definition
-        efs eks elasticache elasticache_cache_parameter_group elasticsearch elb emr firehose iam_group
+        efs eks eks_nodegroup elasticache elasticache_cache_parameter_group elasticsearch elb emr firehose iam_group
         iam_policy iam_role iam_user kinesis kms lambda launch_configuration launch_template mq nat_gateway
         network_acl network_interface nlb nlb_listener nlb_target_group
         rds rds_db_cluster_parameter_group rds_db_parameter_group route53_hosted_zone

--- a/lib/awspec/stub/eks_nodegroup.rb
+++ b/lib/awspec/stub/eks_nodegroup.rb
@@ -1,0 +1,16 @@
+Aws.config[:eks] = {
+  stub_responses: {
+    describe_nodegroup: {
+      nodegroup: {
+        version: '1.17',
+        release_version: '1.17.12-20210322',
+        cluster_name: 'my-cluster',
+        nodegroup_name: 'my-nodegroup',
+        nodegroup_arn: 'arn:aws:eks:us-west-2:012345678910:nodegroup/my-cluster/my-nodegroup/08bd000a',
+        created_at: Time.parse('2018-10-28 00:23:32 -0400'),
+        node_role: 'arn:aws:iam::012345678910:role/eks-nodegroup-role',
+        status: 'ACTIVE'
+      }
+    }
+  }
+}

--- a/lib/awspec/type/eks_nodegroup.rb
+++ b/lib/awspec/type/eks_nodegroup.rb
@@ -1,0 +1,30 @@
+module Awspec::Type
+  class EksNodegroup < ResourceBase
+    attr_accessor :cluster
+
+    def initialize(group_name)
+      super
+      @group_name = group_name
+    end
+
+    def resource_via_client
+      @resource_via_client ||= find_eks_nodegroup(cluster, @group_name)
+    end
+
+    def id
+      @id ||= resource_via_client.nodegroup_arn if resource_via_client
+    end
+
+    def cluster
+      @cluster || 'default'
+    end
+
+    STATES = %w(ACTIVE INACTIVE)
+
+    STATES.each do |state|
+      define_method state.downcase + '?' do
+        resource_via_client.status == state
+      end
+    end
+  end
+end

--- a/spec/type/eks_nodegroup_spec.rb
+++ b/spec/type/eks_nodegroup_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+Awspec::Stub.load 'eks_nodegroup'
+
+describe eks_nodegroup('my-eks-nodegroup'), cluster: 'my-cluster' do
+  it { should exist }
+  its(:version) { should eq '1.17' }
+  it { should be_active }
+end


### PR DESCRIPTION
Add AWS type `eks_nodegroup` using the same structure (with cluster as metadata)  as `ecs_container_instance`.