### PR TITLE
Fix DB resources error

### DIFF
--- a/awspec.gemspec
+++ b/awspec.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'addressable'
   spec.add_runtime_dependency 'awsecrets', '~> 1'
   spec.add_runtime_dependency 'aws-sdk', '~> 3'
-  spec.add_runtime_dependency 'dry-inflector'
+  spec.add_runtime_dependency 'dry-inflector', '>= 1.1'
   spec.add_runtime_dependency 'ipaddress'
   spec.add_runtime_dependency 'rspec', '~> 3.0'
   spec.add_runtime_dependency 'rspec-its'

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -1404,7 +1404,7 @@ describe eks('my-eks') do
 end
 ```
 
-### its(:name), its(:arn), its(:created_at), its(:version), its(:endpoint), its(:role_arn), its(:kubernetes_network_config), its(:logging), its(:identity), its(:status), its(:client_request_token), its(:platform_version), its(:tags), its(:encryption_config), its(:connector_config), its(:id), its(:health), its(:outpost_config), its(:access_config)
+### its(:name), its(:arn), its(:created_at), its(:version), its(:endpoint), its(:role_arn), its(:kubernetes_network_config), its(:logging), its(:identity), its(:status), its(:client_request_token), its(:platform_version), its(:tags), its(:encryption_config), its(:connector_config), its(:id), its(:health), its(:outpost_config), its(:access_config), its(:upgrade_policy)
 ## <a name="eks_nodegroup">eks_nodegroup</a>
 
 EksNodegroup resource type.
@@ -2983,7 +2983,7 @@ end
 
 ## <a name="rds_db_cluster">rds_db_cluster</a>
 
-RdsDbCluster resource type.
+RdsDBCluster resource type.
 
 ```ruby
 describe rds_db_cluster('my-rds-db-cluster') do
@@ -3038,7 +3038,7 @@ end
 ### its(:allocated_storage), its(:availability_zones), its(:backup_retention_period), its(:character_set_name), its(:database_name), its(:db_cluster_identifier), its(:db_cluster_parameter_group), its(:db_subnet_group), its(:status), its(:automatic_restart_time), its(:percent_progress), its(:earliest_restorable_time), its(:endpoint), its(:reader_endpoint), its(:custom_endpoints), its(:multi_az), its(:engine), its(:engine_version), its(:latest_restorable_time), its(:port), its(:master_username), its(:db_cluster_option_group_memberships), its(:preferred_backup_window), its(:preferred_maintenance_window), its(:replication_source_identifier), its(:read_replica_identifiers), its(:status_infos), its(:hosted_zone_id), its(:storage_encrypted), its(:kms_key_id), its(:db_cluster_resource_id), its(:db_cluster_arn), its(:associated_roles), its(:iam_database_authentication_enabled), its(:clone_group_id), its(:cluster_create_time), its(:earliest_backtrack_time), its(:backtrack_window), its(:backtrack_consumed_change_records), its(:enabled_cloudwatch_logs_exports), its(:capacity), its(:engine_mode), its(:scaling_configuration_info), its(:rds_custom_cluster_configuration), its(:deletion_protection), its(:http_endpoint_enabled), its(:activity_stream_mode), its(:activity_stream_status), its(:activity_stream_kms_key_id), its(:activity_stream_kinesis_stream_name), its(:copy_tags_to_snapshot), its(:cross_account_clone), its(:domain_memberships), its(:tag_list), its(:global_write_forwarding_status), its(:global_write_forwarding_requested), its(:pending_modified_values), its(:db_cluster_instance_class), its(:storage_type), its(:iops), its(:publicly_accessible), its(:auto_minor_version_upgrade), its(:monitoring_interval), its(:monitoring_role_arn), its(:performance_insights_enabled), its(:performance_insights_kms_key_id), its(:performance_insights_retention_period), its(:serverless_v2_scaling_configuration), its(:network_type), its(:db_system_id), its(:master_user_secret), its(:io_optimized_next_allowed_modification_time), its(:local_write_forwarding_status), its(:aws_backup_recovery_point_arn), its(:limitless_database), its(:storage_throughput), its(:certificate_details), its(:engine_lifecycle_support)
 ## <a name="rds_db_cluster_parameter_group">rds_db_cluster_parameter_group</a>
 
-RdsDbClusterParameterGroup resource type.
+RdsDBClusterParameterGroup resource type.
 
 ```ruby
 describe rds_db_cluster_parameter_group('my-rds-db-cluster-parameter-group') do
@@ -3059,7 +3059,7 @@ end
 
 ## <a name="rds_db_parameter_group">rds_db_parameter_group</a>
 
-RdsDbParameterGroup resource type.
+RdsDBParameterGroup resource type.
 
 ```ruby
 describe rds_db_parameter_group('my-rds-db-parameter-group') do
