### PR TITLE
Make `transit_gateway` `have_attachment` work with names

### DIFF
--- a/doc/_resource_types/transit_gateway.md
+++ b/doc/_resource_types/transit_gateway.md
@@ -22,3 +22,25 @@ describe transit_gateway('my-tgw') do
   its(:transit_gateway_id) { should eq 'tgw-1234567890abcdefg' }
 end
 ```
+### have_attachment
+
+#### using attachment id
+```ruby
+describe transit_gateway('tgw-1234567890abcdefg') do
+  it { should have_attachment('tgw-attach-1234567890abcdefg') }
+end
+```
+
+#### using attachment name
+```ruby
+describe transit_gateway('tgw-1234567890abcdefg') do
+  it { should have_attachment('my-prod-tgw-attachment') }
+end
+```
+
+#### using regular expression attachment name
+```ruby
+describe transit_gateway('tgw-1234567890abcdefg') do
+  it { should have_attachment(/^my-\w+-tgw-attachment$/) }
+end
+```

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -3884,6 +3884,27 @@ end
 
 ### have_attachment
 
+#### using attachment id
+```ruby
+describe transit_gateway('tgw-1234567890abcdefg') do
+  it { should have_attachment('tgw-attach-1234567890abcdefg') }
+end
+```
+
+#### using attachment name
+```ruby
+describe transit_gateway('tgw-1234567890abcdefg') do
+  it { should have_attachment('my-prod-tgw-attachment') }
+end
+```
+
+#### using regular expression attachment name
+```ruby
+describe transit_gateway('tgw-1234567890abcdefg') do
+  it { should have_attachment(/^my-\w+-tgw-attachment$/) }
+end
+```
+
 ### have_tag
 
 ### its(:transit_gateway_id), its(:transit_gateway_arn), its(:state), its(:owner_id), its(:description), its(:creation_time)

--- a/lib/awspec/type/transit_gateway.rb
+++ b/lib/awspec/type/transit_gateway.rb
@@ -18,9 +18,21 @@ module Awspec::Type
     end
 
     def has_attachment?(att_id)
-      atts = find_tgw_attachments_by_tgw_id(@id)
-      ret = atts.find_all { |att| att.transit_gateway_attachment_id == att_id }
-      ret.any?
+      atts = find_tgw_attachments_by_tgw_id(id)
+
+      atts.any? do |att|
+        att.transit_gateway_attachment_id == att_id || attachment_has_name?(att, att_id)
+      end
+    end
+
+    private
+
+    def attachment_has_name?(attachment, name)
+      if name.is_a?(Regexp)
+        attachment.tags.any? { |tag| tag.key == 'Name' && (name =~ tag.value) }
+      else
+        attachment.tags.any? { |tag| tag.key == 'Name' && tag.value == name }
+      end
     end
   end
 end

--- a/spec/type/transit_gateway_spec.rb
+++ b/spec/type/transit_gateway_spec.rb
@@ -21,3 +21,23 @@ describe transit_gateway('my-transit-gateway') do
   it { should exist }
   its(:transit_gateway_id) { should eq 'tgw-1234567890abcdefg' }
 end
+
+describe transit_gateway('my-transit-gateway') do
+  it { should exist }
+  it 'supports `have_attachment` by attachment name' do
+    should have_attachment('my-transit-gateway-attachment')
+  end
+end
+
+describe transit_gateway('my-transit-gateway') do
+  it { should exist }
+  it 'supports `have_attachment` by attachment regular expression' do
+    should have_attachment(/my-transit-gateway-attachment/)
+  end
+end
+
+describe transit_gateway('my-transit-gateway') do
+  it 'supports have_attachment when `should exist` hasn\'t been called first' do
+    should have_attachment('tgw-attach-1234567890abcdefg')
+  end
+end


### PR DESCRIPTION
With this change, it is now possible to check transit gateways have attachments based on the attachment name instead of just id. The name can either be a string or a regex.

`have_attachment` now also works if `should exist` hasn't been called first (where `@id` wasn't initialised).