### PR TITLE
Make eip searchable by name

### DIFF
--- a/doc/_resource_types/eip.md
+++ b/doc/_resource_types/eip.md
@@ -1,7 +1,7 @@
 ### exist
 
 ```ruby
-describe eip('123.0.456.789') do
+describe eip('my-eip') do
   it { should exist }
 end
 ```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -1324,7 +1324,7 @@ Elastic IP resource type.
 ### exist
 
 ```ruby
-describe eip('123.0.456.789') do
+describe eip('my-eip') do
   it { should exist }
 end
 ```

--- a/lib/awspec/helper/finder.rb
+++ b/lib/awspec/helper/finder.rb
@@ -10,6 +10,7 @@ require 'awspec/helper/finder/ec2'
 require 'awspec/helper/finder/ecr'
 require 'awspec/helper/finder/ecs'
 require 'awspec/helper/finder/efs'
+require 'awspec/helper/finder/eip'
 require 'awspec/helper/finder/security_group'
 require 'awspec/helper/finder/rds'
 require 'awspec/helper/finder/route53'
@@ -70,6 +71,7 @@ module Awspec::Helper
     include Awspec::Helper::Finder::Ecr
     include Awspec::Helper::Finder::Ecs
     include Awspec::Helper::Finder::Efs
+    include Awspec::Helper::Finder::Eip
     include Awspec::Helper::Finder::Firehose
     include Awspec::Helper::Finder::SecurityGroup
     include Awspec::Helper::Finder::Rds

--- a/lib/awspec/helper/finder/ec2.rb
+++ b/lib/awspec/helper/finder/ec2.rb
@@ -163,20 +163,6 @@ module Awspec::Helper
         instances
       end
 
-      def select_eip_by_instance_id(id)
-        res = ec2_client.describe_addresses({
-                                              filters: [{ name: 'instance-id', values: [id] }]
-                                            })
-        res.addresses
-      end
-
-      def select_eip_by_public_ip(id)
-        res = ec2_client.describe_addresses({
-                                              filters: [{ name: 'public-ip', values: [id] }]
-                                            })
-        res.addresses
-      end
-
       def select_network_interface_by_instance_id(id)
         res = ec2_client.describe_network_interfaces({
                                                        filters: [{ name: 'attachment.instance-id', values: [id] }]

--- a/lib/awspec/helper/finder/eip.rb
+++ b/lib/awspec/helper/finder/eip.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Awspec::Helper
+  module Finder
+    module Eip
+      def select_eip_by_instance_id(id)
+        res = ec2_client.describe_addresses({
+                                              filters: [{ name: 'instance-id', values: [id] }]
+                                            })
+        res.addresses
+      end
+
+      def select_eip(id)
+        res = ec2_client.describe_addresses({
+                                              filters: [{ name: 'public-ip', values: [id] }]
+                                            })
+        return res.addresses unless res.addresses.empty?
+
+        res = ec2_client.describe_addresses({
+                                              filters: [{ name: 'tag:Name', values: [id] }]
+                                            })
+        res.addresses
+      end
+    end
+  end
+end

--- a/lib/awspec/stub/eip.rb
+++ b/lib/awspec/stub/eip.rb
@@ -7,7 +7,13 @@ Aws.config[:ec2] = {
         {
           domain: 'vpc',
           public_ip: '123.0.456.789',
-          instance_id: 'i-ec12345a'
+          instance_id: 'i-ec12345a',
+          tags: [
+            {
+              key: 'Name',
+              value: 'my-eip'
+            }
+          ]
         }
       ]
     }

--- a/lib/awspec/type/eip.rb
+++ b/lib/awspec/type/eip.rb
@@ -3,7 +3,7 @@
 module Awspec::Type
   class Eip < ResourceBase
     def resource_via_client
-      @resource_via_client ||= select_eip_by_public_ip(@display_name)
+      @resource_via_client ||= select_eip(@display_name)
     end
 
     def id

--- a/spec/type/eip_spec.rb
+++ b/spec/type/eip_spec.rb
@@ -8,3 +8,9 @@ describe eip('123.0.456.789') do
   it { should be_associated_to('i-ec12345a') }
   it { should belong_to_domain('vpc') }
 end
+
+describe eip('my-eip') do
+  it { should exist }
+  it { should be_associated_to('i-ec12345a') }
+  it { should belong_to_domain('vpc') }
+end


### PR DESCRIPTION
Extract eip methods from `finder/ec2.rb` to a separete file `finder/eip.rb`.
Because rubocop alerts `Module has too many lines.`