### PR TITLE
Fix finding Gateway VPC Endpoints by id

### DIFF
--- a/lib/awspec/helper/finder/vpc_endpoints.rb
+++ b/lib/awspec/helper/finder/vpc_endpoints.rb
@@ -4,9 +4,7 @@ module Awspec::Helper
   module Finder
     module VpcEndpoints
       def find_vpc_endpoint(id)
-        res = ec2_client.describe_vpc_endpoints({
-                                                  filters: [{ name: 'vpc-endpoint-id', values: [id] }]
-                                                })
+        res = ec2_client.describe_vpc_endpoints({ vpc_endpoint_ids: [id] })
 
         ret = res.vpc_endpoints.select do |vpce|
           vpce.vpc_endpoint_id == id


### PR DESCRIPTION
For approximately the last month, the AWS `describe_vpc_endpoints` API has been broken when fetching _Gateway_ VPC endpoints by id using the `filters` option.

Using the `vpc_endpoint_ids` option instead does still work, (for both Interface and Gateway endpoints).

Fixes #594