@@ -3079,7 +3079,7 @@ end
 
 ## <a name="rds_db_subnet_group">rds_db_subnet_group</a>
 
-RdsDbSubnetGroup resource type.
+RdsDBSubnetGroup resource type.
 
 ### exist
 

--- a/lib/awspec/generator/doc/type/rds_db_cluster.rb
+++ b/lib/awspec/generator/doc/type/rds_db_cluster.rb
@@ -3,16 +3,16 @@
 module Awspec::Generator
   module Doc
     module Type
-      class RdsDbCluster < Base
+      class RdsDBCluster < Base
         def initialize
           super
-          @type_name = 'RdsDbCluster'
-          @type = Awspec::Type::RdsDbCluster.new('my-rds-db-cluster')
+          @type_name = 'RdsDBCluster'
+          @type = Awspec::Type::RdsDBCluster.new('my-rds-db-cluster')
           @ret = @type.resource_via_client
           @matchers = [
-            Awspec::Type::RdsDbCluster::STATES.map { |state| "be_#{state.tr('-', '_')}" }.join(', ')
+            Awspec::Type::RdsDBCluster::STATES.map { |state| "be_#{state.tr('-', '_')}" }.join(', ')
           ]
-          @ignore_matchers = Awspec::Type::RdsDbCluster::STATES.map { |state| "be_#{state.tr('-', '_')}" }
+          @ignore_matchers = Awspec::Type::RdsDBCluster::STATES.map { |state| "be_#{state.tr('-', '_')}" }
           @describes = []
         end
       end

--- a/lib/awspec/generator/doc/type/rds_db_cluster_parameter_group.rb
+++ b/lib/awspec/generator/doc/type/rds_db_cluster_parameter_group.rb
@@ -3,10 +3,10 @@
 module Awspec::Generator
   module Doc
     module Type
-      class RdsDbClusterParameterGroup < Base
+      class RdsDBClusterParameterGroup < Base
         def initialize
           super
-          @type = Awspec::Type::RdsDbClusterParameterGroup.new('my-rds-db-cluster-parameter-group')
+          @type = Awspec::Type::RdsDBClusterParameterGroup.new('my-rds-db-cluster-parameter-group')
           @matchers = []
           @ignore_matchers = []
           @describes = []

--- a/lib/awspec/generator/doc/type/rds_db_parameter_group.rb
+++ b/lib/awspec/generator/doc/type/rds_db_parameter_group.rb
@@ -3,10 +3,10 @@
 module Awspec::Generator
   module Doc
     module Type
-      class RdsDbParameterGroup < Base
+      class RdsDBParameterGroup < Base
         def initialize
           super
-          @type = Awspec::Type::RdsDbParameterGroup.new('my-rds-db-parameter-group')
+          @type = Awspec::Type::RdsDBParameterGroup.new('my-rds-db-parameter-group')
           @matchers = []
           @ignore_matchers = []
           @describes = []

--- a/lib/awspec/generator/doc/type/rds_db_subnet_group.rb
+++ b/lib/awspec/generator/doc/type/rds_db_subnet_group.rb
@@ -3,11 +3,11 @@
 module Awspec::Generator
   module Doc
     module Type
-      class RdsDbSubnetGroup < Base
+      class RdsDBSubnetGroup < Base
         def initialize
           super
-          @type_name = 'RdsDbSubnetGroup'
-          @type = Awspec::Type::RdsDbSubnetGroup.new('my-rds-db-subnet-group')
+          @type_name = 'RdsDBSubnetGroup'
+          @type = Awspec::Type::RdsDBSubnetGroup.new('my-rds-db-subnet-group')
           @ret = @type.resource_via_client
           @matchers = %w[belong_to_vpc belong_to_subnet]
           @ignore_matchers = []

--- a/lib/awspec/generator/spec/rds_db_cluster.rb
+++ b/lib/awspec/generator/spec/rds_db_cluster.rb
@@ -2,7 +2,7 @@
 
 module Awspec::Generator
   module Spec
-    class RdsDbCluster
+    class RdsDBCluster
       include Awspec::Helper::Finder
       def generate(db_cluster_identifier)
         cluster = find_db_cluster(db_cluster_identifier)

--- a/lib/awspec/generator/spec/rds_db_cluster_parameter_group.rb
+++ b/lib/awspec/generator/spec/rds_db_cluster_parameter_group.rb
@@ -2,7 +2,7 @@
 
 module Awspec::Generator
   module Spec
-    class RdsDbClusterParameterGroup
+    class RdsDBClusterParameterGroup
       include Awspec::Helper::Finder
       def generate_by_parameter_group(parameter_group)
         @parameter_group = parameter_group

--- a/lib/awspec/generator/spec/rds_db_parameter_group.rb
+++ b/lib/awspec/generator/spec/rds_db_parameter_group.rb
@@ -2,7 +2,7 @@
 
 module Awspec::Generator
   module Spec
