### PR TITLE
Fixed a bug when a bucket was placed in us-east-1

### DIFF
--- a/lib/awspec/helper/finder/s3.rb
+++ b/lib/awspec/helper/finder/s3.rb
@@ -37,7 +37,11 @@ module Awspec::Helper
 
       def find_bucket_location(id)
         bucket_location = s3_client.get_bucket_location(bucket: id)
-        bucket_location.location_constraint
+        if bucket_location.location_constraint.nil? || bucket_location.location_constraint.empty?
+          'us-east-1'
+        else
+          bucket_location.location_constraint
+        end
       rescue Aws::S3::Errors::ServiceError
         nil
       end

--- a/lib/awspec/stub/s3_bucket.rb
+++ b/lib/awspec/stub/s3_bucket.rb
@@ -120,7 +120,7 @@ Aws.config[:s3] = {
       ]
     },
     get_bucket_location: {
-      location_constraint: 'us-east-1'
+      location_constraint: 'ap-northeast-1'
     },
     get_bucket_encryption: {
       server_side_encryption_configuration: {

--- a/spec/generator/spec/s3_bucket_spec.rb
+++ b/spec/generator/spec/s3_bucket_spec.rb
@@ -35,7 +35,7 @@ describe s3_bucket('my-bucket') do
       status: 'Enabled'
     )
   end
-  it { should have_location('us-east-1') }
+  it { should have_location('ap-northeast-1') }
 end
 EOF
     expect(s3_bucket.generate_all.to_s).to eq spec

--- a/spec/type/s3_bucket_spec.rb
+++ b/spec/type/s3_bucket_spec.rb
@@ -10,7 +10,6 @@ describe s3_bucket('my-bucket') do
   it { should have_acl_grant(grantee: 'my-bucket-owner', permission: 'FULL_CONTROL') }
   it { should have_acl_grant(grantee: 'http://acs.amazonaws.com/groups/s3/LogDelivery', permission: 'WRITE') }
   it { should have_acl_grant(grantee: '68f4bb06b094152df53893bfba57760e', permission: 'READ') }
-  it { should have_location('us-east-1') }
 
   it do
     should have_cors_rule(
@@ -65,6 +64,22 @@ describe s3_bucket('my-bucket') do
                                                'Method call :delete is black-listed')
     end
     its('acl.owner.display_name') { should eq 'my-bucket-owner' }
+  end
+end
+
+describe s3_bucket('my-bucket') do
+  context 'with bucket location is not blank' do
+    it { should have_location('ap-northeast-1') }
+  end
+
+  context 'with bucket location is blank' do
+    before do
+      Aws.config[:s3][:stub_responses][:get_bucket_location][:location_constraint] = ''
+    end
+
+    it 'should location be us-east-1' do
+      should have_location('us-east-1')
+    end
   end
 end
 


### PR DESCRIPTION
If a bucket is placed in us-east-1, location_constraint will return blank.

For example, when I wrote the following code, an error occurred.


```ruby
require 'spec_helper'

describe s3_bucket('awspec-test') do
  it { should have_location('us-east-1') }
end
```

```
s3_bucket 'awspec-test'
  is expected to have location "us-east-1" (FAILED - 1)

Failures:

  1) s3_bucket 'awspec-test' is expected to have location "us-east-1"
     Failure/Error: it { should have_location('us-east-1') }
       expected `s3_bucket 'awspec-test'.has_location?("us-east-1")` to be truthy, got false
     # ./spec/s3_spec.rb:6:in `block (2 levels) in <top (required)>'
```

With this change, if location_constraint is blank, it will be recognized as `us-east-1`.

ref: https://github.com/k1LoW/awspec/pull/529#issuecomment-819875870