### PR TITLE
Add type backup

### DIFF
--- a/doc/_resource_types/backup_plan.md
+++ b/doc/_resource_types/backup_plan.md
@@ -1,0 +1,7 @@
+### exist
+
+```ruby
+describe backup_plan('my-backup-plan') do
+  it { should exist }
+end
+```

--- a/doc/_resource_types/backup_selection.md
+++ b/doc/_resource_types/backup_selection.md
@@ -1,0 +1,7 @@
+### exist
+
+```ruby
+describe backup_selection('my-backup-selection') do
+  it { should exist }
+end
+```

--- a/doc/_resource_types/backup_vault.md
+++ b/doc/_resource_types/backup_vault.md
@@ -1,0 +1,35 @@
+### exist
+
+```ruby
+describe backup_vault('my-backup-vault') do
+  it { should exist }
+end
+```
+
+### its(:backup_vault_name), its(:backup_vault_arn), its(:vault_type), its(:vault_state), its(:creation_date), its(:encryption_key_arn), its(:creator_request_id), its(:number_of_recovery_points), its(:locked), its(:min_retention_days), its(:max_retention_days), its(:lock_date)
+
+```ruby
+describe backup_vault('my-backup-vault') do
+  it { should exist }
+  its(:locked) { should be true }
+  its(:lock_date) { should be < (Time.now - 60*60*24*30) }
+  its(:vault_state) { should eq "AVAILABLE" }
+  its(:vault_type) { should eq "BACKUP_VAULT" }
+  its(:min_retention_days) { should be 7 }
+  its(:max_retention_days) { should be 35 }
+  its(:lock_date) { should eq(Time.new(2024, 10, 4, 9, 00, 00, '+00:00')) }
+  its(:encryption_key_arn) { should eq 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab' }
+  its(:number_of_recovery_points) { should be > 100 }
+end
+
+describe backup_vault('my-airgapped-vault') do
+  it { should exist }
+  its(:locked) { should be false }
+  its(:creation_date) { should be > Time.new(2016, 4, 4, 9, 00, 00, '+00:00') }
+  its(:vault_state) { should eq "AVAILABLE" }
+  its(:vault_type) { should eq "LOGICALLY_AIR_GAPPED_BACKUP_VAULT" }
+  its(:backup_vault_arn) { should match /:111122223333:/ }
+  its(:backup_vault_arn) { should match /:us-west-2:/ }
+  its(:number_of_recovery_points) { should be > 10 }
+end
+```

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -4,10 +4,10 @@
 
 1. Create your feature branch (`git checkout -b add-type-redshift`)
 2. Generate template files (`bundle exec bin/toolbox template redshift`)
-3. Fill files with code.
+3. Fill files with code and test your code regularly (`bundle exec rspec spec/type/redshift_spec.rb`)
 4. `bundle update` to update gems.
 5. Generate [doc/resource_types.md](resource_types.md) (`bundle exec rake generate_docs`)