-    class RdsDbParameterGroup
+    class RdsDBParameterGroup
       include Awspec::Helper::Finder
       def generate_by_parameter_group(parameter_group)
         @parameter_group = parameter_group

--- a/lib/awspec/matcher/belong_to_subnet.rb
+++ b/lib/awspec/matcher/belong_to_subnet.rb
@@ -34,7 +34,7 @@ RSpec::Matchers.define :belong_to_subnet do |subnet_id|
     end
 
     # RDS DB Subnet Group
-    if type.instance_of?(Awspec::Type::RdsDbSubnetGroup)
+    if type.instance_of?(Awspec::Type::RdsDBSubnetGroup)
       subnets = type.resource_via_client[:subnets]
       ret = subnets.find do |s|
         s[:subnet_identifier] == subnet_id

--- a/lib/awspec/type/rds_db_cluster.rb
+++ b/lib/awspec/type/rds_db_cluster.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Awspec::Type
-  class RdsDbCluster < ResourceBase
+  class RdsDBCluster < ResourceBase
     aws_resource Aws::RDS::Types::DBCluster
 
     def resource_via_client

--- a/lib/awspec/type/rds_db_cluster_parameter_group.rb
+++ b/lib/awspec/type/rds_db_cluster_parameter_group.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Awspec::Type
-  class RdsDbClusterParameterGroup < ResourceBase
+  class RdsDBClusterParameterGroup < ResourceBase
     def resource_via_client
       return @resource_via_client if @resource_via_client
 

--- a/lib/awspec/type/rds_db_parameter_group.rb
+++ b/lib/awspec/type/rds_db_parameter_group.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Awspec::Type
-  class InvalidRdsDbParameter < StandardError
+  class InvalidRdsDBParameter < StandardError
     ##
     # Overrides the superclass initialize method to include more information
     # and default error message.
@@ -19,7 +19,7 @@ module Awspec::Type
     ##
     # Thanks to AWS for creating parameters names like
     # 'rds.accepted_password_auth_method', which would be caught as method 'rds'
-    # by method_missing in RdsDbParameterGroup class, this class was created
+    # by method_missing in RdsDBParameterGroup class, this class was created
     # See https://github.com/k1LoW/awspec/issues/527 for more details
     def initialize(params)
       @params = params
@@ -33,11 +33,11 @@ module Awspec::Type
       param_name = name.to_sym
       return @params[param_name] if @params.include?(param_name)
 
-      raise InvalidRdsDbParameter, name
+      raise InvalidRdsDBParameter, name
     end
   end
 
-  class RdsDbParameterGroup < ResourceBase
+  class RdsDBParameterGroup < ResourceBase
     def resource_via_client
       return @resource_via_client if @resource_via_client
 

--- a/lib/awspec/type/rds_db_subnet_group.rb
+++ b/lib/awspec/type/rds_db_subnet_group.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Awspec::Type
-  class RdsDbSubnetGroup < ResourceBase
+  class RdsDBSubnetGroup < ResourceBase
     aws_resource Aws::RDS::Types::DBSubnetGroup
 
     def resource_via_client

--- a/spec/generator/spec/rds_db_cluster_spec.rb
+++ b/spec/generator/spec/rds_db_cluster_spec.rb
@@ -2,11 +2,11 @@
 
 require 'spec_helper'
 
-describe 'Awspec::Generator::Spec::RdsDbCluster' do
+describe 'Awspec::Generator::Spec::RdsDBCluster' do
   before do
     Awspec::Stub.load 'rds_db_cluster'
   end
-  let(:rds_db_cluster) { Awspec::Generator::Spec::RdsDbCluster.new }
+  let(:rds_db_cluster) { Awspec::Generator::Spec::RdsDBCluster.new }
   it 'generate spec' do
     spec = <<-'EOF'
 describe rds_db_cluster('my-rds-db-cluster') do

--- a/spec/type/rds_db_parameter_group_spec.rb
+++ b/spec/type/rds_db_parameter_group_spec.rb
@@ -10,5 +10,5 @@ describe rds_db_parameter_group('my-rds-db-parameter-group') do
   its(:max_allowed_packet) { should eq '16777216' }
   its('rds.logical_replication') { should eq '1' }
   its('rds.accepted_password_auth_method') { should eq 'md5+scram' }
-  its('rds.foobar') { will raise_error(Awspec::Type::InvalidRdsDbParameter) }
+  its('rds.foobar') { will raise_error(Awspec::Type::InvalidRdsDBParameter) }
 end


### PR DESCRIPTION
DB resources such as "rds_db_cluster" has a below error.
"uninitialized constant Awspec::Type::RdsDBCluster"

This error is caused by "dry-inflector" v1.1.0 update.