### PR TITLE
Add support for a custom aws endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,23 @@ Awspec.configure do |config|
 end
 ```
 
+### Advanced Tips: Setting A Custom Endpoint And Testing Locally
+
+Set the `aws_custom_endpoint` environment variable to tell awspec to use a different endpoint to connect to aws:
+
+```
+aws_custom_endpoint=http://localhost:5000 bundle exec rake spec
+```
+
+This can be used with [Moto's Standalone Server Mode](http://docs.getmoto.org/en/latest/docs/server_mode.html) to run all your aws tests locally. For example, to create resources on the local server using the aws cli, run:
+
+```
+AWS_SECRET_ACCESS_KEY=dummy AWS_ACCESS_KEY_ID=dummy \
+    aws --endpoint http://localhost:5000 s3 mb my-bucket
+```
+
+Awspec should then be able to verify that those resources were created properly.
+
 ## Support AWS Resources
 
 [Resource Types information here](doc/resource_types.md)

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ For example, first create a resource on a local aws service using the aws cli:
 
 ```
 AWS_SECRET_ACCESS_KEY=dummy AWS_ACCESS_KEY_ID=dummy \
-    aws --endpoint http://localhost:5000 s3 mb my-bucket
+    aws --endpoint-url http://localhost:5000 s3 mb s3://my-bucket
 ```
 
 Then you can tell awspec to run the test suite using the same custom endpoint:

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Awspec.configure do |config|
 end
 ```
 
-### Advanced Tips: Setting A Custom Endpoint And Testing Locally
+### Advanced Tips: Setting A Custom Endpoint
 
 Set the `endpoint` environment variable to tell awspec to use a different
 endpoint to connect to aws. Common use cases are connecting to aws through a

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ end
 
 Set the `endpoint` environment variable to tell awspec to use a different
 endpoint to connect to aws. Common use cases are connecting to aws through a
-proxy or connecting to a local mock aws environment.
+proxy, using a different service with an aws compatible interface, or
+connecting to a local mock aws environment.
 
 For example, first create a resource on a local aws service using the aws cli:
 

--- a/README.md
+++ b/README.md
@@ -174,20 +174,22 @@ end
 
 ### Advanced Tips: Setting A Custom Endpoint And Testing Locally
 
-Set the `aws_custom_endpoint` environment variable to tell awspec to use a different endpoint to connect to aws:
+Set the `endpoint` environment variable to tell awspec to use a different
+endpoint to connect to aws. Common use cases are connecting to aws through a
+proxy or connecting to a local mock aws environment.
 
-```
-aws_custom_endpoint=http://localhost:5000 bundle exec rake spec
-```
-
-This can be used with [Moto's Standalone Server Mode](http://docs.getmoto.org/en/latest/docs/server_mode.html) to run all your aws tests locally. For example, to create resources on the local server using the aws cli, run:
+For example, first create a resource on a local aws service using the aws cli:
 
 ```
 AWS_SECRET_ACCESS_KEY=dummy AWS_ACCESS_KEY_ID=dummy \
     aws --endpoint http://localhost:5000 s3 mb my-bucket
 ```
 
-Awspec should then be able to verify that those resources were created properly.
+Then you can tell awspec to run the test suite using the same custom endpoint:
+
+```
+endpoint=http://localhost:5000 bundle exec rake spec
+```
 
 ## Support AWS Resources
 

--- a/lib/awspec/helper/finder.rb
+++ b/lib/awspec/helper/finder.rb
@@ -177,7 +177,7 @@ module Awspec::Helper
     # because setting the `endpoint` argument to `nil` results in an error from
     # the aws sdk.
     if ENV.key?('endpoint')
-      CLIENT_OPTIONS[:endpoint] = ENV['aws_custom_endpoint']
+      CLIENT_OPTIONS[:endpoint] = ENV['endpoint']
     end
 
     check_configuration = ENV['DISABLE_AWS_CLIENT_CHECK'] != 'true' if ENV.key?('DISABLE_AWS_CLIENT_CHECK')

--- a/lib/awspec/helper/finder.rb
+++ b/lib/awspec/helper/finder.rb
@@ -176,7 +176,7 @@ module Awspec::Helper
     # We have to set this conditionally after defining `CLIENT_OPTIONS`,
     # because setting the `endpoint` argument to `nil` results in an error from
     # the aws sdk.
-    if ENV.has_key?('aws_custom_endpoint')
+    if ENV.key?('aws_custom_endpoint')
       CLIENT_OPTIONS[:endpoint] = ENV['aws_custom_endpoint']
     end
 

--- a/lib/awspec/helper/finder.rb
+++ b/lib/awspec/helper/finder.rb
@@ -170,7 +170,8 @@ module Awspec::Helper
 
     CLIENT_OPTIONS = {
       http_proxy: ENV['http_proxy'] || ENV['https_proxy'] || nil,
-      http_wire_trace: ENV['http_wire_trace'] || false
+      http_wire_trace: ENV['http_wire_trace'] || false,
+      endpoint: ENV['aws_custom_endpoint'] || nil
     }
 
     check_configuration = ENV['DISABLE_AWS_CLIENT_CHECK'] != 'true' if ENV.key?('DISABLE_AWS_CLIENT_CHECK')

--- a/lib/awspec/helper/finder.rb
+++ b/lib/awspec/helper/finder.rb
@@ -176,7 +176,7 @@ module Awspec::Helper
     # We have to set this conditionally after defining `CLIENT_OPTIONS`,
     # because setting the `endpoint` argument to `nil` results in an error from
     # the aws sdk.
-    if ENV.key?('aws_custom_endpoint')
+    if ENV.key?('endpoint')
       CLIENT_OPTIONS[:endpoint] = ENV['aws_custom_endpoint']
     end
 

--- a/lib/awspec/helper/finder.rb
+++ b/lib/awspec/helper/finder.rb
@@ -170,9 +170,15 @@ module Awspec::Helper
 
     CLIENT_OPTIONS = {
       http_proxy: ENV['http_proxy'] || ENV['https_proxy'] || nil,
-      http_wire_trace: ENV['http_wire_trace'] || false,
-      endpoint: ENV['aws_custom_endpoint'] || nil
+      http_wire_trace: ENV['http_wire_trace'] || false
     }
+
+    # We have to set this conditionally after defining `CLIENT_OPTIONS`,
+    # because setting the `endpoint` argument to `nil` results in an error from
+    # the aws sdk.
+    if ENV.has_key?('aws_custom_endpoint')
+      CLIENT_OPTIONS[:endpoint] = ENV['aws_custom_endpoint']
+    end
 
     check_configuration = ENV['DISABLE_AWS_CLIENT_CHECK'] != 'true' if ENV.key?('DISABLE_AWS_CLIENT_CHECK')
 


### PR DESCRIPTION
There may be other use cases, but my main use case is to run this against the standalone moto server:
http://docs.getmoto.org/en/latest/docs/server_mode.html

This would allow awspec to be used as part of a full test loop for aws automation without the need to configure an aws account.