### PR TITLE
Expands elasticache resource to handle ReplicationGroups and Serverless

### DIFF
--- a/doc/_resource_types/elasticache.md
+++ b/doc/_resource_types/elasticache.md
@@ -6,6 +6,18 @@ describe elasticache('my-rep-group-001') do
 end
 ```
 
+```ruby
+describe elasticache('my-rep-group') do
+  it { should exist }
+end
+```
+
+```ruby
+describe elasticache('my-serverless-cache') do
+  it { should exist }
+end
+```
+
 ### be_available, be_creating, be_deleted, be_deleting, be_incompatible_network, be_modifying, be_rebooting_cache_cluster_nodes, be_restore_failed, be_snapshotting
 
 ```ruby
@@ -14,10 +26,24 @@ describe elasticache('my-rep-group-001') do
 end
 ```
 
+### be_serverless
+
+```ruby
+describe elasticache('my-serverless-cache') do
+  it { should be_serverless }
+end
+```
+
 ### have_cache_parameter_group
 
 ```ruby
 describe elasticache('my-rep-group-001') do
+  it { should have_cache_parameter_group('my-cache-parameter-group') }
+end
+```
+
+```ruby
+describe elasticache('my-rep-group') do
   it { should have_cache_parameter_group('my-cache-parameter-group') }
 end
 ```
@@ -40,6 +66,12 @@ describe elasticache('my-rep-group-001') do
 end
 ```
 
+```ruby
+describe elasticache('my-rep-group') do
+  it { should belong_to_cache_subnet_group('my-cache-subnet-group') }
+end
+```
+
 ### belong_to_replication_group
 
 ```ruby
@@ -53,5 +85,73 @@ end
 ```ruby
 describe elasticache('my-rep-group-001') do
   it { should belong_to_vpc('my-vpc') }
