### PR TITLE
Added missing SNS specs

### DIFF
--- a/lib/awspec/stub/sns_topic.rb
+++ b/lib/awspec/stub/sns_topic.rb
@@ -3,24 +3,24 @@ Aws.config[:sns] = {
     get_topic_attributes: {
       attributes: {
         # rubocop:disable LineLength
-        'Policy'                  => '{\"Version\":\"2008-10-17\",\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Sid\":\"__default_statement_ID\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"SNS:GetTopicAttributes\",\"SNS:SetTopicAttributes\",\"SNS:AddPermission\",\"SNS:RemovePermission\",\"SNS:DeleteTopic\",\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:Publish\",\"SNS:Receive\"],\"Resource\":\"arn:aws:sns:us-east-1:123456789:foobar-lambda-sample\",\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"123456789\"}}}]}',
-        'Owner'                   => '123456789',
+        'Policy'                  => "{\"Version\":\"2008-10-17\",\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Sid\":\"__default_statement_ID\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"SNS:GetTopicAttributes\",\"SNS:SetTopicAttributes\",\"SNS:AddPermission\",\"SNS:RemovePermission\",\"SNS:DeleteTopic\",\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:Publish\",\"SNS:Receive\"],\"Resource\":\"arn:aws:sns:#{REGION}:#{OWNER}:foobar-lambda-sample\",\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"#{OWNER}\"}}}]}",
+        'Owner'                   => OWNER,
         'SubscriptionsPending'    => '0',
-        'TopicArn'                => 'arn:aws:sns:us-east-1:123456789:foobar',
+        'TopicArn'                => TOPIC_ARN,
         'EffectiveDeliveryPolicy' => '{\"http\":{\"defaultHealthyRetryPolicy\":{\"minDelayTarget\":20,\"maxDelayTarget\":20,\"numRetries\":3,\"numMaxDelayRetries\":0,\"numNoDelayRetries\":0,\"numMinDelayRetries\":0,\"backoffFunction\":\"linear\"},\"disableSubscriptionOverrides\":false}}',
         'SubscriptionsConfirmed'  => '1',
-        'DisplayName'             => 'Useless',
+        'DisplayName'             => DISPLAY_NAME,
         'SubscriptionsDeleted'    => '0'
       }
     },
     list_subscriptions_by_topic: {
       subscriptions: [
         {
-          subscription_arn: 'arn:aws:sns:us-east-1:123456789:Foobar:3dbf4999-b3e2-4345-bd11-c34c9784ecca',
-          owner: '123456789',
+          subscription_arn: SUBSCRIBED,
+          owner: OWNER,
           protocol: 'lambda',
-          endpoint: 'arn:aws:lambda:us-east-1:123456789:function:foobar',
-          topic_arn: 'arn:aws:sns:us-east-1:123456789:foobar'
+          endpoint: ENDPOINT,
+          topic_arn: TOPIC_ARN
         }
       ],
       next_token: nil

--- a/lib/awspec/stub/sns_topic.rb
+++ b/lib/awspec/stub/sns_topic.rb
@@ -1,3 +1,10 @@
+OWNER = '123456789'
+REGION = 'us-east-1'
+TOPIC_ARN = "arn:aws:sns:#{REGION}:#{OWNER}:foobar"
+DISPLAY_NAME = 'Useless'
+SUBSCRIBED = "arn:aws:sns:#{REGION}:#{OWNER}:Foobar:3dbf4999-b3e2-4345-bd11-c34c9784ecca"
+ENDPOINT = "arn:aws:lambda:#{REGION}:#{OWNER}:function:foobar"
+
 Aws.config[:sns] = {
   stub_responses: {
     get_topic_attributes: {

--- a/lib/awspec/stub/sns_topic_error.rb
+++ b/lib/awspec/stub/sns_topic_error.rb
@@ -1,0 +1,8 @@
+Aws.config[:sns] = {
+  stub_responses: {
+    get_topic_attributes: Aws::SNS::Errors::NotFound.new(
+      TOPIC_ARN, 'no such topic'),
+    list_subscriptions_by_topic: Aws::SNS::Errors::NotFound.new(
+      TOPIC_SUBS_ARN, 'no such topic')
+  }
+}

--- a/lib/awspec/stub/sns_topic_error.rb
+++ b/lib/awspec/stub/sns_topic_error.rb
@@ -1,3 +1,8 @@
+OWNER = '123456789'
+REGION = 'us-east-1'
+TOPIC_ARN = "arn:aws:sns:#{REGION}:#{OWNER}:invalid"
+TOPIC_SUBS_ARN = "arn:aws:sns:us-east-1:#{OWNER}:Foobar:3dbf4999-b3e2-4345-bd11-c34c9784ecca"
+
 Aws.config[:sns] = {
   stub_responses: {
     get_topic_attributes: Aws::SNS::Errors::NotFound.new(

--- a/spec/type/sns_missing_topic_spec.rb
+++ b/spec/type/sns_missing_topic_spec.rb
@@ -16,8 +16,8 @@ describe sns_topic(TOPIC_ARN) do
   its(:subscriptions) { will raise_error(Awspec::NoExistingResource) }
   its(:id) { will_not raise_error }
   its(:id) { should be_nil }
-  it 'has_subscription raises Awspec::NoExistingResource' do
-    expect { subject.has_subscription?(TOPIC_SUBS_ARN) }.to raise_error(Awspec::NoExistingResource)
+  it 'include_subscribed matcher raises Awspec::NoExistingResource' do
+    expect { should include_subscribed(TOPIC_SUBS_ARN) }.to raise_error(Awspec::NoExistingResource)
   end
 
   let(:expected_attribs) do
@@ -27,7 +27,7 @@ describe sns_topic(TOPIC_ARN) do
       endpoint: 'arn:aws:lambda:us-east-1:123456789:function:foobar' }
   end
 
-  it 'have_subscription_attributes raises Awspec::NoExistingResource' do
+  it 'have_subscription_attributes matcher raises Awspec::NoExistingResource' do
     expect { should have_subscription_attributes(expected_attribs) }.to raise_error(Awspec::NoExistingResource)
   end
 end

--- a/spec/type/sns_missing_topic_spec.rb
+++ b/spec/type/sns_missing_topic_spec.rb
@@ -1,10 +1,4 @@
 require 'spec_helper'
-
-OWNER = '123456789'
-REGION = 'us-east-1'
-TOPIC_ARN = "arn:aws:sns:#{REGION}:#{OWNER}:invalid"
-TOPIC_SUBS_ARN = "arn:aws:sns:us-east-1:#{OWNER}:Foobar:3dbf4999-b3e2-4345-bd11-c34c9784ecca"
-
 Awspec::Stub.load 'sns_topic_error'
 
 describe sns_topic(TOPIC_ARN) do

--- a/spec/type/sns_missing_topic_spec.rb
+++ b/spec/type/sns_missing_topic_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 
-TOPIC_ARN = 'arn:aws:sns:us-east-1:123456789:invalid'
-TOPIC_SUBS_ARN = 'arn:aws:sns:us-east-1:123456789:Foobar:3dbf4999-b3e2-4345-bd11-c34c9784ecca'
+OWNER = '123456789'
+REGION = 'us-east-1'
+TOPIC_ARN = "arn:aws:sns:#{REGION}:#{OWNER}:invalid"
+TOPIC_SUBS_ARN = "arn:aws:sns:us-east-1:#{OWNER}:Foobar:3dbf4999-b3e2-4345-bd11-c34c9784ecca"
 
 Awspec::Stub.load 'sns_topic_error'
 
@@ -16,15 +18,16 @@ describe sns_topic(TOPIC_ARN) do
   its(:subscriptions) { will raise_error(Awspec::NoExistingResource) }
   its(:id) { will_not raise_error }
   its(:id) { should be_nil }
+
   it 'include_subscribed matcher raises Awspec::NoExistingResource' do
     expect { should include_subscribed(TOPIC_SUBS_ARN) }.to raise_error(Awspec::NoExistingResource)
   end
 
   let(:expected_attribs) do
     { protocol: 'lambda',
-      owner: '123456789',
+      owner: OWNER,
       subscription_arn: TOPIC_SUBS_ARN, # this is required
-      endpoint: 'arn:aws:lambda:us-east-1:123456789:function:foobar' }
+      endpoint: "arn:aws:lambda:#{REGION}:#{OWNER}:function:foobar" }
   end
 
   it 'have_subscription_attributes matcher raises Awspec::NoExistingResource' do

--- a/spec/type/sns_missing_topic_spec.rb
+++ b/spec/type/sns_missing_topic_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+TOPIC_ARN = 'arn:aws:sns:us-east-1:123456789:invalid'
+TOPIC_SUBS_ARN = 'arn:aws:sns:us-east-1:123456789:Foobar:3dbf4999-b3e2-4345-bd11-c34c9784ecca'
+
+Awspec::Stub.load 'sns_topic_error'
+
+describe sns_topic(TOPIC_ARN) do
+  it { should_not exist }
+  its(:name) { will raise_error(Awspec::NoExistingResource) }
+  its(:confirmed_subscriptions) { will raise_error(Awspec::NoExistingResource) }
+  its(:pending_subscriptions) { will raise_error(Awspec::NoExistingResource) }
+  its(:topic_arn) { will raise_error(Awspec::NoExistingResource) }
+  its(:display_name) { will raise_error(Awspec::NoExistingResource) }
+  its(:deleted_subscriptions) { will raise_error(Awspec::NoExistingResource) }
+  its(:subscriptions) { will raise_error(Awspec::NoExistingResource) }
+  its(:id) { will_not raise_error }
+  its(:id) { should be_nil }
+  it 'has_subscription raises Awspec::NoExistingResource' do
+    expect { subject.has_subscription?(TOPIC_SUBS_ARN) }.to raise_error(Awspec::NoExistingResource)
+  end
+
+  let(:expected_attribs) do
+    { protocol: 'lambda',
+      owner: '123456789',
+      subscription_arn: TOPIC_SUBS_ARN, # this is required
+      endpoint: 'arn:aws:lambda:us-east-1:123456789:function:foobar' }
+  end
+
+  it 'have_subscription_attributes raises Awspec::NoExistingResource' do
+    expect { should have_subscription_attributes(expected_attribs) }.to raise_error(Awspec::NoExistingResource)
+  end
+end

--- a/spec/type/sns_topic_spec.rb
+++ b/spec/type/sns_topic_spec.rb
@@ -33,21 +33,3 @@ describe sns_topic(topic_arn) do
     end
   end
 end
-
-invalid_topic_arn = 'arn:aws:sns:us-east-1:123456789:invalid'
-
-describe sns_topic(invalid_topic_arn) do
-  context 'Issue https://github.com/k1LoW/awspec/issues/445 is still open' do
-    it 'it does not exists'
-    it ':name raises Awspec::NoExistingResource'
-    it ':confirmed_subscriptions raises Awspec::NoExistingResource'
-    it ':pending_subscriptions raises Awspec::NoExistingResource'
-    it ':topic_arn raises Awspec::NoExistingResource'
-    it ':display_name raises Awspec::NoExistingResource'
-    it ':deleted_subscriptions raises Awspec::NoExistingResource'
-    it ':subscriptions raises Awspec::NoExistingResource'
-    it ':id raises Awspec::NoExistingResource'
-    it 'matcher include_subscribed raises Awspec::NoExistingResource'
-    it 'matcher have_subscription_attributes raises Awspec::NoExistingResource'
-  end
-end

--- a/spec/type/sns_topic_spec.rb
+++ b/spec/type/sns_topic_spec.rb
@@ -27,13 +27,6 @@ describe sns_topic(TOPIC_ARN) do
       endpoint: ENDPOINT }
   end
 
-  describe '#include_subscribed' do
-    it { should include_subscribed(SUBSCRIBED) }
-  end
-
-  describe '#subscribed' do
-    it do
-      should have_subscription_attributes(expected_attribs)
-    end
-  end
+  it { should include_subscribed(SUBSCRIBED) }
+  it { should have_subscription_attributes(expected_attribs) }
 end

--- a/spec/type/sns_topic_spec.rb
+++ b/spec/type/sns_topic_spec.rb
@@ -1,30 +1,31 @@
 require 'spec_helper'
 Awspec::Stub.load 'sns_topic'
 
-# based on values from lib/awspec/sub/sns_topic.rb
-topic_arn = 'arn:aws:sns:us-east-1:123456789:foobar'
-subscribed = 'arn:aws:sns:us-east-1:123456789:Foobar:3dbf4999-b3e2-4345-bd11-c34c9784ecca'
+OWNER = '123456789'
+REGION = 'us-east-1'
+TOPIC_ARN = "arn:aws:sns:#{REGION}:#{OWNER}:foobar"
+SUBSCRIBED = "arn:aws:sns:#{REGION}:#{OWNER}:Foobar:3dbf4999-b3e2-4345-bd11-c34c9784ecca"
 
-describe sns_topic(topic_arn) do
+describe sns_topic(TOPIC_ARN) do
   it { should exist }
   its(:name) { should eq 'foobar' }
   its(:confirmed_subscriptions) { should eq 1 }
   its(:pending_subscriptions) { should eq 0 }
-  its(:topic_arn) { should eq topic_arn }
+  its(:topic_arn) { should eq TOPIC_ARN }
   its(:display_name) { should eq 'Useless' }
   its(:deleted_subscriptions) { should eq 0 }
-  its(:subscriptions) { should eql([:"arn:aws:sns:us-east-1:123456789:Foobar:3dbf4999-b3e2-4345-bd11-c34c9784ecca"]) }
-  its(:id) { should eq 'arn:aws:sns:us-east-1:123456789:foobar' }
+  its(:subscriptions) { should eql([SUBSCRIBED.to_sym]) }
+  its(:id) { should eq TOPIC_ARN }
 
   let(:expected_attribs) do
     { protocol: 'lambda',
-      owner: '123456789',
-      subscription_arn: subscribed, # this is required
-      endpoint: 'arn:aws:lambda:us-east-1:123456789:function:foobar' }
+      owner: OWNER,
+      subscription_arn: SUBSCRIBED, # this is required
+      endpoint: "arn:aws:lambda:#{REGION}:#{OWNER}:function:foobar" }
   end
 
   describe '#include_subscribed' do
-    it { should include_subscribed(subscribed) }
+    it { should include_subscribed(SUBSCRIBED) }
   end
 
   describe '#subscribed' do

--- a/spec/type/sns_topic_spec.rb
+++ b/spec/type/sns_topic_spec.rb
@@ -1,10 +1,13 @@
 require 'spec_helper'
-Awspec::Stub.load 'sns_topic'
 
 OWNER = '123456789'
 REGION = 'us-east-1'
 TOPIC_ARN = "arn:aws:sns:#{REGION}:#{OWNER}:foobar"
 SUBSCRIBED = "arn:aws:sns:#{REGION}:#{OWNER}:Foobar:3dbf4999-b3e2-4345-bd11-c34c9784ecca"
+ENDPOINT = "arn:aws:lambda:#{REGION}:#{OWNER}:function:foobar"
+DISPLAY_NAME = 'Useless'
+
+Awspec::Stub.load 'sns_topic'
 
 describe sns_topic(TOPIC_ARN) do
   it { should exist }
@@ -12,7 +15,7 @@ describe sns_topic(TOPIC_ARN) do
   its(:confirmed_subscriptions) { should eq 1 }
   its(:pending_subscriptions) { should eq 0 }
   its(:topic_arn) { should eq TOPIC_ARN }
-  its(:display_name) { should eq 'Useless' }
+  its(:display_name) { should eq DISPLAY_NAME }
   its(:deleted_subscriptions) { should eq 0 }
   its(:subscriptions) { should eql([SUBSCRIBED.to_sym]) }
   its(:id) { should eq TOPIC_ARN }
@@ -21,7 +24,7 @@ describe sns_topic(TOPIC_ARN) do
     { protocol: 'lambda',
       owner: OWNER,
       subscription_arn: SUBSCRIBED, # this is required
-      endpoint: "arn:aws:lambda:#{REGION}:#{OWNER}:function:foobar" }
+      endpoint: ENDPOINT }
   end
 
   describe '#include_subscribed' do

--- a/spec/type/sns_topic_spec.rb
+++ b/spec/type/sns_topic_spec.rb
@@ -1,12 +1,4 @@
 require 'spec_helper'
-
-OWNER = '123456789'
-REGION = 'us-east-1'
-TOPIC_ARN = "arn:aws:sns:#{REGION}:#{OWNER}:foobar"
-SUBSCRIBED = "arn:aws:sns:#{REGION}:#{OWNER}:Foobar:3dbf4999-b3e2-4345-bd11-c34c9784ecca"
-ENDPOINT = "arn:aws:lambda:#{REGION}:#{OWNER}:function:foobar"
-DISPLAY_NAME = 'Useless'
-
 Awspec::Stub.load 'sns_topic'
 
 describe sns_topic(TOPIC_ARN) do


### PR DESCRIPTION
This PR includes the missing SNS specs to validate missing/invalid SNS topics.
It includes the generation of stubs with exceptions for missing SNS topics.
There is also a refactor for the original specs to avoid hard coded constants.