-6. Run test (`bundle exec rake spec`)
+6. Run all tests (`bundle exec rake spec`)
 7. Push to the branch (`git push origin add-type-redshift`)
 8. Create a new Pull Request
 

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -7,6 +7,9 @@
 | [ami](#ami)
 | [apigateway](#apigateway)
 | [autoscaling_group](#autoscaling_group)
+| [backup_plan](#backup_plan)
+| [backup_selection](#backup_selection)
+| [backup_vault](#backup_vault)
 | [batch_compute_environment](#batch_compute_environment)
 | [batch_job_definition](#batch_job_definition)
 | [batch_job_queue](#batch_job_queue)
@@ -369,6 +372,46 @@ end
 ```
 
 ### its(:auto_scaling_group_name), its(:auto_scaling_group_arn), its(:launch_configuration_name), its(:launch_template), its(:mixed_instances_policy), its(:min_size), its(:max_size), its(:desired_capacity), its(:predicted_capacity), its(:default_cooldown), its(:availability_zones), its(:load_balancer_names), its(:target_group_arns), its(:health_check_type), its(:health_check_grace_period), its(:created_time), its(:placement_group), its(:vpc_zone_identifier), its(:enabled_metrics), its(:status), its(:termination_policies), its(:new_instances_protected_from_scale_in), its(:service_linked_role_arn), its(:max_instance_lifetime), its(:capacity_rebalance), its(:warm_pool_configuration), its(:warm_pool_size), its(:context), its(:desired_capacity_type), its(:default_instance_warmup), its(:traffic_sources), its(:instance_maintenance_policy), its(:availability_zone_distribution), its(:availability_zone_impairment_policy), its(:capacity_reservation_specification)
+## <a name="backup_plan">backup_plan</a>
+
+BackupPlan resource type.
+
+### exist
+
+```ruby
+describe backup_plan('my-backup-plan') do
+  it { should exist }
+end
+```
+
+### its(:backup_plan_arn), its(:backup_plan_id), its(:creation_date), its(:deletion_date), its(:version_id), its(:backup_plan_name), its(:creator_request_id), its(:last_execution_date), its(:advanced_backup_settings)
+## <a name="backup_selection">backup_selection</a>
+
+BackupSelection resource type.
+
+### exist
+
+```ruby
+describe backup_selection('my-backup-selection') do
+  it { should exist }
+end
+```
+
+### its(:selection_id), its(:selection_name), its(:backup_plan_id), its(:creation_date), its(:creator_request_id), its(:iam_role_arn)
+## <a name="backup_vault">backup_vault</a>
+
+BackupVault resource type.
+
+### exist
+
+```ruby
+describe backup_vault('my-backup-vault') do
+  it { should exist }
+end
+```
+
+
+### its(:backup_vault_name), its(:backup_vault_arn), its(:vault_type), its(:vault_state), its(:creation_date), its(:encryption_key_arn), its(:creator_request_id), its(:number_of_recovery_points), its(:locked), its(:min_retention_days), its(:max_retention_days), its(:lock_date)
 ## <a name="batch_compute_environment">batch_compute_environment</a>
 
 BatchComputeEnvironment resource type.
@@ -1800,8 +1843,6 @@ end
 ```
 
 
-### be_creating
-
 ### be_deleting
 
 ### have_splunk_destination
@@ -2546,11 +2587,7 @@ end
 
 ### be_active
 
-### be_creating
-
 ### be_deleting
-
-### be_failed
 
 ### be_updating
 

--- a/lib/awspec/generator/doc/type/backup_plan.rb
+++ b/lib/awspec/generator/doc/type/backup_plan.rb
@@ -1,0 +1,17 @@
+module Awspec::Generator
+  module Doc
+    module Type
+      class BackupPlan < Base
+        def initialize
+          super
+          @type_name = 'BackupPlan'
+          @type = Awspec::Type::BackupPlan.new('my-backup-plan')
+          @ret = @type.resource_via_client
+          @matchers = []
+          @ignore_matchers = []
+          @describes = []
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/generator/doc/type/backup_selection.rb
+++ b/lib/awspec/generator/doc/type/backup_selection.rb
@@ -1,0 +1,17 @@
+module Awspec::Generator
+  module Doc
+    module Type
+      class BackupSelection < Base
+        def initialize
+          super
+          @type_name = 'BackupSelection'
+          @type = Awspec::Type::BackupSelection.new('my-backup-selection')
+          @ret = @type.resource_via_client
+          @matchers = []
+          @ignore_matchers = []
+          @describes = []
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/generator/doc/type/backup_vault.rb
+++ b/lib/awspec/generator/doc/type/backup_vault.rb
@@ -1,0 +1,17 @@
+module Awspec::Generator
+  module Doc
+    module Type
+      class BackupVault < Base
+        def initialize
+          super
+          @type_name = 'BackupVault'
+          @type = Awspec::Type::BackupVault.new('my-backup-vault')
+          @ret = @type.resource_via_client
+          @matchers = []
+          @ignore_matchers = []
+          @describes = []
+        end
+      end
+    end
+  end
+end

--- a/lib/awspec/helper/finder.rb
+++ b/lib/awspec/helper/finder.rb
@@ -57,6 +57,7 @@ require 'awspec/helper/finder/cognito_identity_pool'
 require 'awspec/helper/finder/transfer'
 require 'awspec/helper/finder/codepipeline'
 require 'awspec/helper/finder/wafv2'
+require 'awspec/helper/finder/backup'
 
 require 'awspec/helper/finder/account_attributes'
 
@@ -121,6 +122,7 @@ module Awspec::Helper
     include Awspec::Helper::Finder::Transfer
     include Awspec::Helper::Finder::Codepipeline
     include Awspec::Helper::Finder::Wafv2
+    include Awspec::Helper::Finder::Backup
 
     CLIENTS = {
       ec2_client: Aws::EC2::Client,
@@ -171,7 +173,8 @@ module Awspec::Helper
       cognito_identity_provider_client: Aws::CognitoIdentityProvider::Client,
       transfer_client: Aws::Transfer::Client,
       codepipeline_client: Aws::CodePipeline::Client,
-      wafv2_client: Aws::WAFV2::Client
+      wafv2_client: Aws::WAFV2::Client,
+      backup_client: Aws::Backup::Client
     }
 
     CLIENT_OPTIONS = {

--- a/lib/awspec/helper/finder/backup.rb
+++ b/lib/awspec/helper/finder/backup.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Awspec::Helper
+    module Finder
+      module Backup
+        def find_backup_vault(id)
+          res = backup_client.list_backup_vaults
+          res.backup_vault_list.select do |v|
+            v.backup_vault_name == id || v.backup_vault_arn == id
+          end.single_resource(id)
+        rescue Aws::Backup::Errors::ResourceNotFoundException
+          nil
+        end
+
+        def find_backup_plan(id)
+          res = backup_client.list_backup_plans
+          res.backup_plans_list.select do |p|
+            p.backup_plan_name == id || p.backup_plan_arn == id || p.backup_plan_id == id
+          end.single_resource(id)
+        rescue Aws::Backup::Errors::ResourceNotFoundException
+          nil
+        end
+
+        def find_backup_selection(id)
+          selected = []
+          plans = backup_client.list_backup_plans
+          plans.backup_plans_list.each do |p|
+            res = backup_client.list_backup_selections({backup_plan_id: p.backup_plan_id})
+            selected += res.backup_selections_list.select do |s|
+              s.selection_id == id || s.selection_name == id
+            end
+          end
+          selected.single_resource(id)
+        rescue Aws::Backup::Errors::ResourceNotFoundException
+          nil
+        end
+
+        def locked?
+          return resource_via_client.locked
+        end
+
+        def airgapped?
+          return resource_via_client.vault_type == 'LOGICALLY_AIR_GAPPED_BACKUP_VAULT'
+        end
+
+        STATES = %w[
+          creating available failed
+        ]
+        STATES.each do |state|
+          define_method "#{state}?" do
+            resource_via_client.vault_state.downcase == state
+          end
+        end
+      end
+    end
+end

--- a/lib/awspec/helper/finder/backup.rb
+++ b/lib/awspec/helper/finder/backup.rb
@@ -1,3 +1,4 @@
+# copyright (c) 2025 Atlassian US, Inc.
 # frozen_string_literal: true
 
 module Awspec::Helper

--- a/lib/awspec/helper/type.rb
+++ b/lib/awspec/helper/type.rb
@@ -24,7 +24,7 @@ module Awspec
         internet_gateway acm cloudwatch_logs dynamodb_table eip sqs ssm_parameter cloudformation_stack
         codebuild sns_topic redshift redshift_cluster_parameter_group codedeploy codedeploy_deployment_group
         secretsmanager msk transit_gateway cognito_identity_pool cognito_user_pool vpc_endpoints
-        transfer_server managed_prefix_list codepipeline wafv2_ip_set
+        transfer_server managed_prefix_list codepipeline wafv2_ip_set backup_vault backup_plan backup_selection
       ]
 
       ACCOUNT_ATTRIBUTES = %w[

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -93,3 +93,6 @@ require 'awspec/matcher/have_env_var_value'
 
 # ManagedPrefixList
 require 'awspec/matcher/have_cidr'
+
+# BackupSelection
+require 'awspec/matcher/belong_to_backup_plan'

--- a/lib/awspec/matcher/belong_to_backup_plan.rb
+++ b/lib/awspec/matcher/belong_to_backup_plan.rb
@@ -1,0 +1,10 @@
+RSpec::Matchers.define :belong_to_backup_plan do |plan|
+    match do |type|
+      return true if type.backup_plan_id == plan
+
+      ret = type.find_backup_plan(plan)
+      return false unless ret
+
+      type.backup_plan_id == (ret.backup_plan_id)
+    end
+  end

--- a/lib/awspec/matcher/belong_to_backup_plan.rb
+++ b/lib/awspec/matcher/belong_to_backup_plan.rb
@@ -1,3 +1,4 @@
+# copyright (c) 2025 Atlassian US, Inc.
 RSpec::Matchers.define :belong_to_backup_plan do |plan|
     match do |type|
       return true if type.backup_plan_id == plan

--- a/lib/awspec/stub/backup_plan.rb
+++ b/lib/awspec/stub/backup_plan.rb
@@ -1,0 +1,31 @@
+Aws.config[:backup] = {
+  stub_responses: {
+    list_backup_plans: {
+        backup_plans_list: [
+            {
+                backup_plan_arn: 'arn:aws:backup:us-west-2:111122223333:backup-plan:a460d5d5-d30b-4631-8014-38c58e3c72ca',
+                backup_plan_id: 'a460d5d5-d30b-4631-8014-38c58e3c72ca',
+                creation_date: Time.new(2016, 4, 4, 9, 00, 00, '+00:00'),
+                deletion_date: nil,
+                version_id: 'kMlWPgkmipEb4I9gOEZpdoQiMgxP5KIizKLDhhblGiixgahy',
+                backup_plan_name: 'old-obsolete-plan',
+                creator_request_id: nil,
+                last_execution_date: Time.new(2016, 10, 4, 9, 00, 00, '+00:00'),
+                advanced_backup_settings: nil
+            },
+            {
+                backup_plan_arn: 'arn:aws:backup:us-west-2:111122223333:backup-plan:fff3e784-1a0f-4e7c-8fe9-ba69825f7c00',
+                backup_plan_id: 'fff3e784-1a0f-4e7c-8fe9-ba69825f7c00',
+                creation_date: Time.new(2016, 10, 4, 9, 00, 00, '+00:00'),
+                deletion_date: nil,
+                version_id: 'disFW7K0dOAjTaMWKYlhEyScjBhmi5kKGf7BrY7i1BG8F8wB',
+                backup_plan_name: 'my-backup-plan',
+                creator_request_id: nil,
+                last_execution_date: Time.new(2025, 10, 4, 9, 00, 00, '+00:00'),
+                advanced_backup_settings: nil
+            }
+        ],
+        next_token: nil
+    }
+  }
+}

--- a/lib/awspec/stub/backup_plan.rb
+++ b/lib/awspec/stub/backup_plan.rb
@@ -1,3 +1,4 @@
+# copyright (c) 2025 Atlassian US, Inc.
 Aws.config[:backup] = {
   stub_responses: {
     list_backup_plans: {

--- a/lib/awspec/stub/backup_selection.rb
+++ b/lib/awspec/stub/backup_selection.rb
@@ -1,0 +1,30 @@
+Aws.config[:backup] = {
+  stub_responses: {
+    list_backup_plans: {
+        backup_plans_list: [
+            {
+                backup_plan_arn: 'arn:aws:backup:us-west-2:111122223333:backup-plan:fff3e784-1a0f-4e7c-8fe9-ba69825f7c00',
+                backup_plan_id: 'fff3e784-1a0f-4e7c-8fe9-ba69825f7c00',
+                creation_date: Time.new(2016, 10, 4, 9, 00, 00, '+00:00'),
+                deletion_date: nil,
+                version_id: 'disFW7K0dOAjTaMWKYlhEyScjBhmi5kKGf7BrY7i1BG8F8wB',
+                backup_plan_name: 'my-backup-plan',
+                creator_request_id: nil,
+                last_execution_date: Time.new(2025, 10, 4, 9, 00, 00, '+00:00'),
+                advanced_backup_settings: nil
+            }
+        ],
+        next_token: nil
+    },
+    list_backup_selections: {
+        backup_selections_list: [
+            selection_id: '01dfb41f-c3ca-4b45-91e7-63ef43fe7231',
+            selection_name: 'my-backup-selection',
+            backup_plan_id: 'fff3e784-1a0f-4e7c-8fe9-ba69825f7c00',
+            creation_date: Time.new(2016, 10, 4, 9, 00, 00, '+00:00'),
+            creator_request_id: nil,
+            iam_role_arn: 'arn:aws:iam::111122223333:role/service-role/my-backup-service-role'
+        ]
+    }
+  }
+}

--- a/lib/awspec/stub/backup_selection.rb
+++ b/lib/awspec/stub/backup_selection.rb
@@ -1,3 +1,4 @@
+# copyright (c) 2025 Atlassian US, Inc.
 Aws.config[:backup] = {
   stub_responses: {
     list_backup_plans: {

--- a/lib/awspec/stub/backup_vault.rb
+++ b/lib/awspec/stub/backup_vault.rb
@@ -1,0 +1,51 @@
+Aws.config[:backup] = {
+  stub_responses: {
+    list_backup_vaults: {
+        backup_vault_list: [
+            {
+                backup_vault_name: 'Default',
+                backup_vault_arn: 'arn:aws:backup:us-west-2:111122223333:backup-vault:Default',
+                vault_type: 'BACKUP_VAULT',
+                vault_state: 'AVAILABLE',
+                creation_date: Time.new(2024, 4, 4, 9, 00, 00, '+00:00'),
+                encryption_key_arn: 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab',
+                creator_request_id: 'Default',
+                number_of_recovery_points: 0,
+                locked: false,
+                min_retention_days: nil,
+                max_retention_days: nil,
+                lock_date: nil
+            },
+            {
+                backup_vault_name:'my-backup-vault',
+                backup_vault_arn: 'arn:aws:backup:us-west-2:111122223333:backup-vault:my-vault',
+                vault_type: 'BACKUP_VAULT',
+                vault_state: 'AVAILABLE',
+                creation_date: Time.new(2024, 4, 4, 9, 00, 00, '+00:00'),
+                encryption_key_arn: 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab',
+                creator_request_id: 'Default',
+                number_of_recovery_points: 123,
+                locked: true,
+                min_retention_days: 7,
+                max_retention_days: 35,
+                lock_date: Time.new(2024, 10, 4, 9, 00, 00, '+00:00')
+            },
+            {
+                backup_vault_name: 'my-airgapped-vault',
+                backup_vault_arn: 'arn:aws:backup:us-west-2:111122223333:backup-vault:my-airgapped-vault',
+                vault_type: 'LOGICALLY_AIR_GAPPED_BACKUP_VAULT',
+                vault_state: 'AVAILABLE',
+                creation_date:Time.new(2024, 4, 4, 9, 00, 00, '+00:00'),
+                encryption_key_arn: 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab',
+                creator_request_id: nil,
+                number_of_recovery_points: 12,
+                locked: false,
+                min_retention_days: 30,
+                max_retention_days: 30,
+                lock_date: nil
+            }
+        ],
+        next_token: nil
+    }
+  }
+}

--- a/lib/awspec/stub/backup_vault.rb
+++ b/lib/awspec/stub/backup_vault.rb
@@ -1,3 +1,4 @@
+# copyright (c) 2025 Atlassian US, Inc.
 Aws.config[:backup] = {
   stub_responses: {
     list_backup_vaults: {

--- a/lib/awspec/type/backup_plan.rb
+++ b/lib/awspec/type/backup_plan.rb
@@ -1,0 +1,11 @@
+module Awspec::Type
+  class BackupPlan < ResourceBase
+    def resource_via_client
+      @resource_via_client ||= find_backup_plan(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.backup_plan_id if resource_via_client
+    end
+  end
+end

--- a/lib/awspec/type/backup_plan.rb
+++ b/lib/awspec/type/backup_plan.rb
@@ -1,3 +1,4 @@
+# copyright (c) 2025 Atlassian US, Inc.
 module Awspec::Type
   class BackupPlan < ResourceBase
     def resource_via_client

--- a/lib/awspec/type/backup_selection.rb
+++ b/lib/awspec/type/backup_selection.rb
@@ -1,3 +1,4 @@
+# copyright (c) 2025 Atlassian US, Inc.
 module Awspec::Type
   class BackupSelection < ResourceBase
     def resource_via_client

--- a/lib/awspec/type/backup_selection.rb
+++ b/lib/awspec/type/backup_selection.rb
@@ -1,0 +1,11 @@
+module Awspec::Type
+  class BackupSelection < ResourceBase
+    def resource_via_client
+      @resource_via_client ||= find_backup_selection(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.selection_id if resource_via_client
+    end
+  end
+end

--- a/lib/awspec/type/backup_vault.rb
+++ b/lib/awspec/type/backup_vault.rb
@@ -1,3 +1,4 @@
+# copyright (c) 2025 Atlassian US, Inc.
 module Awspec::Type
   class BackupVault < ResourceBase
     def resource_via_client

--- a/lib/awspec/type/backup_vault.rb
+++ b/lib/awspec/type/backup_vault.rb
@@ -1,0 +1,11 @@
+module Awspec::Type
+  class BackupVault < ResourceBase
+    def resource_via_client
+      @resource_via_client ||= find_backup_vault(@display_name)
+    end
+
+    def id
+      @id ||= resource_via_client.backup_vault_arn if resource_via_client
+    end
+  end
+end

--- a/spec/type/backup_plan_spec.rb
+++ b/spec/type/backup_plan_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+Awspec::Stub.load 'backup_plan'
+
+describe backup_plan('my-backup-plan') do
+  it { should exist }
+
+  its(:backup_plan_arn) { should match /us-west-2:111122223333/ }
+  its(:backup_plan_id) { should eq 'fff3e784-1a0f-4e7c-8fe9-ba69825f7c00' }
+  its(:creation_date) { should be < Time.new(2024, 4, 4, 9, 00, 00, '+00:00') }
+  its(:deletion_date) { should be nil }
+  its(:version_id) { should eq 'disFW7K0dOAjTaMWKYlhEyScjBhmi5kKGf7BrY7i1BG8F8wB' }
+  its(:last_execution_date) { should be > Time.new(2016, 4, 4, 9, 00, 00, '+00:00') }
+end

--- a/spec/type/backup_plan_spec.rb
+++ b/spec/type/backup_plan_spec.rb
@@ -1,3 +1,4 @@
+# copyright (c) 2025 Atlassian US, Inc.
 require 'spec_helper'
 Awspec::Stub.load 'backup_plan'
 

--- a/spec/type/backup_selection_spec.rb
+++ b/spec/type/backup_selection_spec.rb
@@ -1,3 +1,4 @@
+# copyright (c) 2025 Atlassian US, Inc.
 require 'spec_helper'
 Awspec::Stub.load 'backup_selection'
 

--- a/spec/type/backup_selection_spec.rb
+++ b/spec/type/backup_selection_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+Awspec::Stub.load 'backup_selection'
+
+describe backup_selection('my-backup-selection') do
+  it { should exist }
+
+  it { should belong_to_backup_plan('fff3e784-1a0f-4e7c-8fe9-ba69825f7c00') }
+  it { should belong_to_backup_plan('arn:aws:backup:us-west-2:111122223333:backup-plan:fff3e784-1a0f-4e7c-8fe9-ba69825f7c00') }
+  it { should belong_to_backup_plan('my-backup-plan') }
+
+  its(:selection_id) { should eq '01dfb41f-c3ca-4b45-91e7-63ef43fe7231' }
+  its(:backup_plan_id) { should eq 'fff3e784-1a0f-4e7c-8fe9-ba69825f7c00' }
+  its(:creation_date) { should be > Time.new(2016, 4, 4, 4, 00, 00, '+00:00') }
+  its(:iam_role_arn) { should match(/111122223333/).and(match(/my-backup-service-role/)) }
+  end

--- a/spec/type/backup_vault_spec.rb
+++ b/spec/type/backup_vault_spec.rb
@@ -1,3 +1,4 @@
+# copyright (c) 2025 Atlassian US, Inc.
 require 'spec_helper'
 Awspec::Stub.load 'backup_vault'
 

--- a/spec/type/backup_vault_spec.rb
+++ b/spec/type/backup_vault_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+Awspec::Stub.load 'backup_vault'
+
+describe backup_vault('my-backup-vault') do
+  it { should exist }
+  it { should be_available }
+  it { should be_locked }
+  it { should_not be_airgapped }
+
+  its(:locked) { should be true }
+  its(:lock_date) { should be < (Time.now - 60*60*24*30) }
+  its(:vault_state) { should eq "AVAILABLE" }
+  its(:vault_type) { should eq "BACKUP_VAULT" }
+  its(:min_retention_days) { should be 7 }
+  its(:max_retention_days) { should be 35 }
+  its(:lock_date) { should eq(Time.new(2024, 10, 4, 9, 00, 00, '+00:00')) }
+  its(:encryption_key_arn) { should eq 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab' }
+  its(:number_of_recovery_points) { should be > 100 }
+end
+
+describe backup_vault('my-airgapped-vault') do
+  it { should exist }
+  it { should_not be_failed }
+  it { should_not be_locked }
+  it { should be_airgapped }
+
+  its(:locked) { should be false }
+  its(:creation_date) { should be > Time.new(2016, 4, 4, 9, 00, 00, '+00:00') }
+  its(:vault_state) { should eq "AVAILABLE" }
+  its(:vault_type) { should eq "LOGICALLY_AIR_GAPPED_BACKUP_VAULT" }
+  its(:backup_vault_arn) { should match /:111122223333:/ }
+  its(:backup_vault_arn) { should match /:us-west-2:/ }
+  its(:number_of_recovery_points) { should be > 10 }
+end


### PR DESCRIPTION
First pass at adding support for AWS Backup resources: vault, plan and selections.
Feedback welcome for any improvement needed for the PR to be merged. Note for instance that I am not checking `next_token`/paginated resources.