### PR TITLE
Feature/metric filter pattern support

### DIFF
--- a/doc/_resource_types/cloudwatch_logs.md
+++ b/doc/_resource_types/cloudwatch_logs.md
@@ -21,6 +21,15 @@ describe cloudwatch_logs('my-cloudwatch-logs-group') do
   it { should have_metric_filter('my-cloudwatch-logs-metric-filter') }
 end
 ```
+or
+```ruby
+describe cloudwatch_logs('my-cloudwatch-logs-group') do
+  it do
+    should have_metric_filter('my-cloudwatch-logs-metric-filter')
+      .filter_pattern('[date, error]')
+ end
+end
+```
 
 ### have_subscription_filter
 

--- a/lib/awspec/generator/spec/cloudwatch_logs.rb
+++ b/lib/awspec/generator/spec/cloudwatch_logs.rb
@@ -23,7 +23,11 @@ module Awspec::Generator
         metric_filters = select_all_cloudwatch_logs_metric_filter(log_group)
         metric_filter_lines = []
         metric_filters.each do |metric_filter|
-          line = "it { should have_metric_filter('#{metric_filter.filter_name}') }"
+          line = "it { should have_metric_filter('#{metric_filter.filter_name}')"
+          unless metric_filter.filter_pattern.empty?
+            line += ".filter_pattern('#{metric_filter.filter_pattern}')"
+          end
+          line += ' }'
           metric_filter_lines.push(line)
         end
         metric_filter_lines

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -56,6 +56,7 @@ require 'awspec/matcher/have_rule'
 
 # CloudWatch Logs
 require 'awspec/matcher/have_subscription_filter'
+require 'awspec/matcher/have_metric_filter'
 
 # DynamoDB
 require 'awspec/matcher/have_attribute_definition'

--- a/lib/awspec/matcher/have_metric_filter.rb
+++ b/lib/awspec/matcher/have_metric_filter.rb
@@ -1,0 +1,9 @@
+RSpec::Matchers.define :have_metric_filter do |filter_name|
+  match do |log_group_name|
+    log_group_name.has_metric_filter?(filter_name, @pattern)
+  end
+
+  chain :filter_pattern do |pattern|
+    @pattern = pattern
+  end
+end

--- a/lib/awspec/stub/cloudwatch_logs.rb
+++ b/lib/awspec/stub/cloudwatch_logs.rb
@@ -18,7 +18,8 @@ Aws.config[:cloudwatchlogs] = {
     describe_metric_filters: {
       metric_filters: [
         {
-          filter_name: 'my-cloudwatch-logs-metric-filter'
+          filter_name: 'my-cloudwatch-logs-metric-filter',
+          filter_pattern: '[date, error]'
         }
       ]
     },

--- a/lib/awspec/type/cloudwatch_logs.rb
+++ b/lib/awspec/type/cloudwatch_logs.rb
@@ -13,9 +13,17 @@ module Awspec::Type
       return true if ret == stream_name
     end
 
-    def has_metric_filter?(filter_name)
-      ret = find_cloudwatch_logs_metric_fileter_by_log_group_name(@id, filter_name).filter_name
-      return true if ret == filter_name
+    def has_metric_filter?(filter_name, pattern = nil)
+      # ret = find_cloudwatch_logs_metric_fileter_by_log_group_name(@id, filter_name).filter_name
+      ret = find_cloudwatch_logs_metric_fileter_by_log_group_name(@id, filter_name)
+      # binding.pry
+      # return true if ret == filter_name
+      if pattern.nil?
+        return true if ret.filter_name == filter_name
+      else
+        return false unless ret.filter_pattern == pattern
+      end
+      return true if ret.filter_name == filter_name
     end
 
     def has_subscription_filter?(filter_name, pattern = nil)

--- a/lib/awspec/type/cloudwatch_logs.rb
+++ b/lib/awspec/type/cloudwatch_logs.rb
@@ -14,10 +14,7 @@ module Awspec::Type
     end
 
     def has_metric_filter?(filter_name, pattern = nil)
-      # ret = find_cloudwatch_logs_metric_fileter_by_log_group_name(@id, filter_name).filter_name
       ret = find_cloudwatch_logs_metric_fileter_by_log_group_name(@id, filter_name)
-      # binding.pry
-      # return true if ret == filter_name
       if pattern.nil?
         return true if ret.filter_name == filter_name
       else

--- a/spec/type/cloudwatch_logs_spec.rb
+++ b/spec/type/cloudwatch_logs_spec.rb
@@ -6,6 +6,10 @@ describe cloudwatch_logs('my-cloudwatch-logs-group') do
   its(:retention_in_days) { should eq 365 }
   it { should have_log_stream('my-cloudwatch-logs-stream') }
   it { should have_metric_filter('my-cloudwatch-logs-metric-filter') }
+  it do
+    should have_metric_filter('my-cloudwatch-logs-metric-filter')\
+      .filter_pattern('[date, error]')
+  end
   it { should have_subscription_filter('my-cloudwatch-logs-subscription-filter') }
   it do
     should have_subscription_filter('my-cloudwatch-logs-subscription-filter')\


### PR DESCRIPTION
Support test case for filter_pattern of CloudWatch logs metric filter.

example:
```ruby
describe cloudwatch_logs('my-cloudwatch-logs-group') do
  it do
    should have_metric_filter('my-cloudwatch-logs-metric-filter')
      .filter_pattern('[date, error]')
 end
end
```