+end
+```
+
+### its(:cache_type)
+
+```ruby
+describe elasticache('my-rep-group-001') do
+  its(:cache_type) { should eq 'cache_cluster' }
+end
+```
+
+```ruby
+describe elasticache('my-rep-group') do
+  its(:cache_type) { should eq 'replication_group' }
+end
+```
+
+```ruby
+describe elasticache('my-serverless-cache') do
+  its(:cache_type) { should eq 'serverless_cache' }
+end
+```
+
+### its(:engine)
+
+```ruby
+describe elasticache('my-rep-group') do
+  its(:engine) { should eq 'redis' }
+end
+```
+
+### its(:engine_version)
+
+```ruby
+describe elasticache('my-rep-group') do
+  its(:engine_version) { should eq '7.1' }
+end
+```
+
+### its(:num_nodes)
+
+```ruby
+describe elasticache('my-rep-group') do
+  its(:num_nodes) { should eq 2 }
+end
+```
+
+### its(:node_count)
+
+```ruby
+describe elasticache('my-rep-group') do
+  its(:node_count) { should eq 2 }
+end
+```
+
+### its(:cluster_mode_enabled)
+
+```ruby
+describe elasticache('my-rep-group') do
+  its(:cluster_mode_enabled) { should eq true }
+end
+```
+
+### its(:serverless)
+
+```ruby
+describe elasticache('my-serverless-cache') do
+  its(:serverless) { should eq true }
 end
 ```

--- a/lib/awspec/generator/spec/elasticache.rb
+++ b/lib/awspec/generator/spec/elasticache.rb
@@ -5,6 +5,77 @@ module Awspec::Generator
     class Elasticache
       include Awspec::Helper::Finder
       def generate_all
+        cache_clusters = collect_cache_clusters
+        replication_groups = collect_replication_groups
+        serverless_caches = collect_serverless_caches
+        if cache_clusters.empty? && replication_groups.empty? && serverless_caches.empty?
+          raise 'Not Found ElastiCache Resources'
+        end
+
+        ERB.new(elasticache_spec_template, trim_mode: '-').result(binding).gsub(/^\n/, '')
+      end
+
+      def elasticache_spec_template
+        <<-'EOF'
+<% cache_clusters.each do |cluster| %>
+describe elasticache('<%= cluster.cache_cluster_id %>') do
+  it { should exist }
+  it { should be_available }
+  it { should have_cache_parameter_group('<%= cluster.cache_parameter_group.cache_parameter_group_name %>') }
+  it { should belong_to_cache_subnet_group('<%= cluster.cache_subnet_group_name %>') }
+<% unless cluster.replication_group_id.nil? %>
+  its(:replication_group_id) { should eq '<%= cluster.replication_group_id %>' }
+<% end %>
+  its(:cache_type) { should eq 'cache_cluster' }
+  its(:engine) { should eq '<%= cluster.engine %>' }
+  its(:engine_version) { should eq '<%= engine_version_for(cluster) %>' }
+  its(:cache_node_type) { should eq '<%= cluster.cache_node_type %>' }
+  its(:num_nodes) { should eq <%= cluster.num_cache_nodes %> }
+<% unless cluster.snapshot_retention_limit.nil? %>
+  its(:snapshot_retention_limit) { should eq <%= cluster.snapshot_retention_limit %> }
+  its(:snapshot_window) { should eq '<%= cluster.snapshot_window %>' }
+<% end %>
+end
+<% end %>
+<% replication_groups.each do |group| %>
+describe elasticache('<%= group.replication_group_id %>') do
+  it { should exist }
+  it { should be_available }
+<% if group.respond_to?(:cache_parameter_group) && group.cache_parameter_group %>
+  it { should have_cache_parameter_group('<%= group.cache_parameter_group.cache_parameter_group_name %>') }
+<% end %>
+<% if group.respond_to?(:cache_subnet_group_name) && group.cache_subnet_group_name %>
+  it { should belong_to_cache_subnet_group('<%= group.cache_subnet_group_name %>') }
+<% end %>
+  its(:cache_type) { should eq 'replication_group' }
+  its(:engine) { should eq '<%= group.engine %>' }
+<% unless engine_version_for(group).nil? %>
+  its(:engine_version) { should eq '<%= engine_version_for(group) %>' }
+<% end %>
+  its(:cluster_mode_enabled) { should eq <%= replication_group_cluster_mode_enabled(group) %> }
+<% unless replication_group_node_count(group).nil? %>
+  its(:num_nodes) { should eq <%= replication_group_node_count(group) %> }
+<% end %>
+end
+<% end %>
+<% serverless_caches.each do |cache| %>
+describe elasticache('<%= cache.serverless_cache_name %>') do
+  it { should exist }
+  it { should be_available }
+  its(:cache_type) { should eq 'serverless_cache' }
+  its(:serverless) { should eq true }
+  its(:engine) { should eq '<%= cache.engine %>' }
+<% unless engine_version_for(cache).nil? %>
+  its(:engine_version) { should eq '<%= engine_version_for(cache) %>' }
+<% end %>
+end
+<% end %>
+EOF
+      end
+
+      private
+
+      def collect_cache_clusters
         opt = {}
         clusters = []
         loop do
@@ -14,32 +85,79 @@ module Awspec::Generator
 
           opt = { marker: res.marker }
         end
-        raise 'Not Found Cache Clusters' if clusters.empty?
-
-        ERB.new(cache_clusters_spec_template, trim_mode: '-').result(binding).gsub(/^\n/, '')
+        clusters
       end
 
-      def cache_clusters_spec_template
-        <<-'EOF'
-<% clusters.each do |cluster| %>
-describe elasticache('<%= cluster.cache_cluster_id %>') do
-  it { should exist }
-  it { should be_available }
-  it { should have_cache_parameter_group('<%= cluster.cache_parameter_group.cache_parameter_group_name %>') }
-  it { should belong_to_cache_subnet_group('<%= cluster.cache_subnet_group_name %>') }
-<% unless cluster.replication_group_id.nil? %>
-  its(:replication_group_id) { should eq '<%= cluster.replication_group_id %>' }
-<% end %>
-  its(:engine) { should eq '<%= cluster.engine %>' }
-  its(:engine_version) { should eq '<%= cluster.engine_version %>' }
-  its(:cache_node_type) { should eq '<%= cluster.cache_node_type %>' }
-<% unless cluster.snapshot_retention_limit.nil? %>
-  its(:snapshot_retention_limit) { should eq <%= cluster.snapshot_retention_limit %> }
-  its(:snapshot_window) { should eq '<%= cluster.snapshot_window %>' }
-<% end %>
-end
-<% end %>
-EOF
+      def collect_replication_groups
+        opt = {}
+        groups = []
+        loop do
+          res = elasticache_client.describe_replication_groups(opt)
+          groups.push(*res.replication_groups)
+          token = pagination_token(res)
+          break if token.nil?
+
+          opt = pagination_param(res, token)
+        end
+        groups
+      end
+
+      def collect_serverless_caches
+        opt = {}
+        caches = []
+        loop do
+          res = elasticache_client.describe_serverless_caches(opt)
+          caches.push(*res.serverless_caches)
+          token = pagination_token(res)
+          break if token.nil?
+
+          opt = pagination_param(res, token)
+        end
+        caches
+      rescue StandardError
+        []
+      end
+
+      def pagination_token(response)
+        return response.marker if response.respond_to?(:marker) && response.marker
+        return response.next_token if response.respond_to?(:next_token) && response.next_token
+
+        nil
+      end
+
+      def pagination_param(response, token)
+        return { marker: token } if response.respond_to?(:marker)
+        return { next_token: token } if response.respond_to?(:next_token)
+
+        {}
+      end
+
+      def engine_version_for(resource)
+        return resource.engine_version if resource.respond_to?(:engine_version) && resource.engine_version
+        return resource.major_engine_version if resource.respond_to?(:major_engine_version)
+
+        nil
+      end
+
+      def replication_group_cluster_mode_enabled(group)
+        return group.cluster_enabled if group.respond_to?(:cluster_enabled)
+        return group.cluster_mode if group.respond_to?(:cluster_mode)
+
+        false
+      end
+
+      def replication_group_node_count(group)
+        if group.respond_to?(:node_groups) && group.node_groups
+          return group.node_groups.sum do |node_group|
+            next 0 unless node_group.respond_to?(:node_group_members)
+
+            node_group.node_group_members&.count.to_i
+          end
+        end
+
+        return group.member_clusters.count if group.respond_to?(:member_clusters)
+
+        nil
       end
     end
   end

--- a/lib/awspec/helper/finder/elasticache.rb
+++ b/lib/awspec/helper/finder/elasticache.rb
@@ -81,6 +81,20 @@ module Awspec::Helper
       rescue StandardError
         []
       end
+
+      def infer_replication_group_id_from_cluster_prefix(name)
+        clusters = select_cache_clusters
+        matches = clusters.select do |cluster|
+          cluster_id = cluster.cache_cluster_id
+          cluster_id == name || cluster_id.start_with?("#{name}-")
+        end
+        group_ids = matches.map(&:replication_group_id).compact.uniq
+        return nil unless group_ids.count == 1
+
+        group_ids.first
+      rescue StandardError
+        nil
+      end
     end
   end
 end

--- a/lib/awspec/helper/finder/elasticache.rb
+++ b/lib/awspec/helper/finder/elasticache.rb
@@ -12,6 +12,24 @@ module Awspec::Helper
         nil
       end
 
+      def find_replication_group(id)
+        res = elasticache_client.describe_replication_groups({
+                                                               replication_group_id: id
+                                                             })
+        res.replication_groups.single_resource(id)
+      rescue StandardError
+        nil
+      end
+
+      def find_serverless_cache(name)
+        res = elasticache_client.describe_serverless_caches({
+                                                              serverless_cache_name: name
+                                                            })
+        res.serverless_caches.single_resource(name)
+      rescue StandardError
+        nil
+      end
+
       def find_cache_subnet_group(group_name)
         res = elasticache_client.describe_cache_subnet_groups({
                                                                 cache_subnet_group_name: group_name

--- a/lib/awspec/helper/finder/elasticache.rb
+++ b/lib/awspec/helper/finder/elasticache.rb
@@ -9,7 +9,7 @@ module Awspec::Helper
                                                          })
         res.cache_clusters.single_resource(id)
       rescue StandardError
-        nil
+        select_cache_clusters.find { |cluster| cluster.cache_cluster_id == id }
       end
 
       def find_replication_group(id)
@@ -18,7 +18,7 @@ module Awspec::Helper
                                                              })
         res.replication_groups.single_resource(id)
       rescue StandardError
-        nil
+        select_replication_groups.find { |group| group.replication_group_id == id }
       end
 
       def find_serverless_cache(name)
@@ -27,7 +27,7 @@ module Awspec::Helper
                                                             })
         res.serverless_caches.single_resource(name)
       rescue StandardError
-        nil
+        select_serverless_caches.find { |cache| cache.serverless_cache_name == name }
       end
 
       def find_cache_subnet_group(group_name)
@@ -35,6 +35,51 @@ module Awspec::Helper
                                                                 cache_subnet_group_name: group_name
                                                               })
         res.cache_subnet_groups.single_resource(group_name)
+      end
+
+      def select_cache_clusters
+        opt = {}
+        clusters = []
+        loop do
+          res = elasticache_client.describe_cache_clusters(opt)
+          clusters.push(*res.cache_clusters)
+          break if res.marker.nil?
+
+          opt = { marker: res.marker }
+        end
+        clusters
+      rescue StandardError
+        []
+      end
+
+      def select_replication_groups
+        opt = {}
+        groups = []
+        loop do
+          res = elasticache_client.describe_replication_groups(opt)
+          groups.push(*res.replication_groups)
+          break if res.marker.nil?
+
+          opt = { marker: res.marker }
+        end
+        groups
+      rescue StandardError
+        []
+      end
+
+      def select_serverless_caches
+        opt = {}
+        caches = []
+        loop do
+          res = elasticache_client.describe_serverless_caches(opt)
+          caches.push(*res.serverless_caches)
+          break if res.next_token.nil?
+
+          opt = { next_token: res.next_token }
+        end
+        caches
+      rescue StandardError
+        []
       end
     end
   end

--- a/lib/awspec/stub/elasticache.rb
+++ b/lib/awspec/stub/elasticache.rb
@@ -44,6 +44,46 @@ Aws.config[:elasticache] = {
             replication_group_id: 'my-rep-group',
             snapshot_retention_limit: 0,
             snapshot_window: '17:30-18:30'
+          },
+          {
+            cache_cluster_id: 'my-valkey-001',
+            configuration_endpoint: nil,
+            client_download_landing_page:
+              'https://console.aws.amazon.com/elasticache/home#client-download:',
+            cache_node_type: 'cache.m7g.large',
+            engine: 'valkey',
+            engine_version: '7.1.0',
+            cache_cluster_status: 'available',
+            num_cache_nodes: 1,
+            preferred_availability_zone: 'ap-northeast-1b',
+            cache_cluster_create_time: Time.new(2015, 1, 2, 10, 00, 00, '+00:00'),
+            preferred_maintenance_window: 'wed:15:30-wed:16:30',
+            pending_modified_values:
+              {
+                num_cache_nodes: nil,
+                cache_node_ids_to_remove: [],
+                engine_version: nil
+              },
+            notification_configuration: nil,
+            cache_security_groups: [],
+            cache_parameter_group:
+              {
+                cache_parameter_group_name: 'my-cache-parameter-group',
+                parameter_apply_status: 'in-sync',
+                cache_node_ids_to_reboot: []
+              },
+            cache_subnet_group_name: 'my-cache-subnet-group',
+            cache_nodes: [],
+            auto_minor_version_upgrade: true,
+            security_groups: [
+              {
+                security_group_id: 'sg-da1bc2ef',
+                status: 'active'
+              }
+            ],
+            replication_group_id: 'my-valkey',
+            snapshot_retention_limit: 0,
+            snapshot_window: '17:30-18:30'
           }
         ]
     },
@@ -78,6 +118,27 @@ Aws.config[:elasticache] = {
               node_group_members: [
                 { cache_cluster_id: 'my-rep-group-001' },
                 { cache_cluster_id: 'my-rep-group-002' }
+              ]
+            }
+          ]
+        },
+        {
+          replication_group_id: 'my-valkey',
+          status: 'available',
+          engine: 'valkey',
+          engine_version: nil,
+          cache_subnet_group_name: 'my-cache-subnet-group',
+          cache_parameter_group: {
+            cache_parameter_group_name: 'my-cache-parameter-group'
+          },
+          member_clusters: [
+            'my-valkey-001'
+          ],
+          cluster_enabled: false,
+          node_groups: [
+            {
+              node_group_members: [
+                { cache_cluster_id: 'my-valkey-001' }
               ]
             }
           ]

--- a/lib/awspec/stub/elasticache.rb
+++ b/lib/awspec/stub/elasticache.rb
@@ -56,6 +56,43 @@ Aws.config[:elasticache] = {
           subnets: []
         }
       ]
+    },
+    describe_replication_groups: {
+      replication_groups: [
+        {
+          replication_group_id: 'my-rep-group',
+          status: 'available',
+          engine: 'redis',
+          engine_version: '7.1',
+          cache_subnet_group_name: 'my-cache-subnet-group',
+          cache_parameter_group: {
+            cache_parameter_group_name: 'my-cache-parameter-group'
+          },
+          member_clusters: [
+            'my-rep-group-001',
+            'my-rep-group-002'
+          ],
+          cluster_enabled: true,
+          node_groups: [
+            {
+              node_group_members: [
+                { cache_cluster_id: 'my-rep-group-001' },
+                { cache_cluster_id: 'my-rep-group-002' }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    describe_serverless_caches: {
+      serverless_caches: [
+        {
+          serverless_cache_name: 'my-serverless-cache',
+          status: 'available',
+          engine: 'valkey',
+          engine_version: '7.2'
+        }
+      ]
     }
   }
 }

--- a/lib/awspec/type/elasticache.rb
+++ b/lib/awspec/type/elasticache.rb
@@ -13,6 +13,7 @@ module Awspec::Type
       @resource_via_client = find_cache_cluster(@display_name)
       @resource_via_client ||= find_replication_group(@display_name)
       @resource_via_client ||= find_serverless_cache(@display_name)
+      @resource_via_client ||= infer_replication_group_from_cluster_prefix
     end
 
     def id
@@ -136,7 +137,18 @@ module Awspec::Type
       nil
     end
 
+    def node_count
+      num_nodes
+    end
+
     private
+    def infer_replication_group_from_cluster_prefix
+      group_id = infer_replication_group_id_from_cluster_prefix(@display_name)
+      return nil unless group_id
+
+      find_replication_group(group_id)
+    end
+
     def resource_status
       return nil unless resource_via_client
       return resource_via_client.cache_cluster_status if cache_cluster?

--- a/lib/awspec/type/elasticache.rb
+++ b/lib/awspec/type/elasticache.rb
@@ -8,11 +8,24 @@ module Awspec::Type
     end
 
     def resource_via_client
-      @resource_via_client ||= find_cache_cluster(@display_name)
+      return @resource_via_client if @resource_via_client
+
+      @resource_via_client = find_cache_cluster(@display_name)
+      @resource_via_client ||= find_replication_group(@display_name)
+      @resource_via_client ||= find_serverless_cache(@display_name)
     end
 
     def id
-      @id ||= resource_via_client.cache_cluster_id if resource_via_client
+      return @id if @id
+      return nil unless resource_via_client
+
+      @id = if cache_cluster?
+              resource_via_client.cache_cluster_id
+            elsif serverless?
+              resource_via_client.serverless_cache_name
+            else
+              resource_via_client.replication_group_id
+            end
     end
 
     STATES = %w[
@@ -24,12 +37,22 @@ module Awspec::Type
 
     STATES.each do |state|
       define_method "#{state.tr('-', '_')}?" do
-        resource_via_client.cache_cluster_status == state
+        resource_status == state
       end
     end
 
     def has_cache_parameter_group?(group_name)
-      resource_via_client.cache_parameter_group.cache_parameter_group_name == group_name
+      return false unless resource_via_client
+
+      if resource_via_client.respond_to?(:cache_parameter_group) && resource_via_client.cache_parameter_group
+        return resource_via_client.cache_parameter_group.cache_parameter_group_name == group_name
+      end
+
+      if resource_via_client.respond_to?(:cache_parameter_group_name)
+        return resource_via_client.cache_parameter_group_name == group_name
+      end
+
+      false
     end
 
     def has_security_group?(sg_id)
@@ -39,11 +62,88 @@ module Awspec::Type
     end
 
     def vpc_id
+      return nil unless resource_via_client
+      return nil unless resource_via_client.respond_to?(:cache_subnet_group_name)
+
       cache_subnet_group = find_cache_subnet_group(resource_via_client.cache_subnet_group_name)
       cache_subnet_group.vpc_id if cache_subnet_group
     end
 
+    def cache_type
+      return nil unless resource_via_client
+
+      return 'cache_cluster' if cache_cluster?
+      return 'serverless_cache' if serverless?
+
+      'replication_group'
+    end
+
+    def serverless
+      serverless?
+    end
+
+    def cache_cluster?
+      resource_via_client&.respond_to?(:cache_cluster_id)
+    end
+
+    def serverless?
+      resource_via_client&.respond_to?(:serverless_cache_name)
+    end
+
+    def replication_group?
+      return false unless resource_via_client
+
+      !cache_cluster? && !serverless?
+    end
+
+    def engine
+      return nil unless resource_via_client
+      return resource_via_client.engine if resource_via_client.respond_to?(:engine)
+
+      nil
+    end
+
+    def engine_version
+      return nil unless resource_via_client
+      return resource_via_client.engine_version if resource_via_client.respond_to?(:engine_version)
+      return resource_via_client.major_engine_version if resource_via_client.respond_to?(:major_engine_version)
+
+      nil
+    end
+
+    def cluster_mode_enabled
+      return false unless replication_group?
+      return resource_via_client.cluster_enabled if resource_via_client.respond_to?(:cluster_enabled)
+      return resource_via_client.cluster_mode if resource_via_client.respond_to?(:cluster_mode)
+
+      false
+    end
+
+    def num_nodes
+      return resource_via_client.num_cache_nodes if cache_cluster?
+      return nil if serverless?
+
+      if resource_via_client.respond_to?(:node_groups) && resource_via_client.node_groups
+        return resource_via_client.node_groups.sum do |group|
+          next 0 unless group.respond_to?(:node_group_members)
+
+          group.node_group_members&.count.to_i
+        end
+      end
+
+      return resource_via_client.member_clusters.count if resource_via_client.respond_to?(:member_clusters)
+
+      nil
+    end
+
     private
+    def resource_status
+      return nil unless resource_via_client
+      return resource_via_client.cache_cluster_status if cache_cluster?
+      return resource_via_client.status if resource_via_client.respond_to?(:status)
+
+      nil
+    end
 
     def has_vpc_security_group_id?(sg_id)
       resource_security_group_ids.include?(sg_id)
@@ -66,7 +166,15 @@ module Awspec::Type
     end
 
     def resource_security_group_ids
-      resource_via_client.security_groups.map(&:security_group_id)
+      return [] unless resource_via_client
+
+      if resource_via_client.respond_to?(:security_groups) && resource_via_client.security_groups
+        return resource_via_client.security_groups.map(&:security_group_id)
+      end
+
+      return resource_via_client.security_group_ids if resource_via_client.respond_to?(:security_group_ids)
+
+      []
     end
   end
 end

--- a/spec/generator/spec/elasticache_spec.rb
+++ b/spec/generator/spec/elasticache_spec.rb
@@ -15,11 +15,32 @@ describe elasticache('my-rep-group-001') do
   it { should have_cache_parameter_group('my-cache-parameter-group') }
   it { should belong_to_cache_subnet_group('my-cache-subnet-group') }
   its(:replication_group_id) { should eq 'my-rep-group' }
+  its(:cache_type) { should eq 'cache_cluster' }
   its(:engine) { should eq 'redis' }
   its(:engine_version) { should eq '2.8.21' }
   its(:cache_node_type) { should eq 'cache.m3.medium' }
+  its(:num_nodes) { should eq 1 }
   its(:snapshot_retention_limit) { should eq 0 }
   its(:snapshot_window) { should eq '17:30-18:30' }
+end
+describe elasticache('my-rep-group') do
+  it { should exist }
+  it { should be_available }
+  it { should have_cache_parameter_group('my-cache-parameter-group') }
+  it { should belong_to_cache_subnet_group('my-cache-subnet-group') }
+  its(:cache_type) { should eq 'replication_group' }
+  its(:engine) { should eq 'redis' }
+  its(:engine_version) { should eq '7.1' }
+  its(:cluster_mode_enabled) { should eq true }
+  its(:num_nodes) { should eq 2 }
+end
+describe elasticache('my-serverless-cache') do
+  it { should exist }
+  it { should be_available }
+  its(:cache_type) { should eq 'serverless_cache' }
+  its(:serverless) { should eq true }
+  its(:engine) { should eq 'valkey' }
+  its(:engine_version) { should eq '7.2' }
 end
 EOF
     expect(elasticache.generate_all.to_s).to eq spec

--- a/spec/generator/spec/elasticache_spec.rb
+++ b/spec/generator/spec/elasticache_spec.rb
@@ -23,6 +23,20 @@ describe elasticache('my-rep-group-001') do
   its(:snapshot_retention_limit) { should eq 0 }
   its(:snapshot_window) { should eq '17:30-18:30' }
 end
+describe elasticache('my-valkey-001') do
+  it { should exist }
+  it { should be_available }
+  it { should have_cache_parameter_group('my-cache-parameter-group') }
+  it { should belong_to_cache_subnet_group('my-cache-subnet-group') }
+  its(:replication_group_id) { should eq 'my-valkey' }
+  its(:cache_type) { should eq 'cache_cluster' }
+  its(:engine) { should eq 'valkey' }
+  its(:engine_version) { should eq '7.1.0' }
+  its(:cache_node_type) { should eq 'cache.m7g.large' }
+  its(:num_nodes) { should eq 1 }
+  its(:snapshot_retention_limit) { should eq 0 }
+  its(:snapshot_window) { should eq '17:30-18:30' }
+end
 describe elasticache('my-rep-group') do
   it { should exist }
   it { should be_available }
@@ -33,6 +47,16 @@ describe elasticache('my-rep-group') do
   its(:engine_version) { should eq '7.1' }
   its(:cluster_mode_enabled) { should eq true }
   its(:num_nodes) { should eq 2 }
+end
+describe elasticache('my-valkey') do
+  it { should exist }
+  it { should be_available }
+  it { should have_cache_parameter_group('my-cache-parameter-group') }
+  it { should belong_to_cache_subnet_group('my-cache-subnet-group') }
+  its(:cache_type) { should eq 'replication_group' }
+  its(:engine) { should eq 'valkey' }
+  its(:cluster_mode_enabled) { should eq false }
+  its(:num_nodes) { should eq 1 }
 end
 describe elasticache('my-serverless-cache') do
   it { should exist }

--- a/spec/type/elasticache_spec.rb
+++ b/spec/type/elasticache_spec.rb
@@ -13,4 +13,32 @@ describe elasticache('my-rep-group-001') do
   it { should have_security_group('sg-da1bc2ef') }
   it { should have_security_group('group-name-sg') }
   it { should have_security_group('my-cache-sg') }
+  its(:cache_type) { should eq 'cache_cluster' }
+  its(:engine) { should eq 'redis' }
+  its(:engine_version) { should eq '2.8.21' }
+  its(:num_nodes) { should eq 1 }
+  its(:cluster_mode_enabled) { should eq false }
+  its(:serverless) { should eq false }
+end
+
+describe elasticache('my-rep-group') do
+  it { should exist }
+  it { should be_available }
+  it { should have_cache_parameter_group('my-cache-parameter-group') }
+  it { should belong_to_cache_subnet_group('my-cache-subnet-group') }
+  its(:cache_type) { should eq 'replication_group' }
+  its(:engine) { should eq 'redis' }
+  its(:engine_version) { should eq '7.1' }
+  its(:num_nodes) { should eq 2 }
+  its(:cluster_mode_enabled) { should eq true }
+  its(:serverless) { should eq false }
+end
+
+describe elasticache('my-serverless-cache') do
+  it { should exist }
+  it { should be_available }
+  its(:cache_type) { should eq 'serverless_cache' }
+  its(:engine) { should eq 'valkey' }
+  its(:engine_version) { should eq '7.2' }
+  its(:serverless) { should eq true }
 end

--- a/spec/type/elasticache_spec.rb
+++ b/spec/type/elasticache_spec.rb
@@ -34,6 +34,17 @@ describe elasticache('my-rep-group') do
   its(:serverless) { should eq false }
 end
 
+describe elasticache('my-valkey') do
+  it { should exist }
+  it { should be_available }
+  its(:cache_type) { should eq 'replication_group' }
+  its(:engine) { should eq 'valkey' }
+  its(:engine_version) { should eq '7.1.0' }
+  its(:num_nodes) { should eq 1 }
+  its(:cluster_mode_enabled) { should eq false }
+  its(:serverless) { should eq false }
+end
+
 describe elasticache('my-serverless-cache') do
   it { should exist }
   it { should be_available }


### PR DESCRIPTION
While writing some tests, I noticed `elasticache('cluster-name')` only found one of our instances that was configured in cluster mode, but missed the rest of the resources.
 
I wasn't sure whether to add other resources or modify this one, but I modified the current one to meet my expectations that `elasticache` would find my ElastiCache stuff. If it makes more sense to create separate resources, I can refactor.

I'm not a Ruby guy, so I had Cursor+gpt-5.2-codex help me out. I checked through the files, they look sane, and they work on my machine, but I'm not a Ruby guy, so I'm not entirely certain it's the best it can be.

I did ask it to double-check the code for safety issues and consistency with the rest of the codebase, and the main suggestion was to reduce usage of `rescue StandardError` to avoid swallowing exceptions, but I left it as-is for consistency.